### PR TITLE
feat(rl): make MockArxivEnv usable for offline deterministic rollouts

### DIFF
--- a/AgenticArxiv/agents/agent_engine.py
+++ b/AgenticArxiv/agents/agent_engine.py
@@ -17,8 +17,8 @@ from utils.logger import log
 class ReActAgent(BaseAgent):
     """方案 A: ReAct + 正则解析 Agent"""
 
-    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, max_iterations: int = 5):
-        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, max_iterations=max_iterations)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env, max_iterations=max_iterations)
         try:
             import tools.arxiv_tool  # noqa: F401
             import tools.pdf_download_tool  # noqa: F401

--- a/AgenticArxiv/agents/base_agent.py
+++ b/AgenticArxiv/agents/base_agent.py
@@ -22,6 +22,7 @@ class BaseAgent(ABC):
         self,
         llm_client: LLMClient,
         side_effect_mgr: Optional[SideEffectManager] = None,
+        env: Optional[Any] = None,
         max_iterations: int = 5,
     ):
         """
@@ -29,10 +30,13 @@ class BaseAgent(ABC):
             llm_client: LLM 调用客户端
             side_effect_mgr: 副作用管理器；默认 LocalSideEffectManager（无 DB/SSE）。
                 Web 应用请显式传入 MySQLSideEffectManager 以保持原行为。
+            env: 可选的工具执行环境（需实现 execute_tool(name, args)）。
+                传入 MockArxivEnv 即可让 rollout 走快照回放而非真实 API。
             max_iterations: ReAct 最大迭代轮数
         """
         self.llm_client = llm_client
         self.side_effects = side_effect_mgr or LocalSideEffectManager()
+        self.env = env
         self.max_iterations = max_iterations
         self.session_id = "default"
 
@@ -230,6 +234,14 @@ class BaseAgent(ABC):
             pass
         return task
 
+    # ---------- 工具执行（可被 env 接管） ----------
+
+    def _dispatch_tool(self, tool_name: str, args: Dict[str, Any]) -> Any:
+        """统一的工具执行入口：注入了 env 就走 env（快照回放），否则走子类实现。"""
+        if self.env is not None:
+            return self.env.execute_tool(tool_name, args)
+        return self.invoke_tool(tool_name, args)
+
     # ---------- 通用副作用逻辑 ----------
 
     def _execute_with_side_effects(self, action_dict: Dict[str, Any]) -> str:
@@ -273,8 +285,8 @@ class BaseAgent(ABC):
                     f"任务完成后刷新 /translate/assets 或 /pdf/assets。"
                 )
 
-            # 调用子类实现的工具执行
-            result = self.invoke_tool(tool_name, args)
+            # 调用工具（注入了 env 则优先走 env）
+            result = self._dispatch_tool(tool_name, args)
 
             # paper_id 写入 last_active
             try:

--- a/AgenticArxiv/mcp_protocol/mcp_agent.py
+++ b/AgenticArxiv/mcp_protocol/mcp_agent.py
@@ -31,8 +31,8 @@ class MCPAgent(BaseAgent):
     """通过 MCP 协议调用工具的 Agent"""
     agent_type = "mcp"
 
-    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, max_iterations: int = 5):
-        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, max_iterations=max_iterations)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env, max_iterations=max_iterations)
         self._session: Optional[ClientSession] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._mcp_tools: List[Dict[str, Any]] = []

