### PR TITLE
refactor(agents): make side effects injectable and the store backend …

### DIFF
--- a/AgenticArxiv/agents/agent_engine.py
+++ b/AgenticArxiv/agents/agent_engine.py
@@ -17,8 +17,8 @@ from utils.logger import log
 class ReActAgent(BaseAgent):
     """方案 A: ReAct + 正则解析 Agent"""
 
-    def __init__(self, llm_client: LLMClient):
-        super().__init__(llm_client)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, max_iterations: int = 5):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, max_iterations=max_iterations)
         try:
             import tools.arxiv_tool  # noqa: F401
             import tools.pdf_download_tool  # noqa: F401

--- a/AgenticArxiv/agents/base_agent.py
+++ b/AgenticArxiv/agents/base_agent.py
@@ -9,10 +9,8 @@ from utils.llm_client import LLMClient
 from utils.logger import log
 from config import settings
 from models.schemas import Paper
-from models.store import store
-from services.log_service import log_service
-from services.runtime import translate_runner, event_bus
 from tools.tool_registry import registry
+from agents.side_effects import SideEffectManager, LocalSideEffectManager
 
 
 class BaseAgent(ABC):
@@ -20,9 +18,22 @@ class BaseAgent(ABC):
 
     agent_type: str = "regex"  # 子类覆写
 
-    def __init__(self, llm_client: LLMClient):
+    def __init__(
+        self,
+        llm_client: LLMClient,
+        side_effect_mgr: Optional[SideEffectManager] = None,
+        max_iterations: int = 5,
+    ):
+        """
+        Args:
+            llm_client: LLM 调用客户端
+            side_effect_mgr: 副作用管理器；默认 LocalSideEffectManager（无 DB/SSE）。
+                Web 应用请显式传入 MySQLSideEffectManager 以保持原行为。
+            max_iterations: ReAct 最大迭代轮数
+        """
         self.llm_client = llm_client
-        self.max_iterations = 5
+        self.side_effects = side_effect_mgr or LocalSideEffectManager()
+        self.max_iterations = max_iterations
         self.session_id = "default"
 
     # ---------- 子类必须实现 ----------
@@ -75,7 +86,9 @@ class BaseAgent(ABC):
             agent_model = settings.models.agent_model
 
         try:
-            log_service.create_chat_log(session_id, msg_id, "user", task, model=agent_model, agent_type=self.agent_type)
+            self.side_effects.create_chat_log(
+                session_id, msg_id, "user", task, model=agent_model, agent_type=self.agent_type
+            )
         except Exception as e:
             log.warning(f"Failed to log user message: {e}")
 
@@ -171,7 +184,10 @@ class BaseAgent(ABC):
         reply = reply or final_observation
 
         try:
-            log_service.create_chat_log(session_id, msg_id + "_reply", "assistant", reply, model=agent_model, agent_type=self.agent_type)
+            self.side_effects.create_chat_log(
+                session_id, msg_id + "_reply", "assistant", reply,
+                model=agent_model, agent_type=self.agent_type,
+            )
         except Exception as e:
             log.warning(f"Failed to log assistant reply: {e}")
 
@@ -204,7 +220,7 @@ class BaseAgent(ABC):
     def _enrich_task_with_context(self, task: str, session_id: str) -> str:
         """向任务描述注入当前会话状态，帮助 LLM 避免重复操作"""
         try:
-            papers = store.get_last_papers(session_id)
+            papers = self.side_effects.get_last_papers(session_id)
             if papers:
                 titles = [f"  {i+1}. {p.title}" for i, p in enumerate(papers[:10])]
                 ctx = f"\n\n[会话上下文] 当前会话已有 {len(papers)} 篇论文:\n" + "\n".join(titles)
@@ -240,7 +256,7 @@ class BaseAgent(ABC):
 
             # 翻译工具异步 enqueue
             if tool_name == "translate_arxiv_pdf":
