### PR TITLE
fix(rl): make the RL rollout entrypoint runnable

### DIFF
--- a/AgenticArxiv/requirements.txt
+++ b/AgenticArxiv/requirements.txt
@@ -13,5 +13,13 @@ loguru
 pydantic>=2.0
 fire
 
+# ===== 当前 RL 路径实际仍需要的依赖 =====
+# agents/base_agent.py 顶层 import 了 models.store（SQLAlchemy）与
+# services.runtime（FastAPI 的 jsonable_encoder），因此 rl.rollout 也会拉进这三个包。
+# 注：解除这层耦合后即可移除，见 README 的"依赖说明"。
+sqlalchemy>=2.0
+pymysql
+fastapi
+
 # ===== 可选依赖（eval/demo 时需要，训练时不需要） =====
 # pdf2zh  # PDF 翻译（训练时用 mock）

--- a/AgenticArxiv/rl/rollout.py
+++ b/AgenticArxiv/rl/rollout.py
@@ -20,7 +20,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from benchmark.tasks import get_task_by_id, get_all_tasks
 from agents.agent_engine import ReActAgent
-from agents.side_effects import NoOpSideEffectManager
 from utils.llm_client import get_env_llm_client
 from rl.reward import RewardCalculator
 from rl.trajectory import create_trajectory, save_trajectory
@@ -48,7 +47,7 @@ def rollout_single_task(
 
     # 2. 创建 Agent（使用 NoOpSideEffectManager）
     llm_client = get_env_llm_client()
-    agent = ReActAgent(llm_client, side_effect_mgr=NoOpSideEffectManager())
+    agent = ReActAgent(llm_client)
 
     # 3. 执行 Agent
     print(f"🤖 执行 Agent...")

--- a/scripts/generate_dpo_data.py
+++ b/scripts/generate_dpo_data.py
@@ -23,7 +23,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "AgenticArxiv"))
 
 from benchmark.tasks import get_all_tasks
 from agents.agent_engine import ReActAgent
-from agents.side_effects import NoOpSideEffectManager
 from utils.llm_client import get_env_llm_client
 from rl.reward import RewardCalculator
 
@@ -45,7 +44,7 @@ def generate_dpo_dataset(num_rollouts_per_task: int = 5):
     # TODO: 加载 SFT 模型（需要修改 llm_client 支持本地模型）
     # 目前占位：使用原始 LLM
     llm_client = get_env_llm_client()
-    agent = ReActAgent(llm_client, side_effect_mgr=NoOpSideEffectManager())
+    agent = ReActAgent(llm_client)
 
     reward_calc = RewardCalculator()
     dpo_data = []

--- a/scripts/generate_sft_data.py
+++ b/scripts/generate_sft_data.py
@@ -18,7 +18,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "AgenticArxiv"))
 
 from benchmark.tasks import get_all_tasks
 from agents.agent_engine import ReActAgent
-from agents.side_effects import NoOpSideEffectManager
 from utils.llm_client import get_env_llm_client
 
 
@@ -26,7 +25,7 @@ def generate_sft_dataset():
     """执行所有 benchmark tasks，收集成功的 trajectories 作为 expert demos"""
 
     llm_client = get_env_llm_client()
-    agent = ReActAgent(llm_client, side_effect_mgr=NoOpSideEffectManager())
+    agent = ReActAgent(llm_client)
 
     sft_data = []
     tasks = get_all_tasks()


### PR DESCRIPTION
## Problem

Following the quickstart in the README:

```bash
pip install -r AgenticArxiv/requirements.txt
cd AgenticArxiv && python -m rl.rollout search_01 ../traces/train/
```

fails before reaching any step of the RL tutorial. Verified against current
`main` (i.e. after #4), two blockers remain, each surfacing only once the
previous is fixed:

**① `ModuleNotFoundError: No module named 'sqlalchemy'`**

```
File "AgenticArxiv/rl/rollout.py", line 22, in <module>
    from agents.agent_engine import ReActAgent
File "AgenticArxiv/agents/base_agent.py", line 12, in <module>
    from models.store import store
File "AgenticArxiv/models/store.py", line 11, in <module>
    from sqlalchemy import func
ModuleNotFoundError: No module named 'sqlalchemy'
```

`agents/base_agent.py` imports `models.store` (SQLAlchemy) and
`services.runtime` (FastAPI's `jsonable_encoder`) at module level, but those
three packages are only listed in `requirements-extra.txt`, not
`requirements.txt`.

**② `TypeError: unexpected keyword argument 'side_effect_mgr'`**

```
File "AgenticArxiv/rl/rollout.py", line 51, in rollout_single_task
    agent = ReActAgent(llm_client, side_effect_mgr=NoOpSideEffectManager())
TypeError: ReActAgent.__init__() got an unexpected keyword argument 'side_effect_mgr'
```

`agents/side_effects.py` defines the `SideEffectManager` interface, but it was
never wired into `BaseAgent` (item 1 of the pending list in
`REFACTOR_SUMMARY.md`), while `rl/rollout.py` and both scripts already pass
the argument.

> An earlier revision of this PR also fixed `rl/reward.py` importing a
> non-existent `compute_metrics`. That was fixed independently by #4, so this
> PR no longer touches `reward.py` at all.

## Changes

Only the **minimal fix** for each remaining issue, without changing any design
decision:

- `requirements.txt` — declare `sqlalchemy` / `pymysql` / `fastapi`, which the
  current coupling genuinely requires
- `rl/rollout.py`, `scripts/generate_sft_data.py`,
  `scripts/generate_dpo_data.py` — drop the unsupported keyword argument so the
  call matches `BaseAgent`'s current signature

4 files, +11 / −6.

## Verification

```bash
cd AgenticArxiv && python -m rl.rollout search_01 ../traces/train/
```

runs to completion and writes a trajectory JSONL. (Without a valid
`LLM_API_KEY` the LLM call fails and the run ends with `Reward: 0.00`, which is
expected behaviour rather than a crash.)

## Follow-ups

Two further changes are ready and depend on this one (branches already pushed):

1. **Injectable side effects + pluggable store backend** — actually removes the
   MySQL/FastAPI dependency, at which point the three packages added here can be
   dropped again. It also fixes a quieter problem: when MySQL is unreachable, a
   *successful* arXiv search is swallowed by the enclosing `try` in
   `_execute_with_side_effects()` and returned as `工具执行失败`, so correct
   behaviour is penalised and the reward signal is corrupted at its source.
2. **Make `MockArxivEnv` usable** — it is currently not in the call path at all,
   and `generate_snapshot_from_benchmark()` calls a
   `benchmark.runner.run_single_benchmark` that does not exist.

Happy to combine or split these differently, whichever suits you.