--- a/AgenticArxiv/rl/build_snapshot.py
+++ b/AgenticArxiv/rl/build_snapshot.py
@@ -1,0 +1,87 @@
+"""生成 MockArxivEnv 快照（唯一需要联网的一步）。
+
+跑一次即可，之后所有 rollout / 训练都能完全离线、确定性复现：
+
+    python -m rl.build_snapshot                       # 默认写 ../data/mock_arxiv_snapshot.json
+    python -m rl.build_snapshot --aspects AI LG CL CV --max_results 30
+
+设计说明
+--------
+不再依赖 benchmark.runner（原实现调用了并不存在的 run_single_benchmark），
+而是直接驱动检索工具，为每个 aspect 记录一个"论文池"。
+rollout 时 MockArxivEnv 会按 aspect 取池、按 max_results 切片，
+从而对任意参数组合都能给出合理返回，而不是精确 key 命中才行。
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# 快照生成阶段不需要数据库
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+import tools.arxiv_tool  # noqa: F401  触发工具注册
+from rl.env import MockArxivEnv
+
+# 覆盖 benchmark/rl 任务集里出现过的所有方向
+DEFAULT_ASPECTS = ["*", "AI", "LG", "CL", "CV", "RO", "CR"]
+
+
+def build(
+    snapshot_path: str = "../data/mock_arxiv_snapshot.json",
+    aspects=None,
+    max_results: int = 50,
+    days: int = 30,
+) -> None:
+    aspects = list(aspects or DEFAULT_ASPECTS)
+    path = Path(snapshot_path)
+    env = MockArxivEnv(snapshot_path=path, mode="record")
+
+    print(f"生成 MockEnv 快照 → {path}")
+    print(f"  aspects={aspects} max_results={max_results} days={days}")
+
+    ok, fail = 0, 0
+    for aspect in aspects:
+        try:
+            papers = env.execute_tool(
+                "get_recently_submitted_cs_papers",
+                {
+                    "aspect": aspect,
+                    "days": days,
+                    "max_results": max_results,
+                    "save_to_file": False,
+                },
+            )
+            print(f"  [OK]   aspect={aspect:<3} → {len(papers)} 篇")
+            ok += 1
+        except Exception as e:
+            print(f"  [FAIL] aspect={aspect:<3} → {e}")
+            fail += 1
+
+    env.save_snapshot()
+    total = sum(len(v) for v in env.snapshot.values())
+    print(f"\n完成：{ok} 个 aspect 成功、{fail} 个失败，共 {total} 条快照记录")
+    print(f"快照文件: {path.resolve()}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="生成 MockArxivEnv 快照")
+    parser.add_argument("--snapshot", default="../data/mock_arxiv_snapshot.json")
+    parser.add_argument("--aspects", nargs="+", default=None)
+    parser.add_argument("--max_results", type=int, default=50)
+    parser.add_argument("--days", type=int, default=30)
+    args = parser.parse_args()
+
+    build(
+        snapshot_path=args.snapshot,
+        aspects=args.aspects,
+        max_results=args.max_results,
+        days=args.days,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/AgenticArxiv/rl/env.py
+++ b/AgenticArxiv/rl/env.py
@@ -1,93 +1,273 @@
-"""RL 环境封装
+"""RL 环境封装：把"工具执行"变成可记录、可回放、可离线的状态转移函数。
 
-MockArxivEnv: 快照回放环境（用于快速 rollout）
+设计要点
+--------
+原实现有三个问题，这里一并修掉：
+
+1. **拦不住调用**：Agent 直接用全局 `registry`，env 根本没进链路。
+   → 现在 BaseAgent 支持注入 `env`，`_dispatch_tool()` 优先走 `env.execute_tool()`。
+
+2. **快照永远为空**：`_add_to_snapshot` 的调用点被注释掉了，
+   且 `generate_snapshot_from_benchmark()` 调用了并不存在的 `run_single_benchmark`。
+   → 现在 record 模式会真正落盘，快照生成脚本直接驱动工具、不依赖 benchmark runner。
+
+3. **key 含 session_id**：每次 rollout 的 session_id 都不同，缓存永远 miss。
+   → key 归一化时剔除易变字段。
+
+四个工具在离线模式下的处理策略不同：
+
+    get_recently_submitted_cs_papers  网络请求 → 快照回放
+    download_arxiv_pdf                网络请求 → 离线桩（写占位文件 + 更新 store）
+    translate_arxiv_pdf               子进程   → 由 LocalSideEffectManager 拦截，不进 env
+    get_paper_cache_status            纯本地   → 直接真实执行（读内存 store）
 """
 
 import json
+import os
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional, Set
+
 from tools.tool_registry import registry
+from utils.logger import log
+
+# 构造缓存 key 时忽略的易变字段
+_VOLATILE_ARG_KEYS = {"session_id", "output_path", "save_to_file"}
+
+# 需要走快照回放的"网络型"工具
+DEFAULT_SNAPSHOT_TOOLS: Set[str] = {"get_recently_submitted_cs_papers"}
 
 
 class MockArxivEnv:
-    """快照回放环境（用于快速 rollout）
+    """快照回放环境（用于快速、确定性、离线的 rollout）
 
     工作原理：