-                t = translate_runner.enqueue(
+                t = self.side_effects.enqueue_translate(
                     session_id=self.session_id,
                     ref=args.get("ref", None),
                     force=bool(args.get("force", False)),
@@ -265,7 +281,7 @@ class BaseAgent(ABC):
                 if isinstance(result, dict):
                     pid = result.get("paper_id")
                     if isinstance(pid, str) and pid.strip():
-                        store.set_last_active_paper_id(self.session_id, pid.strip())
+                        self.side_effects.set_last_active_paper_id(self.session_id, pid.strip())
             except Exception:
                 pass
 
@@ -281,7 +297,7 @@ class BaseAgent(ABC):
                 if isinstance(result, list):
                     if result:
                         papers_obj = [Paper(**p) for p in result]
-                        store.set_last_papers(self.session_id, papers_obj)
+                        self.side_effects.set_last_papers(self.session_id, papers_obj)
                         papers_count = len(result)
                         paper_titles = [paper.get("title", "无标题") for paper in result[:3]]
                         titles_str = "\n".join([f"  - {title}" for title in paper_titles])
@@ -319,13 +335,13 @@ class BaseAgent(ABC):
         session_id: str,
     ):
         try:
-            log_service.save_agent_step(
+            self.side_effects.save_agent_step(
                 msg_id=msg_id, step_index=step_index,
                 thought=thought, action_name=action_name,
                 action_args=action_args, observation=observation,
                 llm_latency_ms=llm_ms, tool_latency_ms=tool_ms,
             )
-            event_bus.publish(session_id, {
+            self.side_effects.publish_sse(session_id, {
                 "type": "agent_step",
                 "step": {
                     "thought": thought, "action_name": action_name,

--- a/AgenticArxiv/agents/side_effects.py
+++ b/AgenticArxiv/agents/side_effects.py
@@ -1,70 +1,252 @@
-"""副作用管理器（解耦 DB/SSE/translate/store 等副作用）
+"""副作用管理器（解耦 DB / SSE / translate / store 等副作用）。
 
-RL 训练时用 NoOpSideEffectManager（无操作），
-生产环境可用 MySQLSideEffectManager（原逻辑）。
+BaseAgent 的执行循环本身是纯粹的 ReAct 逻辑，但历史上混入了四类副作用：
+    1. chat log / agent step 写 MySQL
+    2. SSE 事件推送
+    3. 翻译任务异步入队（起线程 + 调 pdf2zh）
+    4. 会话记忆读写（last_papers / last_active_paper_id）
+
+本模块把它们抽成可注入接口，提供三种实现：
+
+    NoOpSideEffectManager    完全无操作（连会话记忆都不保留）
+    LocalSideEffectManager   ★ RL 默认：会话记忆走内存 store，无 DB/SSE/线程
+    MySQLSideEffectManager   Web 应用原行为（懒加载，只有用到才 import fastapi/sqlalchemy）
+
+注意第 4 类不能简单 no-op：download / translate / cache 三类任务都要靠会话记忆
+解析 ref（"第1篇"、null 指代），若会话记忆失效，这些任务在 RL 环境里必然失败，
+奖励信号会被污染成"全是工具执行失败"。
 """
 
 from abc import ABC, abstractmethod
-from typing import Dict, Any, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class TranslateHandle:
+    """enqueue_translate 的返回值（只保留 BaseAgent 用到的字段）。"""
+
+    task_id: str
+    paper_id: Optional[str]
+    status: str = "PENDING"
 
 
 class SideEffectManager(ABC):
-    """副作用管理器抽象接口"""
+    """副作用管理器抽象接口。"""
+
+    # ---- 日志 / 推送 ----
 
     @abstractmethod
     def create_chat_log(
-        self, session_id: str, msg_id: str, role: str, content: str, model: str
+        self,
+        session_id: str,
+        msg_id: str,
+        role: str,
+        content: str,
+        model: Optional[str] = None,
+        agent_type: Optional[str] = None,
     ) -> None:
-        """记录对话日志（DB）"""
-        pass
+        """记录对话日志。"""
 
     @abstractmethod
     def save_agent_step(
-        self, session_id: str, msg_id: str, step_index: int, step_data: Dict[str, Any]
+        self,
+        msg_id: str,
+        step_index: int,
+        thought: str,
+        action_name: str,
+        action_args: str,
+        observation: str,
+        llm_latency_ms: int,
+        tool_latency_ms: int,
     ) -> None:
-        """保存 Agent 执行步骤（DB）"""
-        pass
+        """保存 Agent 执行步骤。"""
 
     @abstractmethod
     def publish_sse(self, session_id: str, event_data: Dict[str, Any]) -> None:
-        """发布 SSE 事件（实时推送到前端）"""
-        pass
+        """发布 SSE 事件。"""
+
+    # ---- 异步任务 ----
 
     @abstractmethod
-    def enqueue_translate(
-        self, paper_id: int, session_id: str, **kwargs
-    ) -> None:
-        """入队翻译任务（异步）"""
-        pass
+    def enqueue_translate(self, session_id: str, **kwargs) -> TranslateHandle:
+        """入队翻译任务，返回任务句柄。"""
+
+    # ---- 会话记忆（读 + 写）----
 
     @abstractmethod
     def set_last_papers(self, session_id: str, papers: list) -> None:
-        """设置会话最近论文列表（store）"""
-        pass
+        """写入会话论文列表。"""
 
     @abstractmethod
-    def set_last_active_paper_id(self, session_id: str, paper_id: int) -> None:
-        """设置会话最后活跃论文 ID（store）"""
-        pass
+    def get_last_papers(self, session_id: str) -> List[Any]:
+        """读取会话论文列表（用于 prompt 上下文注入）。"""
+
+    @abstractmethod
+    def set_last_active_paper_id(self, session_id: str, paper_id: str) -> None:
+        """写入最近操作的论文 ID。"""
 
 
 class NoOpSideEffectManager(SideEffectManager):
-    """无操作实现（用于离线 RL 训练）"""
+    """完全无操作实现。
 
-    def create_chat_log(self, *args, **kwargs):
+    连会话记忆都不保留 —— 只适合"单步、无状态"的任务（如纯搜索）。
+    多步/指代类任务请用 LocalSideEffectManager。
+    """
+
+    def create_chat_log(self, *args, **kwargs) -> None:
         pass
 
-    def save_agent_step(self, *args, **kwargs):
+    def save_agent_step(self, *args, **kwargs) -> None:
         pass
 
-    def publish_sse(self, *args, **kwargs):
+    def publish_sse(self, *args, **kwargs) -> None:
         pass
 
-    def enqueue_translate(self, *args, **kwargs):
+    def enqueue_translate(self, session_id: str, **kwargs) -> TranslateHandle:
+        return TranslateHandle(task_id="noop", paper_id=kwargs.get("paper_id"), status="PENDING")
+
+    def set_last_papers(self, *args, **kwargs) -> None:
         pass
 
-    def set_last_papers(self, *args, **kwargs):
+    def get_last_papers(self, session_id: str) -> List[Any]:
+        return []
+
+    def set_last_active_paper_id(self, *args, **kwargs) -> None:
         pass
 
-    def set_last_active_paper_id(self, *args, **kwargs):
+
+class LocalSideEffectManager(SideEffectManager):
+    """离线 RL 默认实现：会话记忆走内存 store，其余副作用全部关闭。
+
+    - chat log / agent step：不落库（轨迹由 rl/trajectory.py 负责持久化）
+    - SSE：丢弃
+    - 翻译：不起线程、不调 pdf2zh，只返回一个确定性的 mock 句柄
+      （观测文本形状与线上一致，因此指标/奖励计算不受影响）
+    - 会话记忆：委托给 models.store 的当前后端（RL 下为 MemoryStore）
+    """
+
+    def __init__(self, store: Any = None, fake_translate: bool = True):
+        if store is None:
+            from models.store import store as global_store
+            store = global_store
+        self.store = store
+        self.fake_translate = fake_translate
+        self._translate_seq = 0
+        self.published_events: List[Dict[str, Any]] = []  # 便于测试断言
+
+    def create_chat_log(self, *args, **kwargs) -> None:
         pass
+
+    def save_agent_step(self, *args, **kwargs) -> None:
+        pass
+
+    def publish_sse(self, session_id: str, event_data: Dict[str, Any]) -> None:
+        # 保留在内存里，方便调试/断言，但不做任何 IO
+        self.published_events.append({"session_id": session_id, **event_data})
+
+    def enqueue_translate(self, session_id: str, **kwargs) -> TranslateHandle:
+        if not self.fake_translate:
+            from services.runtime import translate_runner
+            return translate_runner.enqueue(session_id=session_id, **kwargs)
+
+        # 确定性 mock：task_id 单调递增，便于快照回放时结果稳定
+        self._translate_seq += 1
+        paper_id = kwargs.get("paper_id")
+        if not paper_id:
+            ref = kwargs.get("ref")
+            paper = self.store.resolve_paper(session_id, ref)
+            paper_id = paper.id if paper else self.store.get_last_active_paper_id(session_id)
+        if paper_id:
+            self.store.set_last_active_paper_id(session_id, paper_id)
+        return TranslateHandle(
+            task_id=f"mocktask{self._translate_seq:04d}",
+            paper_id=paper_id,
+            status="PENDING",
+        )
+
+    def set_last_papers(self, session_id: str, papers: list) -> None:
+        self.store.set_last_papers(session_id, papers)
+
+    def get_last_papers(self, session_id: str) -> List[Any]:
+        return self.store.get_last_papers(session_id)
+
+    def set_last_active_paper_id(self, session_id: str, paper_id: str) -> None:
+        self.store.set_last_active_paper_id(session_id, paper_id)
+
+
+class MySQLSideEffectManager(SideEffectManager):
+    """Web 应用原行为：MySQL 落库 + SSE 推送 + 异步翻译线程。
+
+    所有重依赖（sqlalchemy / fastapi / 线程池）都在方法内部懒加载，
+    因此只要不实例化本类，离线 RL 路径就不会碰到它们。
+    """
+
+    def __init__(self):
+        from models.store import store
+        from services.log_service import log_service
+        from services.runtime import event_bus, translate_runner
+
+        self.store = store
+        self.log_service = log_service
+        self.event_bus = event_bus
+        self.translate_runner = translate_runner
+
+    def create_chat_log(
+        self,
+        session_id: str,
+        msg_id: str,
+        role: str,
+        content: str,
+        model: Optional[str] = None,
+        agent_type: Optional[str] = None,
+    ) -> None:
+        self.log_service.create_chat_log(
+            session_id, msg_id, role, content, model=model, agent_type=agent_type
+        )
+
+    def save_agent_step(
+        self,
+        msg_id: str,
+        step_index: int,
+        thought: str,
+        action_name: str,
+        action_args: str,
+        observation: str,
+        llm_latency_ms: int,
+        tool_latency_ms: int,
+    ) -> None:
+        self.log_service.save_agent_step(
+            msg_id=msg_id,
+            step_index=step_index,
+            thought=thought,
+            action_name=action_name,
+            action_args=action_args,
+            observation=observation,
+            llm_latency_ms=llm_latency_ms,
+            tool_latency_ms=tool_latency_ms,
+        )
+
+    def publish_sse(self, session_id: str, event_data: Dict[str, Any]) -> None:
+        self.event_bus.publish(session_id, event_data)
+
+    def enqueue_translate(self, session_id: str, **kwargs) -> TranslateHandle:
+        t = self.translate_runner.enqueue(session_id=session_id, **kwargs)
+        return TranslateHandle(task_id=t.task_id, paper_id=t.paper_id, status=t.status)
+
+    def set_last_papers(self, session_id: str, papers: list) -> None:
+        self.store.set_last_papers(session_id, papers)
+
+    def get_last_papers(self, session_id: str) -> List[Any]:
+        return self.store.get_last_papers(session_id)
+
+    def set_last_active_paper_id(self, session_id: str, paper_id: str) -> None:
+        self.store.set_last_active_paper_id(session_id, paper_id)
+
+
+def default_side_effect_manager() -> SideEffectManager:
+    """按运行环境挑默认实现：能连 MySQL 就用 MySQL，否则本地内存。"""
+    try:
+        return MySQLSideEffectManager()
+    except Exception:
+        return LocalSideEffectManager()

--- a/AgenticArxiv/api/endpoints.py
+++ b/AgenticArxiv/api/endpoints.py
@@ -392,9 +392,10 @@ def run_agent(req: AgentRunRequest) -> AgentRunResponse:
     try:
         from utils.llm_client import get_env_llm_client
         from agents.agent_engine import ReActAgent
+        from agents.side_effects import MySQLSideEffectManager
 
         llm_client = get_env_llm_client()
-        agent = ReActAgent(llm_client)
+        agent = ReActAgent(llm_client, side_effect_mgr=MySQLSideEffectManager())
         result = agent.run(
             task=req.task, agent_model=req.agent_model, session_id=req.session_id
         )
@@ -470,18 +471,20 @@ def pdf_translate_async(req: TranslatePdfRequest) -> CreateTranslateTaskResponse
 def chat(req: ChatRequest) -> ChatResponse:
     try:
         from utils.llm_client import get_env_llm_client
+        from agents.side_effects import MySQLSideEffectManager
 
         llm_client = get_env_llm_client()
+        side_fx = MySQLSideEffectManager()
 
         if req.agent_type == "mcp":
             from mcp_protocol.mcp_agent import MCPAgent
-            agent = MCPAgent(llm_client)
+            agent = MCPAgent(llm_client, side_effect_mgr=side_fx)
         elif req.agent_type == "skill_cli":
             from skill_cli.skill_agent import SkillAgent
-            agent = SkillAgent(llm_client)
+            agent = SkillAgent(llm_client, side_effect_mgr=side_fx)
         else:
             from agents.agent_engine import ReActAgent
-            agent = ReActAgent(llm_client)
+            agent = ReActAgent(llm_client, side_effect_mgr=side_fx)
 
         result = agent.run(
             task=req.message, agent_model=req.agent_model, session_id=req.session_id

--- a/AgenticArxiv/benchmark/runner.py
+++ b/AgenticArxiv/benchmark/runner.py
@@ -51,6 +51,7 @@ class BenchmarkRunner:
             session_prefix = f"bench_r{datetime.now().strftime('%Y%m%d_%H%M%S')}"
         self.session_prefix = session_prefix
         self._llm_client: Optional[LLMClient] = None
+        self._side_fx = None
         # 缓存已执行的依赖任务，避免重复
         self._dep_done: Dict[str, bool] = {}
 
@@ -115,16 +116,24 @@ class BenchmarkRunner:
 
         return results
 
+    def _side_effects(self):
+        """Benchmark 沿用原行为（MySQL 落库 + SSE）；无数据库时自动降级到本地内存。"""
+        if self._side_fx is None:
+            from agents.side_effects import default_side_effect_manager
+            self._side_fx = default_side_effect_manager()
+        return self._side_fx
+
     def _create_agent(self, agent_type: str):
+        side_fx = self._side_effects()
         if agent_type == "mcp":
             from mcp_protocol.mcp_agent import MCPAgent
-            return MCPAgent(self.llm_client)
+            return MCPAgent(self.llm_client, side_effect_mgr=side_fx)
         elif agent_type == "skill_cli":
             from skill_cli.skill_agent import SkillAgent
-            return SkillAgent(self.llm_client)
+            return SkillAgent(self.llm_client, side_effect_mgr=side_fx)
         else:
             from agents.agent_engine import ReActAgent
-            return ReActAgent(self.llm_client)
+            return ReActAgent(self.llm_client, side_effect_mgr=side_fx)
 
     @staticmethod
     def _cleanup_paper_artifacts(session_id: str):

--- a/AgenticArxiv/mcp_protocol/mcp_agent.py
+++ b/AgenticArxiv/mcp_protocol/mcp_agent.py
@@ -31,8 +31,8 @@ class MCPAgent(BaseAgent):
     """通过 MCP 协议调用工具的 Agent"""
     agent_type = "mcp"
 
-    def __init__(self, llm_client: LLMClient):
-        super().__init__(llm_client)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, max_iterations: int = 5):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, max_iterations=max_iterations)
         self._session: Optional[ClientSession] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._mcp_tools: List[Dict[str, Any]] = []

--- a/AgenticArxiv/models/store.py
+++ b/AgenticArxiv/models/store.py
@@ -1,401 +1,81 @@
 # AgenticArxiv/models/store.py
+"""Store 后端分发器。
+
+保持 `from models.store import store` 这一历史调用方式不变，
+但让底层实现可切换，从而使离线 RL 路径不再强依赖 MySQL：
+
+    STORE_BACKEND=auto    （默认）sqlalchemy 可用则用 MySQL，否则回落内存
+    STORE_BACKEND=memory  强制内存（RL 训练 / 测试 / 无数据库演示）
+    STORE_BACKEND=mysql   强制 MySQL（Web 应用；缺依赖时直接报错而非静默降级）
+
+`store` 是一个代理对象：运行时调用 use_memory_store() 切换后端后，
+即使其他模块早已 `from models.store import store`，也会自动指向新后端。
+"""
 from __future__ import annotations
 
-import json
 import os
-import re
-import uuid
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Union
+from typing import Any, Optional
 
-from sqlalchemy import func
-
-from config import settings
-from models.db import get_sync_session
-from models.orm import (
-    PdfAssetRow, TranslateAssetRow, SessionRow, SessionPaperRow, TranslateTaskRow,
-)
-from models.schemas import (
-    Paper, PdfAsset, TranslateAsset, TranslateTask,
-)
-
-_REF_RE = re.compile(r"(?:第)?\s*(\d+)\s*(?:篇)?")
+_BACKEND_ENV = "STORE_BACKEND"
+_backend: Optional[Any] = None
 
 
-def _pdf_row_to_schema(row: PdfAssetRow) -> PdfAsset:
-    return PdfAsset(
-        paper_id=row.paper_id,
-        pdf_url=row.pdf_url or "",
-        local_path=row.local_path or "",
-        status=row.status or "NOT_DOWNLOADED",
-        size_bytes=row.size_bytes or 0,
-        sha256=row.sha256,
-        downloaded_at=row.downloaded_at,
-        updated_at=row.updated_at or datetime.now(),
-        error=row.error,
-    )
+def _make_store() -> Any:
+    backend = os.getenv(_BACKEND_ENV, "auto").strip().lower()
+
+    if backend == "memory":
+        from models.store_memory import MemoryStore
+        return MemoryStore()
+
+    if backend == "mysql":
+        from models.store_mysql import Store
+        return Store()
+
+    # auto：优先 MySQL，缺依赖时静默回落内存（离线训练场景）
+    try:
+        from models.store_mysql import Store
+        return Store()
+    except Exception:  # ImportError（无 sqlalchemy/pymysql）或配置异常
+        from models.store_memory import MemoryStore
+        return MemoryStore()
 
 
-def _translate_row_to_schema(row: TranslateAssetRow) -> TranslateAsset:
-    return TranslateAsset(
-        paper_id=row.paper_id,
-        input_pdf_path=row.input_pdf_path or "",
-        output_mono_path=row.output_mono_path or "",
-        output_dual_path=row.output_dual_path,
-        status=row.status or "NOT_TRANSLATED",
-        service=row.service,
-        threads=row.threads or 0,
-        translated_at=row.translated_at,
-        updated_at=row.updated_at or datetime.now(),
-        error=row.error,
-    )
+def get_store() -> Any:
+    """返回当前后端实例（首次调用时惰性创建）。"""
+    global _backend
+    if _backend is None:
+        _backend = _make_store()
+    return _backend
 
 
-def _task_row_to_schema(row: TranslateTaskRow) -> TranslateTask:
-    meta = {}
-    if row.meta:
-        try:
-            meta = json.loads(row.meta)
-        except Exception:
-            pass
-    return TranslateTask(
-        task_id=row.task_id,
-        session_id=row.session_id,
-        paper_id=row.paper_id,
-        status=row.status or "PENDING",
-        progress=row.progress or 0.0,
-        input_pdf_url=row.input_pdf_url,
-        input_pdf_path=row.input_pdf_path,
-        output_pdf_path=row.output_pdf_path,
-        error=row.error,
-        meta=meta,
-        created_at=row.created_at or datetime.now(),
-        updated_at=row.updated_at or datetime.now(),
-    )
+class _StoreProxy:
+    """透明代理，使后端切换对所有既有 import 立即生效。"""
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(get_store(), name)
+
+    def __repr__(self) -> str:
+        return f"<StoreProxy backend={type(get_store()).__name__}>"
 
 
-def _paper_row_to_schema(row: SessionPaperRow) -> Paper:
-    def _load_json_list(s):
-        if not s:
-            return []
-        try:
-            return json.loads(s)
-        except Exception:
-            return []
-
-    return Paper(
-        id=row.paper_id,
-        title=row.title or "",
-        authors=_load_json_list(row.authors),
-        summary=row.summary,
-        published=row.published,
-        updated=row.updated,
-        pdf_url=row.pdf_url,
-        primary_category=row.primary_category,
-        categories=_load_json_list(row.categories),
-        comment=row.comment,
-        links=_load_json_list(row.links),
-    )
+store = _StoreProxy()
 
 
-class Store:
-    """MySQL-backed store (synchronous, thread-safe via SQLAlchemy connection pool)."""
+def use_memory_store(reset: bool = True) -> Any:
+    """把全局 store 切换为内存实现，并返回它。
 
-    def __init__(self, ttl_minutes: int = 60, max_papers: int = 50):
-        self.ttl = timedelta(minutes=ttl_minutes)
-        self.max_papers = max_papers
+    RL rollout 在进程启动早期调用一次即可保证全程无外部副作用。
+    """
+    global _backend
+    from models.store_memory import MemoryStore
 
-        # Ensure output directories exist
-        os.makedirs(settings.pdf_raw_path, exist_ok=True)
-        os.makedirs(settings.pdf_translated_path, exist_ok=True)
-
-    # -------- session memory --------
-
-    def set_last_papers(self, session_id: str, papers: List[Paper]) -> None:
-        with get_sync_session() as db:
-            # Ensure session row exists
-            row = db.query(SessionRow).filter_by(session_id=session_id).first()
-            if not row:
-                row = SessionRow(session_id=session_id)
-                db.add(row)
-            row.updated_at = datetime.now()
-
-            # Replace session_papers
-            db.query(SessionPaperRow).filter_by(session_id=session_id).delete()
-            for i, p in enumerate(papers[: self.max_papers]):
-                db.add(SessionPaperRow(
-                    session_id=session_id,
-                    paper_id=p.id,
-                    title=p.title,
-                    authors=json.dumps(p.authors, ensure_ascii=False),
-                    summary=p.summary,
-                    published=p.published,
-                    updated=p.updated,
-                    pdf_url=p.pdf_url,
-                    primary_category=p.primary_category,
-                    categories=json.dumps(p.categories, ensure_ascii=False),
-                    comment=p.comment,
-                    links=json.dumps(p.links, ensure_ascii=False),
-                    position=i,
-                ))
-            db.commit()
-
-    def get_last_papers(self, session_id: str) -> List[Paper]:
-        with get_sync_session() as db:
-            row = db.query(SessionRow).filter_by(session_id=session_id).first()
-            if not row:
-                return []
-            if row.updated_at and (datetime.now() - row.updated_at) > self.ttl:
-                return []
-            paper_rows = (
-                db.query(SessionPaperRow)
-                .filter_by(session_id=session_id)
-                .order_by(SessionPaperRow.position)
-                .all()
-            )
-            return [_paper_row_to_schema(r) for r in paper_rows]
-
-    # -------- last active paper --------
-
-    def set_last_active_paper_id(self, session_id: str, paper_id: str) -> None:
-        if not paper_id:
-            return
-        with get_sync_session() as db:
-            row = db.query(SessionRow).filter_by(session_id=session_id).first()
-            if not row:
-                row = SessionRow(session_id=session_id)
-                db.add(row)
-            row.last_active_paper_id = paper_id
-            row.last_active_at = datetime.now()
-            row.updated_at = datetime.now()
-            db.commit()
-
-    def get_last_active_paper_id(self, session_id: str) -> Optional[str]:
-        with get_sync_session() as db:
-            row = db.query(SessionRow).filter_by(session_id=session_id).first()
-            if not row:
-                return None
-            if row.last_active_at and (datetime.now() - row.last_active_at) > self.ttl:
-                row.last_active_paper_id = None
-                row.last_active_at = None
-                db.commit()
-                return None
-            return row.last_active_paper_id
-
-    def resolve_paper(
-        self, session_id: str, ref: Union[str, int, None]
-    ) -> Optional[Paper]:
-        papers = self.get_last_papers(session_id)
-        if not papers:
-            return None
-
-        if ref is None:
-            last_id = self.get_last_active_paper_id(session_id)
-            if not last_id:
-                return None
-            for p in papers:
-                if p.id == last_id:
-                    return p
-            return None
-
-        if isinstance(ref, int):
-            idx = ref - 1
-            return papers[idx] if 0 <= idx < len(papers) else None
-
-        s = str(ref).strip()
-        m = _REF_RE.fullmatch(s)
-        if m:
-            idx = int(m.group(1)) - 1
-            return papers[idx] if 0 <= idx < len(papers) else None
-
-        for p in papers:
-            if p.id == s:
-                return p
-
-        low = s.lower()
-        for p in papers:
-            if low in (p.title or "").lower():
-                return p
-        return None
-
-    # -------- PDF cache --------
-
-    def get_pdf_asset(self, paper_id: str) -> Optional[PdfAsset]:
-        with get_sync_session() as db:
-            row = db.query(PdfAssetRow).filter_by(paper_id=paper_id).first()
-            return _pdf_row_to_schema(row) if row else None
-
-    def upsert_pdf_asset(self, asset: PdfAsset) -> PdfAsset:
-        with get_sync_session() as db:
-            row = db.query(PdfAssetRow).filter_by(paper_id=asset.paper_id).first()
-            if not row:
-                row = PdfAssetRow(paper_id=asset.paper_id)
-                db.add(row)
-            row.pdf_url = asset.pdf_url
-            row.local_path = asset.local_path
-            row.status = asset.status
-            row.size_bytes = asset.size_bytes
-            row.sha256 = asset.sha256
-            row.downloaded_at = asset.downloaded_at
-            row.updated_at = datetime.now()
-            row.error = asset.error
-            db.commit()
-            db.refresh(row)
-            return _pdf_row_to_schema(row)
-
-    def update_pdf_asset(self, paper_id: str, **kwargs) -> Optional[PdfAsset]:
-        with get_sync_session() as db:
-            row = db.query(PdfAssetRow).filter_by(paper_id=paper_id).first()
-            if not row:
-                return None
-            for k, v in kwargs.items():
-                if hasattr(row, k):
-                    setattr(row, k, v)
-            row.updated_at = datetime.now()
-            db.commit()
-            db.refresh(row)
-            return _pdf_row_to_schema(row)
-
-    def delete_pdf_asset(self, paper_id: str) -> bool:
-        with get_sync_session() as db:
-            row = db.query(PdfAssetRow).filter_by(paper_id=paper_id).first()
-            if not row:
-                return False
-            db.delete(row)
-            db.commit()
-            return True
-
-    def list_pdf_assets(self) -> List[PdfAsset]:
-        with get_sync_session() as db:
-            rows = db.query(PdfAssetRow).order_by(PdfAssetRow.updated_at.desc()).all()
-            return [_pdf_row_to_schema(r) for r in rows]
-
-    # -------- Translate cache --------
-
-    def get_translate_asset(self, paper_id: str) -> Optional[TranslateAsset]:
-        with get_sync_session() as db:
-            row = db.query(TranslateAssetRow).filter_by(paper_id=paper_id).first()
-            return _translate_row_to_schema(row) if row else None
-
-    def upsert_translate_asset(self, asset: TranslateAsset) -> TranslateAsset:
-        with get_sync_session() as db:
-            row = db.query(TranslateAssetRow).filter_by(paper_id=asset.paper_id).first()
-            if not row:
-                row = TranslateAssetRow(paper_id=asset.paper_id)
-                db.add(row)
-            row.input_pdf_path = asset.input_pdf_path
-            row.output_mono_path = asset.output_mono_path
-            row.output_dual_path = asset.output_dual_path
-            row.status = asset.status
-            row.service = asset.service
-            row.threads = asset.threads
-            row.translated_at = asset.translated_at
-            row.updated_at = datetime.now()
-            row.error = asset.error
-            db.commit()
-            db.refresh(row)
-            return _translate_row_to_schema(row)
-
-    def update_translate_asset(self, paper_id: str, **kwargs) -> Optional[TranslateAsset]:
-        with get_sync_session() as db:
-            row = db.query(TranslateAssetRow).filter_by(paper_id=paper_id).first()
-            if not row:
-                return None
-            for k, v in kwargs.items():
-                if hasattr(row, k):
-                    setattr(row, k, v)
-            row.updated_at = datetime.now()
-            db.commit()
-            db.refresh(row)
-            return _translate_row_to_schema(row)
-
-    def delete_translate_asset(self, paper_id: str) -> bool:
-        with get_sync_session() as db:
-            row = db.query(TranslateAssetRow).filter_by(paper_id=paper_id).first()
-            if not row:
-                return False
-            db.delete(row)
-            db.commit()
-            return True
-
-    def list_translate_assets(self) -> List[TranslateAsset]:
-        with get_sync_session() as db:
-            rows = db.query(TranslateAssetRow).order_by(TranslateAssetRow.updated_at.desc()).all()
-            return [_translate_row_to_schema(r) for r in rows]
-
-    # -------- tasks --------
-
-    def create_translate_task(
-        self,
-        session_id: str,
-        paper_id: str,
-        input_pdf_url: Optional[str] = None,
-        meta: Optional[Dict[str, str]] = None,
-    ) -> TranslateTask:
-        task_id = uuid.uuid4().hex
-        now = datetime.now()
-        with get_sync_session() as db:
-            row = TranslateTaskRow(
-                task_id=task_id,
-                session_id=session_id,
-                paper_id=paper_id,
-                status="PENDING",
-                input_pdf_url=input_pdf_url,
-                meta=json.dumps(meta or {}, ensure_ascii=False),
-                created_at=now,
-                updated_at=now,
-            )
-            db.add(row)
-            db.commit()
-            db.refresh(row)
-            return _task_row_to_schema(row)
-
-    def get_task(self, task_id: str) -> Optional[TranslateTask]:
-        with get_sync_session() as db:
-            row = db.query(TranslateTaskRow).filter_by(task_id=task_id).first()
-            return _task_row_to_schema(row) if row else None
-
-    def update_task(self, task_id: str, **kwargs) -> Optional[TranslateTask]:
-        with get_sync_session() as db:
-            row = db.query(TranslateTaskRow).filter_by(task_id=task_id).first()
-            if not row:
-                return None
-            for k, v in kwargs.items():
-                if k == "meta" and isinstance(v, dict):
-                    row.meta = json.dumps(v, ensure_ascii=False)
-                elif hasattr(row, k):
-                    setattr(row, k, v)
-            row.updated_at = datetime.now()
-            db.commit()
-            db.refresh(row)
-            return _task_row_to_schema(row)
-
-    def list_tasks(
-        self, session_id: Optional[str] = None, limit: int = 50
-    ) -> List[TranslateTask]:
-        with get_sync_session() as db:
-            q = db.query(TranslateTaskRow)
-            if session_id:
-                q = q.filter_by(session_id=session_id)
-            rows = q.order_by(TranslateTaskRow.updated_at.desc()).limit(max(1, limit)).all()
-            return [_task_row_to_schema(r) for r in rows]
-
-    # -------- startup validation --------
-
-    def validate_local_paths(self) -> None:
-        """Mark READY assets as FAILED if their local files are missing."""
-        with get_sync_session() as db:
-            for row in db.query(PdfAssetRow).filter_by(status="READY").all():
-                if not row.local_path or not os.path.exists(row.local_path):
-                    row.status = "FAILED"
-                    row.error = f"local file missing: {row.local_path}"
-                    row.updated_at = datetime.now()
-            for row in db.query(TranslateAssetRow).filter_by(status="READY").all():
-                if not row.output_mono_path or not os.path.exists(row.output_mono_path):
-                    row.status = "FAILED"
-                    row.error = f"local file missing: {row.output_mono_path}"
-                    row.updated_at = datetime.now()
-            db.commit()
+    if not isinstance(_backend, MemoryStore):
+        _backend = MemoryStore()
+    elif reset:
+        _backend.reset()
+    return _backend
 
 
-store = Store()
+def is_memory_backend() -> bool:
+    from models.store_memory import MemoryStore
+    return isinstance(get_store(), MemoryStore)

--- a/AgenticArxiv/models/store_memory.py
+++ b/AgenticArxiv/models/store_memory.py
@@ -1,0 +1,249 @@
+# AgenticArxiv/models/store_memory.py
+"""进程内内存版 Store，与 MySQL 版 API 完全一致。
+
+用途：离线 RL rollout / 单元测试 / 无数据库演示。
+- 不依赖 sqlalchemy / pymysql
+- 单进程内有效，进程退出即丢失
+- TTL 语义与 MySQL 版保持一致，便于复现同样的"会话记忆过期"行为
+"""
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Union
+
+from config import settings
+from models.schemas import Paper, PdfAsset, TranslateAsset, TranslateTask
+
+_REF_RE = re.compile(r"(?:第)?\s*(\d+)\s*(?:篇)?")
+
+
+class _SessionState:
+    __slots__ = ("papers", "last_active_paper_id", "last_active_at", "updated_at")
+
+    def __init__(self) -> None:
+        self.papers: List[Paper] = []
+        self.last_active_paper_id: Optional[str] = None
+        self.last_active_at: Optional[datetime] = None
+        self.updated_at: datetime = datetime.now()
+
+
+class MemoryStore:
+    """In-memory store (single process, no external dependency)."""
+
+    def __init__(self, ttl_minutes: int = 60, max_papers: int = 50, make_dirs: bool = True):
+        self.ttl = timedelta(minutes=ttl_minutes)
+        self.max_papers = max_papers
+        self._sessions: Dict[str, _SessionState] = {}
+        self._pdf_assets: Dict[str, PdfAsset] = {}
+        self._translate_assets: Dict[str, TranslateAsset] = {}
+        self._tasks: Dict[str, TranslateTask] = {}
+
+        if make_dirs:
+            os.makedirs(settings.pdf_raw_path, exist_ok=True)
+            os.makedirs(settings.pdf_translated_path, exist_ok=True)
+
+    # -------- internal --------
+
+    def _session(self, session_id: str) -> _SessionState:
+        st = self._sessions.get(session_id)
+        if st is None:
+            st = _SessionState()
+            self._sessions[session_id] = st
+        return st
+
+    def reset(self) -> None:
+        """清空所有状态（RL rollout 之间隔离用）。"""
+        self._sessions.clear()
+        self._pdf_assets.clear()
+        self._translate_assets.clear()
+        self._tasks.clear()
+
+    # -------- session memory --------
+
+    def set_last_papers(self, session_id: str, papers: List[Paper]) -> None:
+        st = self._session(session_id)
+        st.papers = list(papers[: self.max_papers])
+        st.updated_at = datetime.now()
+
+    def get_last_papers(self, session_id: str) -> List[Paper]:
+        st = self._sessions.get(session_id)
+        if not st:
+            return []
+        if st.updated_at and (datetime.now() - st.updated_at) > self.ttl:
+            return []
+        return list(st.papers)
+
+    # -------- last active paper --------
+
+    def set_last_active_paper_id(self, session_id: str, paper_id: str) -> None:
+        if not paper_id:
+            return
+        st = self._session(session_id)
+        st.last_active_paper_id = paper_id
+        st.last_active_at = datetime.now()
+        st.updated_at = datetime.now()
+
+    def get_last_active_paper_id(self, session_id: str) -> Optional[str]:
+        st = self._sessions.get(session_id)
+        if not st:
+            return None
+        if st.last_active_at and (datetime.now() - st.last_active_at) > self.ttl:
+            st.last_active_paper_id = None
+            st.last_active_at = None
+            return None
+        return st.last_active_paper_id
+
+    def resolve_paper(
+        self, session_id: str, ref: Union[str, int, None]
+    ) -> Optional[Paper]:
+        papers = self.get_last_papers(session_id)
+        if not papers:
+            return None
+
+        if ref is None:
+            last_id = self.get_last_active_paper_id(session_id)
+            if not last_id:
+                return None
+            for p in papers:
+                if p.id == last_id:
+                    return p
+            return None
+
+        if isinstance(ref, int):
+            idx = ref - 1
+            return papers[idx] if 0 <= idx < len(papers) else None
+
+        s = str(ref).strip()
+        m = _REF_RE.fullmatch(s)
+        if m:
+            idx = int(m.group(1)) - 1
+            return papers[idx] if 0 <= idx < len(papers) else None
+
+        for p in papers:
+            if p.id == s:
+                return p
+
+        low = s.lower()
+        for p in papers:
+            if low in (p.title or "").lower():
+                return p
+        return None
+
+    # -------- PDF cache --------
+
+    def get_pdf_asset(self, paper_id: str) -> Optional[PdfAsset]:
+        return self._pdf_assets.get(paper_id)
+
+    def upsert_pdf_asset(self, asset: PdfAsset) -> PdfAsset:
+        asset.updated_at = datetime.now()
+        self._pdf_assets[asset.paper_id] = asset
+        return asset
+
+    def update_pdf_asset(self, paper_id: str, **kwargs) -> Optional[PdfAsset]:
+        asset = self._pdf_assets.get(paper_id)
+        if not asset:
+            return None
+        for k, v in kwargs.items():
+            if hasattr(asset, k):
+                setattr(asset, k, v)
+        asset.updated_at = datetime.now()
+        return asset
+
+    def delete_pdf_asset(self, paper_id: str) -> bool:
+        return self._pdf_assets.pop(paper_id, None) is not None
+
+    def list_pdf_assets(self) -> List[PdfAsset]:
+        return sorted(
+            self._pdf_assets.values(), key=lambda a: a.updated_at, reverse=True
+        )
+
+    # -------- Translate cache --------
+
+    def get_translate_asset(self, paper_id: str) -> Optional[TranslateAsset]:
+        return self._translate_assets.get(paper_id)
+
+    def upsert_translate_asset(self, asset: TranslateAsset) -> TranslateAsset:
+        asset.updated_at = datetime.now()
+        self._translate_assets[asset.paper_id] = asset
+        return asset
+
+    def update_translate_asset(self, paper_id: str, **kwargs) -> Optional[TranslateAsset]:
+        asset = self._translate_assets.get(paper_id)
+        if not asset:
+            return None
+        for k, v in kwargs.items():
+            if hasattr(asset, k):
+                setattr(asset, k, v)
+        asset.updated_at = datetime.now()
+        return asset
+
+    def delete_translate_asset(self, paper_id: str) -> bool:
+        return self._translate_assets.pop(paper_id, None) is not None
+
+    def list_translate_assets(self) -> List[TranslateAsset]:
+        return sorted(
+            self._translate_assets.values(), key=lambda a: a.updated_at, reverse=True
+        )
+
+    # -------- tasks --------
+
+    def create_translate_task(
+        self,
+        session_id: str,
+        paper_id: str,
+        input_pdf_url: Optional[str] = None,
+        meta: Optional[Dict[str, str]] = None,
+    ) -> TranslateTask:
+        task = TranslateTask(
+            task_id=uuid.uuid4().hex,
+            session_id=session_id,
+            paper_id=paper_id,
+            status="PENDING",
+            input_pdf_url=input_pdf_url,
+            meta=meta or {},
+        )
+        self._tasks[task.task_id] = task
+        return task
+
+    def get_task(self, task_id: str) -> Optional[TranslateTask]:
+        return self._tasks.get(task_id)
+
+    def update_task(self, task_id: str, **kwargs) -> Optional[TranslateTask]:
+        task = self._tasks.get(task_id)
+        if not task:
+            return None
+        for k, v in kwargs.items():
+            if hasattr(task, k):
+                setattr(task, k, v)
+        task.updated_at = datetime.now()
+        return task
+
+    def list_tasks(
+        self, session_id: Optional[str] = None, limit: int = 50
+    ) -> List[TranslateTask]:
+        items = list(self._tasks.values())
+        if session_id:
+            items = [t for t in items if t.session_id == session_id]
+        items.sort(key=lambda t: t.updated_at, reverse=True)
+        return items[: max(1, limit)]
+
+    # -------- startup validation --------
+
+    def validate_local_paths(self) -> None:
+        for asset in self._pdf_assets.values():
+            if asset.status == "READY" and (
+                not asset.local_path or not os.path.exists(asset.local_path)
+            ):
+                asset.status = "FAILED"
+                asset.error = f"local file missing: {asset.local_path}"
+                asset.updated_at = datetime.now()
+        for asset in self._translate_assets.values():
+            if asset.status == "READY" and (
+                not asset.output_mono_path or not os.path.exists(asset.output_mono_path)
+            ):
+                asset.status = "FAILED"
+                asset.error = f"local file missing: {asset.output_mono_path}"
+                asset.updated_at = datetime.now()

--- a/AgenticArxiv/models/store_mysql.py
+++ b/AgenticArxiv/models/store_mysql.py
@@ -1,0 +1,406 @@
+# AgenticArxiv/models/store_mysql.py
+"""MySQL-backed session/asset store（原 models/store.py 的实现）。
+
+只有在 STORE_BACKEND=mysql（或 auto 且 sqlalchemy 可用）时才会被导入，
+离线 RL 训练路径不会触碰本模块，因此也不需要 sqlalchemy/pymysql 依赖。
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional, Union
+
+from sqlalchemy import func
+
+from config import settings
+from models.db import get_sync_session
+from models.orm import (
+    PdfAssetRow, TranslateAssetRow, SessionRow, SessionPaperRow, TranslateTaskRow,
+)
+from models.schemas import (
+    Paper, PdfAsset, TranslateAsset, TranslateTask,
+)
+
+_REF_RE = re.compile(r"(?:第)?\s*(\d+)\s*(?:篇)?")
+
+
+def _pdf_row_to_schema(row: PdfAssetRow) -> PdfAsset:
+    return PdfAsset(
+        paper_id=row.paper_id,
+        pdf_url=row.pdf_url or "",
+        local_path=row.local_path or "",
+        status=row.status or "NOT_DOWNLOADED",
+        size_bytes=row.size_bytes or 0,
+        sha256=row.sha256,
+        downloaded_at=row.downloaded_at,
+        updated_at=row.updated_at or datetime.now(),
+        error=row.error,
+    )
+
+
+def _translate_row_to_schema(row: TranslateAssetRow) -> TranslateAsset:
+    return TranslateAsset(
+        paper_id=row.paper_id,
+        input_pdf_path=row.input_pdf_path or "",
+        output_mono_path=row.output_mono_path or "",
+        output_dual_path=row.output_dual_path,
+        status=row.status or "NOT_TRANSLATED",
+        service=row.service,
+        threads=row.threads or 0,
+        translated_at=row.translated_at,
+        updated_at=row.updated_at or datetime.now(),
+        error=row.error,
+    )
+
+
+def _task_row_to_schema(row: TranslateTaskRow) -> TranslateTask:
+    meta = {}
+    if row.meta:
+        try:
+            meta = json.loads(row.meta)
+        except Exception:
+            pass
+    return TranslateTask(
+        task_id=row.task_id,
+        session_id=row.session_id,
+        paper_id=row.paper_id,
+        status=row.status or "PENDING",
+        progress=row.progress or 0.0,
+        input_pdf_url=row.input_pdf_url,
+        input_pdf_path=row.input_pdf_path,
+        output_pdf_path=row.output_pdf_path,
+        error=row.error,
+        meta=meta,
+        created_at=row.created_at or datetime.now(),
+        updated_at=row.updated_at or datetime.now(),
+    )
+
+
+def _paper_row_to_schema(row: SessionPaperRow) -> Paper:
+    def _load_json_list(s):
+        if not s:
+            return []
+        try:
+            return json.loads(s)
+        except Exception:
+            return []
+
+    return Paper(
+        id=row.paper_id,
+        title=row.title or "",
+        authors=_load_json_list(row.authors),
+        summary=row.summary,
+        published=row.published,
+        updated=row.updated,
+        pdf_url=row.pdf_url,
+        primary_category=row.primary_category,
+        categories=_load_json_list(row.categories),
+        comment=row.comment,
+        links=_load_json_list(row.links),
+    )
+
+
+class Store:
+    """MySQL-backed store (synchronous, thread-safe via SQLAlchemy connection pool)."""
+
+    def __init__(self, ttl_minutes: int = 60, max_papers: int = 50):
+        self.ttl = timedelta(minutes=ttl_minutes)
+        self.max_papers = max_papers
+
+        # Ensure output directories exist
+        os.makedirs(settings.pdf_raw_path, exist_ok=True)
+        os.makedirs(settings.pdf_translated_path, exist_ok=True)
+
+    # -------- session memory --------
+
+    def set_last_papers(self, session_id: str, papers: List[Paper]) -> None:
+        with get_sync_session() as db:
+            # Ensure session row exists
+            row = db.query(SessionRow).filter_by(session_id=session_id).first()
+            if not row:
+                row = SessionRow(session_id=session_id)
+                db.add(row)
+            row.updated_at = datetime.now()
+
+            # Replace session_papers
+            db.query(SessionPaperRow).filter_by(session_id=session_id).delete()
+            for i, p in enumerate(papers[: self.max_papers]):
+                db.add(SessionPaperRow(
+                    session_id=session_id,
+                    paper_id=p.id,
+                    title=p.title,
+                    authors=json.dumps(p.authors, ensure_ascii=False),
+                    summary=p.summary,
+                    published=p.published,
+                    updated=p.updated,
+                    pdf_url=p.pdf_url,
+                    primary_category=p.primary_category,
+                    categories=json.dumps(p.categories, ensure_ascii=False),
+                    comment=p.comment,
+                    links=json.dumps(p.links, ensure_ascii=False),
+                    position=i,
+                ))
+            db.commit()
+
+    def get_last_papers(self, session_id: str) -> List[Paper]:
+        with get_sync_session() as db:
+            row = db.query(SessionRow).filter_by(session_id=session_id).first()
+            if not row:
+                return []
+            if row.updated_at and (datetime.now() - row.updated_at) > self.ttl:
+                return []
+            paper_rows = (
+                db.query(SessionPaperRow)
+                .filter_by(session_id=session_id)
+                .order_by(SessionPaperRow.position)
+                .all()
+            )
+            return [_paper_row_to_schema(r) for r in paper_rows]
+
+    # -------- last active paper --------
+
+    def set_last_active_paper_id(self, session_id: str, paper_id: str) -> None:
+        if not paper_id:
+            return
+        with get_sync_session() as db:
+            row = db.query(SessionRow).filter_by(session_id=session_id).first()
+            if not row:
+                row = SessionRow(session_id=session_id)
+                db.add(row)
+            row.last_active_paper_id = paper_id
+            row.last_active_at = datetime.now()
+            row.updated_at = datetime.now()
+            db.commit()
+
+    def get_last_active_paper_id(self, session_id: str) -> Optional[str]:
+        with get_sync_session() as db:
+            row = db.query(SessionRow).filter_by(session_id=session_id).first()
+            if not row:
+                return None
+            if row.last_active_at and (datetime.now() - row.last_active_at) > self.ttl:
+                row.last_active_paper_id = None
+                row.last_active_at = None
+                db.commit()
+                return None
+            return row.last_active_paper_id
+
+    def resolve_paper(
+        self, session_id: str, ref: Union[str, int, None]
+    ) -> Optional[Paper]:
+        papers = self.get_last_papers(session_id)
+        if not papers:
+            return None
+
+        if ref is None:
+            last_id = self.get_last_active_paper_id(session_id)
+            if not last_id:
+                return None
+            for p in papers:
+                if p.id == last_id:
+                    return p
+            return None
+
+        if isinstance(ref, int):
+            idx = ref - 1
+            return papers[idx] if 0 <= idx < len(papers) else None
+
+        s = str(ref).strip()
+        m = _REF_RE.fullmatch(s)
+        if m:
+            idx = int(m.group(1)) - 1
+            return papers[idx] if 0 <= idx < len(papers) else None
+
+        for p in papers:
+            if p.id == s:
+                return p
+
+        low = s.lower()
+        for p in papers:
+            if low in (p.title or "").lower():
+                return p
+        return None
+
+    # -------- PDF cache --------
+
+    def get_pdf_asset(self, paper_id: str) -> Optional[PdfAsset]:
+        with get_sync_session() as db:
+            row = db.query(PdfAssetRow).filter_by(paper_id=paper_id).first()
+            return _pdf_row_to_schema(row) if row else None
+
+    def upsert_pdf_asset(self, asset: PdfAsset) -> PdfAsset:
+        with get_sync_session() as db:
+            row = db.query(PdfAssetRow).filter_by(paper_id=asset.paper_id).first()
+            if not row:
+                row = PdfAssetRow(paper_id=asset.paper_id)
+                db.add(row)
+            row.pdf_url = asset.pdf_url
+            row.local_path = asset.local_path
+            row.status = asset.status
+            row.size_bytes = asset.size_bytes
+            row.sha256 = asset.sha256
+            row.downloaded_at = asset.downloaded_at
+            row.updated_at = datetime.now()
+            row.error = asset.error
+            db.commit()
+            db.refresh(row)
+            return _pdf_row_to_schema(row)
+
+    def update_pdf_asset(self, paper_id: str, **kwargs) -> Optional[PdfAsset]:
+        with get_sync_session() as db:
+            row = db.query(PdfAssetRow).filter_by(paper_id=paper_id).first()
+            if not row:
+                return None
+            for k, v in kwargs.items():
+                if hasattr(row, k):
+                    setattr(row, k, v)
+            row.updated_at = datetime.now()
+            db.commit()
+            db.refresh(row)
+            return _pdf_row_to_schema(row)
+
+    def delete_pdf_asset(self, paper_id: str) -> bool:
+        with get_sync_session() as db:
+            row = db.query(PdfAssetRow).filter_by(paper_id=paper_id).first()
+            if not row:
+                return False
+            db.delete(row)
+            db.commit()
+            return True
+
+    def list_pdf_assets(self) -> List[PdfAsset]:
+        with get_sync_session() as db:
+            rows = db.query(PdfAssetRow).order_by(PdfAssetRow.updated_at.desc()).all()
+            return [_pdf_row_to_schema(r) for r in rows]
+
+    # -------- Translate cache --------
+
+    def get_translate_asset(self, paper_id: str) -> Optional[TranslateAsset]:
+        with get_sync_session() as db:
+            row = db.query(TranslateAssetRow).filter_by(paper_id=paper_id).first()
+            return _translate_row_to_schema(row) if row else None
+
+    def upsert_translate_asset(self, asset: TranslateAsset) -> TranslateAsset:
+        with get_sync_session() as db:
+            row = db.query(TranslateAssetRow).filter_by(paper_id=asset.paper_id).first()
+            if not row:
+                row = TranslateAssetRow(paper_id=asset.paper_id)
+                db.add(row)
+            row.input_pdf_path = asset.input_pdf_path
+            row.output_mono_path = asset.output_mono_path
+            row.output_dual_path = asset.output_dual_path
+            row.status = asset.status
+            row.service = asset.service
+            row.threads = asset.threads
+            row.translated_at = asset.translated_at
+            row.updated_at = datetime.now()
+            row.error = asset.error
+            db.commit()
+            db.refresh(row)
+            return _translate_row_to_schema(row)
+
+    def update_translate_asset(self, paper_id: str, **kwargs) -> Optional[TranslateAsset]:
+        with get_sync_session() as db:
+            row = db.query(TranslateAssetRow).filter_by(paper_id=paper_id).first()
+            if not row:
+                return None
+            for k, v in kwargs.items():
+                if hasattr(row, k):
+                    setattr(row, k, v)
+            row.updated_at = datetime.now()
+            db.commit()
+            db.refresh(row)
+            return _translate_row_to_schema(row)
+
+    def delete_translate_asset(self, paper_id: str) -> bool:
+        with get_sync_session() as db:
+            row = db.query(TranslateAssetRow).filter_by(paper_id=paper_id).first()
+            if not row:
+                return False
+            db.delete(row)
+            db.commit()
+            return True
+
+    def list_translate_assets(self) -> List[TranslateAsset]:
+        with get_sync_session() as db:
+            rows = db.query(TranslateAssetRow).order_by(TranslateAssetRow.updated_at.desc()).all()
+            return [_translate_row_to_schema(r) for r in rows]
+
+    # -------- tasks --------
+
+    def create_translate_task(
+        self,
+        session_id: str,
+        paper_id: str,
+        input_pdf_url: Optional[str] = None,
+        meta: Optional[Dict[str, str]] = None,
+    ) -> TranslateTask:
+        task_id = uuid.uuid4().hex
+        now = datetime.now()
+        with get_sync_session() as db:
+            row = TranslateTaskRow(
+                task_id=task_id,
+                session_id=session_id,
+                paper_id=paper_id,
+                status="PENDING",
+                input_pdf_url=input_pdf_url,
+                meta=json.dumps(meta or {}, ensure_ascii=False),
+                created_at=now,
+                updated_at=now,
+            )
+            db.add(row)
+            db.commit()
+            db.refresh(row)
+            return _task_row_to_schema(row)
+
+    def get_task(self, task_id: str) -> Optional[TranslateTask]:
+        with get_sync_session() as db:
+            row = db.query(TranslateTaskRow).filter_by(task_id=task_id).first()
+            return _task_row_to_schema(row) if row else None
+
+    def update_task(self, task_id: str, **kwargs) -> Optional[TranslateTask]:
+        with get_sync_session() as db:
+            row = db.query(TranslateTaskRow).filter_by(task_id=task_id).first()
+            if not row:
+                return None
+            for k, v in kwargs.items():
+                if k == "meta" and isinstance(v, dict):
+                    row.meta = json.dumps(v, ensure_ascii=False)
+                elif hasattr(row, k):
+                    setattr(row, k, v)
+            row.updated_at = datetime.now()
+            db.commit()
+            db.refresh(row)
+            return _task_row_to_schema(row)
+
+    def list_tasks(
+        self, session_id: Optional[str] = None, limit: int = 50
+    ) -> List[TranslateTask]:
+        with get_sync_session() as db:
+            q = db.query(TranslateTaskRow)
+            if session_id:
+                q = q.filter_by(session_id=session_id)
+            rows = q.order_by(TranslateTaskRow.updated_at.desc()).limit(max(1, limit)).all()
+            return [_task_row_to_schema(r) for r in rows]
+
+    # -------- startup validation --------
+
+    def validate_local_paths(self) -> None:
+        """Mark READY assets as FAILED if their local files are missing."""
+        with get_sync_session() as db:
+            for row in db.query(PdfAssetRow).filter_by(status="READY").all():
+                if not row.local_path or not os.path.exists(row.local_path):
+                    row.status = "FAILED"
+                    row.error = f"local file missing: {row.local_path}"
+                    row.updated_at = datetime.now()
+            for row in db.query(TranslateAssetRow).filter_by(status="READY").all():
+                if not row.output_mono_path or not os.path.exists(row.output_mono_path):
+                    row.status = "FAILED"
+                    row.error = f"local file missing: {row.output_mono_path}"
+                    row.updated_at = datetime.now()
+            db.commit()
+
+
+# 注意：单例由 models/store.py 的 backend 分发器负责创建，此处不再实例化。

--- a/AgenticArxiv/requirements.txt
+++ b/AgenticArxiv/requirements.txt
@@ -13,13 +13,9 @@ loguru
 pydantic>=2.0
 fire
 
-# ===== 当前 RL 路径实际仍需要的依赖 =====
-# agents/base_agent.py 顶层 import 了 models.store（SQLAlchemy）与
-# services.runtime（FastAPI 的 jsonable_encoder），因此 rl.rollout 也会拉进这三个包。
-# 注：解除这层耦合后即可移除，见 README 的"依赖说明"。
-sqlalchemy>=2.0
-pymysql
-fastapi
-
 # ===== 可选依赖（eval/demo 时需要，训练时不需要） =====
 # pdf2zh  # PDF 翻译（训练时用 mock）
+#
+# 说明：RL 路径已与 MySQL/FastAPI 解耦（STORE_BACKEND=memory +
+# agents/side_effects.py），以上依赖即可跑通 rollout。
+# 运行 Web 应用才需要 fastapi/sqlalchemy/pymysql，见 requirements-extra.txt。

--- a/AgenticArxiv/rl/rollout.py
+++ b/AgenticArxiv/rl/rollout.py
@@ -10,6 +10,7 @@
     python -m rl.rollout search_01 traces/train/
 """
 
+import os
 import sys
 from pathlib import Path
 from datetime import datetime
@@ -18,8 +19,12 @@ import fire
 # 添加 AgenticArxiv 到 Python 路径
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+# RL 路径不依赖数据库：会话状态走内存 store
+os.environ.setdefault("STORE_BACKEND", "memory")
+
 from benchmark.tasks import get_task_by_id, get_all_tasks
 from agents.agent_engine import ReActAgent
+from agents.side_effects import LocalSideEffectManager
 from utils.llm_client import get_env_llm_client
 from rl.reward import RewardCalculator
 from rl.trajectory import create_trajectory, save_trajectory
@@ -47,7 +52,7 @@ def rollout_single_task(
 
     # 2. 创建 Agent（使用 NoOpSideEffectManager）
     llm_client = get_env_llm_client()
-    agent = ReActAgent(llm_client)
+    agent = ReActAgent(llm_client, side_effect_mgr=LocalSideEffectManager())
 
     # 3. 执行 Agent
     print(f"🤖 执行 Agent...")

--- a/AgenticArxiv/skill_cli/skill_agent.py
+++ b/AgenticArxiv/skill_cli/skill_agent.py
@@ -38,8 +38,8 @@ class SkillAgent(BaseAgent):
     """通过 Skill 文档 + CLI 子进程执行工具的 Agent"""
     agent_type = "skill_cli"
 
-    def __init__(self, llm_client: LLMClient):
-        super().__init__(llm_client)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, max_iterations: int = 5):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, max_iterations=max_iterations)
         self._skill_doc = self._load_skill_doc()
 
         # 确保底层工具已注册（供 _execute_with_side_effects 使用）

--- a/scripts/generate_dpo_data.py
+++ b/scripts/generate_dpo_data.py
@@ -14,6 +14,7 @@ DPO 数据格式：
     python scripts/generate_dpo_data.py
 """
 
+import os
 import sys
 import json
 from pathlib import Path
@@ -21,8 +22,12 @@ from pathlib import Path
 # 添加 AgenticArxiv 到 Python 路径
 sys.path.insert(0, str(Path(__file__).parent.parent / "AgenticArxiv"))
 
+# RL 路径不依赖数据库：会话状态走内存 store
+os.environ.setdefault("STORE_BACKEND", "memory")
+
 from benchmark.tasks import get_all_tasks
 from agents.agent_engine import ReActAgent
+from agents.side_effects import LocalSideEffectManager
 from utils.llm_client import get_env_llm_client
 from rl.reward import RewardCalculator
 
@@ -44,7 +49,7 @@ def generate_dpo_dataset(num_rollouts_per_task: int = 5):
     # TODO: 加载 SFT 模型（需要修改 llm_client 支持本地模型）
     # 目前占位：使用原始 LLM
     llm_client = get_env_llm_client()
-    agent = ReActAgent(llm_client)
+    agent = ReActAgent(llm_client, side_effect_mgr=LocalSideEffectManager())
 
     reward_calc = RewardCalculator()
     dpo_data = []

--- a/scripts/generate_sft_data.py
+++ b/scripts/generate_sft_data.py
@@ -9,6 +9,7 @@ SFT 数据格式：
     python scripts/generate_sft_data.py
 """
 
+import os
 import sys
 import json
 from pathlib import Path
@@ -16,8 +17,12 @@ from pathlib import Path
 # 添加 AgenticArxiv 到 Python 路径
 sys.path.insert(0, str(Path(__file__).parent.parent / "AgenticArxiv"))
 
+# RL 路径不依赖数据库：会话状态走内存 store
+os.environ.setdefault("STORE_BACKEND", "memory")
+
 from benchmark.tasks import get_all_tasks
 from agents.agent_engine import ReActAgent
+from agents.side_effects import LocalSideEffectManager
 from utils.llm_client import get_env_llm_client
 
 
@@ -25,7 +30,7 @@ def generate_sft_dataset():
     """执行所有 benchmark tasks，收集成功的 trajectories 作为 expert demos"""
 
     llm_client = get_env_llm_client()
-    agent = ReActAgent(llm_client)
+    agent = ReActAgent(llm_client, side_effect_mgr=LocalSideEffectManager())
 
     sft_data = []
     tasks = get_all_tasks()


### PR DESCRIPTION
## Problem

The README describes the RL fork as *"pure Python + JSONL storage, no
MySQL/FastAPI/frontend required"*, but `agents/base_agent.py` imports at module
level:

```python
from models.store import store
from services.log_service import log_service
from services.runtime import translate_runner, event_bus
```

so `rl.rollout` hard-depends on `sqlalchemy`, `pymysql`, `fastapi` and a running
MySQL instance. #5 had to declare those three packages in `requirements.txt`
just to let the entrypoint import.

**The more damaging consequence is quieter.** Even with every dependency
installed, if MySQL is unreachable then a *successful* arXiv search is recorded
as a failure. `_execute_with_side_effects()` calls `store.set_last_papers()`
after a successful search; that exception is caught by the enclosing `try` and
the function returns:

```
工具执行失败: (pymysql.err.OperationalError) (2003, "Can't connect to MySQL server on '127.0.0.1' ([Errno 61] Connection refused)")
```

So **correct behaviour is counted as a tool-execution failure**,
`tool_exec_failures` is incremented and the reward is reduced. For an RL
environment that means the reward signal is wrong at its source — the policy is
penalised for doing the right thing.

`agents/side_effects.py` already declared the `SideEffectManager` interface; it
was simply never wired into `BaseAgent` (item 1 of the pending list in
`REFACTOR_SUMMARY.md`). This PR completes that work.

## Changes

### Injectable side effects

Three implementations in `agents/side_effects.py`:

| Implementation | Purpose |
|---|---|
| `NoOpSideEffectManager` | no-op throughout |
| `LocalSideEffectManager` | RL default: session memory in an in-process store, no DB / SSE / threads |
| `MySQLSideEffectManager` | the original web behaviour; heavy imports deferred into methods |

One point worth calling out: **session memory cannot simply be a no-op.** The
`download` / `translate` / `cache` tasks all resolve `ref` (`"第1篇"`, `null`
back-reference) through `last_papers` and `last_active_paper_id`. Blanking that
would make those tasks fail unconditionally and skew the reward towards
"everything is a tool error". `LocalSideEffectManager` therefore keeps the
session state, just in memory.

`BaseAgent.__init__` accepts `side_effect_mgr` and routes every `store.*` /
`log_service.*` / `event_bus.*` / `translate_runner.*` call through
`self.side_effects.*`; those modules are no longer imported at module level.
The three Agent subclasses forward the argument.

### Pluggable store backend

`models/store.py` is split into three files while keeping
`from models.store import store` working unchanged:

- `store_mysql.py` — the original implementation, moved verbatim
- `store_memory.py` — in-memory implementation mirroring the same API,
  including the TTL semantics
- `store.py` — dispatcher, `STORE_BACKEND=auto|memory|mysql`

A proxy object is used rather than a module-level rebind, so switching backends
at runtime is visible to modules that already did
`from models.store import store`.

### Call sites

- `api/endpoints.py` and `benchmark/runner.py` pass the MySQL manager
  explicitly to preserve current behaviour (benchmark degrades to in-memory
  when no database is available)
- `rl/rollout.py` and the two scripts set `STORE_BACKEND=memory` and inject
  `LocalSideEffectManager`
- `requirements.txt` drops the `sqlalchemy` / `pymysql` / `fastapi` that #5 had
  to add, so the declared dependencies now match what the README claims

## Verification

**With sqlalchemy installed** — the meaningful case, showing this is not merely
"not installed, so not connected":

```
sqlalchemy present: 2.0.52
RL entrypoint uses memory backend: True
search observation: 成功获取 3 篇论文:   - Don't Drop the BATON: Long-Horizon Robot Man...
```

That last line previously read `工具执行失败: (pymysql.err.OperationalError) ...`.

**Without sqlalchemy**: `python -m rl.rollout search_01 ../traces/train/` runs
to completion.

**Existing work unaffected**:

- `tests/test_multigranular_reward.py` from #4 — 6/6 pass, identical to `main`
- `rl/reward.py` is not touched by this PR
- `rl/rollout.py` keeps #4's `compute_reward_breakdown` / `reward_components`;
  the only additions here are the store backend and the injected manager
- `MySQLSideEffectManager`, `api.app` and `BenchmarkRunner` all import cleanly

## Compatibility

- The new `BaseAgent` arguments have defaults, so existing call sites are
  unaffected
- `STORE_BACKEND` defaults to `auto` (MySQL when sqlalchemy is available,
  in-memory otherwise), so existing deployments behave as before
- Existing benchmark trajectory data is still parsed correctly by
  `extract_metrics`