-    1. 预先运行真实工具，记录输入→输出映射到 snapshot
-    2. rollout 时从 snapshot 查询，命中则直接返回
-    3. 未命中则回退到真实工具执行（并可选记录到 snapshot）
+      1. record 模式：真实调用工具，把 (tool, key) → result 落盘为 snapshot
+      2. replay 模式：只查 snapshot，miss 即报错（保证完全离线、可复现）
+      3. auto   模式：先查 snapshot，miss 则真实调用并顺手记录
 
     适用场景：
-    - 快速 rollout（避免真实 arxiv API 调用）
-    - 确定性重放（同样输入保证同样输出）
-    - 离线训练（不依赖外部网络）
+      - 快速 rollout（避免真实 arXiv API 调用，GRPO 采样吞吐的刚需）
+      - 确定性重放（同样输入保证同样输出，实验可复现）
+      - 离线训练（不依赖外部网络）
     """
 
-    def __init__(self, snapshot_path: Optional[Path] = None):
+    MODES = ("replay", "record", "auto")
+
+    def __init__(
+        self,
+        snapshot_path: Optional[Path] = None,
+        mode: str = "auto",
+        offline_download: bool = True,
+        snapshot_tools: Optional[Set[str]] = None,
+    ):
         """
         Args:
-            snapshot_path: 快照文件路径（JSON 格式）
+            snapshot_path: 快照文件路径（JSON）
+            mode: replay | record | auto
+            offline_download: True 时 download_arxiv_pdf 走离线桩（不发 HTTP）
+            snapshot_tools: 需要快照的工具名集合
         """
-        self.snapshot_path = snapshot_path
+        if mode not in self.MODES:
+            raise ValueError(f"mode 必须是 {self.MODES} 之一，收到 {mode!r}")
+
+        self.snapshot_path = Path(snapshot_path) if snapshot_path else None
+        self.mode = mode
+        self.offline_download = offline_download
+        self.snapshot_tools = snapshot_tools or set(DEFAULT_SNAPSHOT_TOOLS)
         self.snapshot: Dict[str, Dict[str, Any]] = {}
 
-        if snapshot_path and snapshot_path.exists():
-            with open(snapshot_path, "r", encoding="utf-8") as f:
+        # 统计信息，便于确认 rollout 真的没打外网
+        self.stats = {"hit": 0, "miss": 0, "real_calls": 0, "offline_stubs": 0}
+
+        if self.snapshot_path and self.snapshot_path.exists():
+            with open(self.snapshot_path, "r", encoding="utf-8") as f:
                 self.snapshot = json.load(f)
+            log.info(
+                f"[MockArxivEnv] 载入快照 {self.snapshot_path} "
+                f"({sum(len(v) for v in self.snapshot.values())} 条记录)"
+            )
 
-    def execute_tool(self, tool_name: str, args: Dict[str, Any]) -> str:
-        """执行工具（优先从快照查询）
+    # ---------- 主入口 ----------
 
-        Args:
-            tool_name: 工具名称
-            args: 工具参数
+    def execute_tool(self, tool_name: str, args: Dict[str, Any]) -> Any:
+        """执行工具（返回值与 registry.execute_tool 保持同一契约：list/dict/str）"""
+        # 1) 离线下载桩
+        if tool_name == "download_arxiv_pdf" and self.offline_download:
+            self.stats["offline_stubs"] += 1
+            return self._offline_download(args)
 
-        Returns:
-            工具执行结果（字符串）
-        """
-        # 构造 key（参数排序后拼接）
+        # 2) 非快照工具（纯本地，如缓存查询）→ 直接真实执行
+        if tool_name not in self.snapshot_tools:
+            self.stats["real_calls"] += 1
+            return registry.execute_tool(tool_name, args)
+
+        # 3) 快照工具
         key = self._make_key(args)
         tool_data = self.snapshot.get(tool_name, {})
 
+        # record 模式必须每次都真打，否则派生逻辑会"帮倒忙"：
+        # 后续 aspect 直接命中已有池子，快照里就只剩第一条记录。
+        if self.mode == "record":
+            self.stats["real_calls"] += 1
+            result = registry.execute_tool(tool_name, args)
+            self._add_to_snapshot(tool_name, key, args, result)
+            return result
+
         if key in tool_data:
-            # 命中快照，直接返回
+            self.stats["hit"] += 1
             return tool_data[key]["result"]
 
-        # 未命中，回退到真实工具
+        # 3a) 搜索工具：按"论文池"语义派生，而不是死抠精确 key
+        #     真实 API 下 max_results=5 / 7 / 10 都能正常返回，mock 也应如此，
+        #     否则策略稍微改个参数就变成 KeyError，奖励信号会被污染成"全是工具失败"。
+        if tool_name == "get_recently_submitted_cs_papers":
+            derived = self._derive_search_result(args, tool_data)
+            if derived is not None:
+                self.stats["hit"] += 1
+                return derived
+
+        self.stats["miss"] += 1
+        if self.mode == "replay":
+            raise KeyError(
+                f"[MockArxivEnv] replay 模式下快照缺失: tool={tool_name} key={key}。"
+                f"请先运行 `python -m rl.build_snapshot` 生成快照。"
+            )
+
+        # record / auto：真实调用并记录
+        self.stats["real_calls"] += 1
         result = registry.execute_tool(tool_name, args)
-
-        # 可选：记录到 snapshot（供下次使用）
-        # self._add_to_snapshot(tool_name, key, args, result)
-
+        self._add_to_snapshot(tool_name, key, args, result)
         return result
 
-    def _make_key(self, args: Dict[str, Any]) -> str:
-        """构造参数 key（排序后拼接）
+    # ---------- 搜索语义派生 ----------
 
-        Args:
-            args: 工具参数
+    @staticmethod
+    def _derive_search_result(args: Dict[str, Any], tool_data: Dict[str, Any]):
+        """从已记录的论文池里按 aspect 取子集，模拟真实检索的参数语义。
 
-        Returns:
-            key 字符串（如 "cs.AI|7|5"）
+        匹配优先级：同 aspect 的池 → "*" 全域池 → 任意池。
+        返回 None 表示无可用池（交给上层走 miss 分支）。
         """
-        sorted_keys = sorted(args.keys())
-        return "|".join(str(args.get(k, "")) for k in sorted_keys)
+        if not tool_data:
+            return None
+
+        aspect = str(args.get("aspect", "*"))
+        # 容错：模型可能写成 "cs.AI" 而 schema 要求 "AI"
+        norm_aspect = aspect.split(".")[-1] if aspect.startswith("cs.") else aspect
+
+        def pool_of(entry) -> list:
+            r = entry.get("result")
+            return r if isinstance(r, list) else []
+
+        exact, wildcard, anypool = None, None, None
+        for entry in tool_data.values():
+            a = str(entry.get("args", {}).get("aspect", "*"))
+            if anypool is None:
+                anypool = pool_of(entry)
+            if a == "*":
+                wildcard = pool_of(entry)
+            if a == norm_aspect:
+                exact = pool_of(entry)
+
+        pool = exact if exact else (wildcard if wildcard else anypool)
+        if not pool:
+            return None
+
+        try:
+            max_results = int(args.get("max_results", 50))
+        except (TypeError, ValueError):
+            max_results = 50
+        max_results = max(1, min(max_results, len(pool)))
+        return pool[:max_results]
+
+    # ---------- 离线下载桩 ----------
+
+    def _offline_download(self, args: Dict[str, Any]) -> Dict[str, Any]:
+        """不发 HTTP 的 download_arxiv_pdf 替身，返回契约与真实工具一致。
+
+        真实工具会：解析 ref → 下载 → 写 PdfAsset。
+        这里保留前后两步（让 cache_status / 复合任务依然有意义），只跳过网络下载，
+        改为写一个占位文件。
+        """
+        from datetime import datetime
+
+        from config import settings
+        from models.schemas import PdfAsset
+        from models.store import store
+
+        session_id = args.get("session_id", "default")
+        ref = args.get("ref", 1)
+
+        if ref is None:
+            paper_id = store.get_last_active_paper_id(session_id)
+            if not paper_id:
+                raise ValueError(
+                    "未找到指代对象：请先下载/翻译/查状态某篇论文，或明确提供 ref（序号/id/标题）"
+                )
+            paper = store.resolve_paper(session_id, paper_id)
+        else:
+            paper = store.resolve_paper(session_id, ref)
+            if paper is None:
+                raise ValueError(
+                    "未找到论文：请先调用 /arxiv/recent 写入 session 记忆，或检查 ref 是否正确"
+                )
+            paper_id = paper.id
+
+        pdf_url = (paper.pdf_url if paper else None) or f"https://arxiv.org/pdf/{paper_id}.pdf"
+        store.set_last_active_paper_id(session_id, paper_id)
+
+        safe_id = str(paper_id).replace("/", "_")
+        os.makedirs(settings.pdf_raw_path, exist_ok=True)
+        local_path = os.path.join(settings.pdf_raw_path, f"{safe_id}.pdf")
+
+        existed = os.path.exists(local_path) and os.path.getsize(local_path) > 0
+        if not existed:
+            # 最小合法 PDF 头，避免下游把它当成空文件
+            with open(local_path, "wb") as f:
+                f.write(b"%PDF-1.4\n% offline stub for RL rollout\n")
+
+        size_bytes = os.path.getsize(local_path)
+        store.upsert_pdf_asset(
+            PdfAsset(
+                paper_id=paper_id,
+                pdf_url=pdf_url,
+                local_path=local_path,
+                status="READY",
+                size_bytes=size_bytes,
+                downloaded_at=datetime.now(),
+            )
+        )
+
+        return {
+            "session_id": session_id,
+            "paper_id": paper_id,
+            "pdf_url": pdf_url,
+            "local_path": local_path,
+            "status": "READY",
+            "existed": existed,
+            "size_bytes": size_bytes,
+            "sha256": None,
+        }
+
+    # ---------- 快照读写 ----------
+
+    @staticmethod
+    def _make_key(args: Dict[str, Any]) -> str:
+        """构造参数 key（剔除易变字段后按键排序，保证跨 session 可命中）"""
+        stable = {
+            k: v for k, v in (args or {}).items()
+            if k not in _VOLATILE_ARG_KEYS and v is not None
+        }
+        return json.dumps(stable, sort_keys=True, ensure_ascii=False)
 
     def _add_to_snapshot(
-        self, tool_name: str, key: str, args: Dict[str, Any], result: str
+        self, tool_name: str, key: str, args: Dict[str, Any], result: Any
     ) -> None:
-        """添加到快照（供下次使用）
-
-        Args:
-            tool_name: 工具名称
-            key: 参数 key
-            args: 工具参数
-            result: 工具结果
-        """
-        if tool_name not in self.snapshot:
-            self.snapshot[tool_name] = {}
-
-        self.snapshot[tool_name][key] = {"args": args, "result": result}
+        """添加到快照（供下次回放使用）"""
+        self.snapshot.setdefault(tool_name, {})[key] = {
+            "args": {k: v for k, v in (args or {}).items() if k not in _VOLATILE_ARG_KEYS},
+            "result": result,
+        }
 
     def save_snapshot(self) -> None:
         """保存快照到文件"""
@@ -97,32 +277,12 @@ class MockArxivEnv:
         self.snapshot_path.parent.mkdir(parents=True, exist_ok=True)
         with open(self.snapshot_path, "w", encoding="utf-8") as f:
             json.dump(self.snapshot, f, ensure_ascii=False, indent=2)
+        n = sum(len(v) for v in self.snapshot.values())
+        log.info(f"[MockArxivEnv] 快照已保存: {self.snapshot_path} ({n} 条)")
 
-
-def generate_snapshot_from_benchmark():
-    """从 benchmark tasks 生成初始快照
-
-    运行所有 benchmark 任务，记录工具调用到快照文件。
-    供后续 rollout 快速回放使用。
-    """
-    from benchmark.tasks import get_all_tasks
-    from benchmark.runner import run_single_benchmark
-
-    snapshot_path = Path("data/mock_arxiv_snapshot.json")
-    env = MockArxivEnv(snapshot_path)
-
-    print("📸 生成 MockEnv 快照...")
-
-    for task_def in get_all_tasks():
-        print(f"  运行任务: {task_def['id']}")
-        try:
-            # 运行一次真实任务，触发工具调用
-            result = run_single_benchmark(
-                task_def, agent_type="regex", trial=0, session_id="snapshot_gen"
-            )
-            # 工具调用会通过 registry 执行，已被 env 记录
-        except Exception as e:
-            print(f"    ⚠️  任务执行失败: {e}")
-
-    env.save_snapshot()
-    print(f"✅ 快照已保存: {snapshot_path}")
+    def describe(self) -> str:
+        s = self.stats
+        return (
+            f"mode={self.mode} hit={s['hit']} miss={s['miss']} "
+            f"real_calls={s['real_calls']} offline_stubs={s['offline_stubs']}"
+        )

--- a/AgenticArxiv/skill_cli/skill_agent.py
+++ b/AgenticArxiv/skill_cli/skill_agent.py
@@ -38,8 +38,8 @@ class SkillAgent(BaseAgent):
     """通过 Skill 文档 + CLI 子进程执行工具的 Agent"""
     agent_type = "skill_cli"
 
-    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, max_iterations: int = 5):
-        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, max_iterations=max_iterations)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env, max_iterations=max_iterations)
         self._skill_doc = self._load_skill_doc()
 
         # 确保底层工具已注册（供 _execute_with_side_effects 使用）

--- a/AgenticArxiv/tests/test_mock_env.py
+++ b/AgenticArxiv/tests/test_mock_env.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""MockArxivEnv 测试：验证快照回放、参数语义与离线下载桩。
+
+运行：
+    cd AgenticArxiv
+    python -m rl.build_snapshot        # 先生成快照（需联网，一次即可）
+    python tests/test_mock_env.py
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+import tools.arxiv_tool  # noqa: F401,E402
+import tools.cache_status_tool  # noqa: F401,E402
+import tools.pdf_download_tool  # noqa: F401,E402
+
+from agents.agent_engine import ReActAgent  # noqa: E402
+from agents.side_effects import LocalSideEffectManager  # noqa: E402
+from models.schemas import Paper  # noqa: E402
+from models.store import store  # noqa: E402
+from rl.env import MockArxivEnv  # noqa: E402
+
+SNAPSHOT = Path(__file__).resolve().parent.parent.parent / "data" / "mock_arxiv_snapshot.json"
+
+PASSED, FAILED = [], []
+
+
+def check(name, cond, detail=""):
+    (PASSED if cond else FAILED).append(name)
+    print(f"  [{'PASS' if cond else 'FAIL'}] {name}" + (f" — {detail}" if detail else ""))
+
+
+def main():
+    if not SNAPSHOT.exists():
+        print(f"快照不存在: {SNAPSHOT}\n请先运行: python -m rl.build_snapshot")
+        return 1
+
+    print("=== 快照回放（不触网）===")
+    env = MockArxivEnv(snapshot_path=SNAPSHOT, mode="replay")
+    papers = env.execute_tool(
+        "get_recently_submitted_cs_papers",
+        {"aspect": "AI", "days": 7, "max_results": 5, "session_id": "t"},
+    )
+    check("检索命中快照且零真实调用",
+          len(papers) == 5 and env.stats["real_calls"] == 0, env.describe())
+
+    print("\n=== 参数语义（按 max_results 切片，而非精确 key 命中）===")
+    n3 = len(env.execute_tool("get_recently_submitted_cs_papers",
+                              {"aspect": "AI", "days": 7, "max_results": 3}))
+    n9 = len(env.execute_tool("get_recently_submitted_cs_papers",
+                              {"aspect": "AI", "days": 3, "max_results": 9}))
+    check("未记录过的参数组合也能返回正确数量", n3 == 3 and n9 == 9, f"{n3} / {n9}")
+
+    print("\n=== aspect 归一化 ===")
+    a = env.execute_tool("get_recently_submitted_cs_papers", {"aspect": "AI", "max_results": 2})
+    b = env.execute_tool("get_recently_submitted_cs_papers", {"aspect": "cs.AI", "max_results": 2})
+    check("cs.AI 与 AI 取到同一论文池", [p["id"] for p in a] == [p["id"] for p in b])
+
+    print("\n=== 离线下载桩（不发 HTTP）===")
+    store.set_last_papers("t", [Paper(**p) for p in papers])
+    before = env.stats["real_calls"]
+    res = env.execute_tool("download_arxiv_pdf", {"session_id": "t", "ref": 1})
+    check("下载返回 READY 且未产生真实调用",
+          res["status"] == "READY" and env.stats["real_calls"] == before,
+          f"paper_id={res['paper_id']}")
+    check("下载后缓存状态可查",
+          env.execute_tool("get_paper_cache_status",
+                           {"session_id": "t", "ref": 1})["pdf_ready"] is True)
+
+    print("\n=== env 注入 Agent 后接管工具执行 ===")
+    env2 = MockArxivEnv(snapshot_path=SNAPSHOT, mode="replay")
+    agent = ReActAgent(llm_client=None, side_effect_mgr=LocalSideEffectManager(), env=env2)
+    obs = agent._execute_with_side_effects(
+        {"name": "get_recently_submitted_cs_papers",
+         "args": {"aspect": "CV", "days": 7, "max_results": 3}}
+    )
+    check("Agent 的工具调用走到了 env",
+          "成功获取 3 篇论文" in obs and env2.stats["hit"] >= 1, env2.describe())
+
+    print("\n" + "=" * 56)
+    print(f"通过 {len(PASSED)} / {len(PASSED) + len(FAILED)}")
+    if FAILED:
+        for f in FAILED:
+            print(f"  - {f}")
+        return 1
+    print("全部通过")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION

`MockArxivEnv` in `rl/env.py` is meant to be a snapshot-replay environment for fast, deterministic, offline rollouts. It cannot currently work, for five reasons:

**1. It never intercepts anything**

`BaseAgent` executes tools through the global `registry`, so `env` is not in the call path at all. The comment in `generate_snapshot_from_benchmark()`:

```python
# 工具调用会通过 registry 执行，已被 env 记录
```

does not hold — `env` never gets a chance to observe those calls.

**2. The snapshot generator references an API that does not exist**

```python
from benchmark.runner import run_single_benchmark   # does not exist
```

`benchmark/runner.py` only defines the `BenchmarkRunner` class.

**3. The snapshot is always empty**

The sole call to `_add_to_snapshot()` is commented out:

```python
# 可选：记录到 snapshot（供下次使用）
# self._add_to_snapshot(tool_name, key, args, result)
```

**4. The cache key includes `session_id`**

`_make_key()` joins all arguments, and `session_id` differs on every rollout, so the hit rate is always zero.

**5. Inconsistent return type**

`execute_tool()` is annotated as returning `str`, but on a miss it falls back to `registry.execute_tool()`, which returns `list` / `dict`.

## Changes

### Wire env into the call path

`BaseAgent` gains an optional `env` argument and `_dispatch_tool()`: when an env is injected, tool execution goes through it; otherwise the existing `invoke_tool` path is unchanged. Default behaviour is preserved, and the three subclasses forward the argument.

### Rewrite `rl/env.py`

- volatile fields such as `session_id` are excluded from the cache key
- the search tool is served by **paper-pool semantics**: pick the pool by aspect, slice by `max_results`. Under the real API `max_results=5/7/10` are all valid, so the mock should behave the same — otherwise a slight parameter change becomes a `KeyError` and the reward collapses into "all tool errors"
- aspect tolerance: `cs.AI` and `AI` resolve to the same pool (the tool schema wants the latter, but task descriptions use the former)
- `download_arxiv_pdf` gets an offline stub: it resolves `ref`, writes a placeholder file and updates the store, but issues no HTTP. This keeps `get_paper_cache_status` and multi-step composite tasks meaningful offline
- `record` / `replay` / `auto` modes; `stats` reports `hit / miss / real_calls / offline_stubs`, so a rollout can be confirmed not to touch the network

### New `rl/build_snapshot.py`

Drives the search tool directly and records one paper pool per aspect, without depending on the benchmark runner. This is the **only step in the whole RL pipeline that needs network access**, and it is run once.

### New `tests/test_mock_env.py` (6 checks, all passing)

## Verification

```bash
cd AgenticArxiv
python -m rl.build_snapshot        # one-off, fetches 7 aspects x 50 real papers
python tests/test_mock_env.py
```

```
[PASS] snapshot hit, zero real calls -- mode=replay hit=1 miss=0 real_calls=0
[PASS] unrecorded parameter combinations return correct counts -- 3 / 9
[PASS] cs.AI and AI resolve to the same pool
[PASS] download returns READY with no real call -- paper_id=2608.14539v1
[PASS] cache status queryable after download
[PASS] agent tool calls are routed through env
6 / 6
```

The snapshot file is gitignored and can be regenerated at any time by `build_snapshot.py`.

## Scope note

This PR only makes `env` itself usable. Wiring `rollout.py` to actually use it
involves a policy abstraction (how to drive a rollout without an API key),
which I would rather discuss separately rather than bundle in here.

## Verification on a clean checkout

Verified from a fresh checkout with no local artifacts, regenerating the
snapshot from scratch:

- `python -m rl.build_snapshot` — 7 aspects x 50 papers, 0 failures
- `tests/test_mock_env.py` — 6/6
- `tests/test_multigranular_reward.py` (from #4) — 6/6, unchanged
- `python -m rl.rollout search_01 ../traces/train/` — runs to completion
- `env=None` still routes through `invoke_tool`, so default behaviour is unchanged
- two independent replays of the same query return identical results
