### PR TITLE
Add argument-level verification for benchmark rewards

### DIFF
--- a/AgenticArxiv/benchmark/tasks.py
+++ b/AgenticArxiv/benchmark/tasks.py
@@ -10,6 +10,9 @@ BENCHMARK_TASKS: List[Dict[str, Any]] = [
         "id": "search_01",
         "task": "检索最近7天内人工智能(cs.AI)方向的论文，最多5篇",
         "expected_tools": ["get_recently_submitted_cs_papers"],
+        "expected_tool_args": [
+            {"aspect": "AI", "days": 7, "max_results": 5}
+        ],
         "expected_termination": "FINISH",
         "category": "search",
     },
@@ -17,6 +20,9 @@ BENCHMARK_TASKS: List[Dict[str, Any]] = [
         "id": "search_02",
         "task": "获取最近3天机器学习(cs.LG)方向的最新论文，最多10篇",
         "expected_tools": ["get_recently_submitted_cs_papers"],
+        "expected_tool_args": [
+            {"aspect": "LG", "days": 3, "max_results": 10}
+        ],
         "expected_termination": "FINISH",
         "category": "search",
     },
@@ -24,6 +30,9 @@ BENCHMARK_TASKS: List[Dict[str, Any]] = [
         "id": "search_03",
         "task": "搜索最近7天自然语言处理(cs.CL)方向的论文，最多5篇",
         "expected_tools": ["get_recently_submitted_cs_papers"],
+        "expected_tool_args": [
+            {"aspect": "CL", "days": 7, "max_results": 5}
+        ],
         "expected_termination": "FINISH",
         "category": "search",
     },
@@ -63,6 +72,10 @@ BENCHMARK_TASKS: List[Dict[str, Any]] = [
         "id": "composite_01",
         "task": "搜索最近7天计算机视觉(cs.CV)的论文(最多3篇)，然后下载第1篇",
         "expected_tools": ["get_recently_submitted_cs_papers", "download_arxiv_pdf"],
+        "expected_tool_args": [
+            {"aspect": "CV", "days": 7, "max_results": 3},
+            None,
+        ],
         "expected_termination": "FINISH",
         "category": "composite",
     },

--- a/AgenticArxiv/rl/reward.py
+++ b/AgenticArxiv/rl/reward.py
@@ -176,7 +176,7 @@ class RewardCalculator:
     @staticmethod
     def _argument_score(
         history: Sequence[Dict[str, Any]],
-        expected_args: Optional[Sequence[Mapping[str, Any]]],
+        expected_args: Optional[Sequence[Optional[Mapping[str, Any]]]],
     ) -> Optional[float]:
         if expected_args is None:
             return None
@@ -187,6 +187,8 @@ class RewardCalculator:
                 actual.append(action.get("parameters", action.get("args", {})))
         scores = []
         for index, expected in enumerate(expected_args):
+            if expected is None:
+                continue
             predicted = actual[index] if index < len(actual) else {}
             keys = set(expected)
             if not keys:

--- a/AgenticArxiv/tests/test_multigranular_reward.py
+++ b/AgenticArxiv/tests/test_multigranular_reward.py
@@ -1,7 +1,10 @@
 """Unit tests for hierarchical reward shaping."""
 
 import unittest
+from types import ModuleType
+from unittest.mock import Mock, patch
 
+from benchmark.tasks import BENCHMARK_TASKS, get_task_by_id
 from rl.reward import RewardCalculator, compute_group_relative_advantages
 
 
@@ -54,6 +57,127 @@ class MultiGranularRewardTest(unittest.TestCase):
         ]
         reward, _ = self.calculator.compute_reward_breakdown(task, _result(history))
         self.assertEqual(reward.argument, 0.5)
+
+    def test_complete_args_receive_maximum_argument_score(self):
+        task = {
+            "id": "search",
+            "expected_tools": ["get_recently_submitted_cs_papers"],
+            "expected_tool_args": [
+                {"aspect": "AI", "days": 7, "max_results": 5}
+            ],
+        }
+        history = [
+            {
+                "action": '{"name":"get_recently_submitted_cs_papers",'
+                '"args":{"aspect":"AI","days":7,"max_results":5}}',
+                "observation": "ok",
+            },
+            {"action": "FINISH", "observation": "done"},
+        ]
+        reward, _ = self.calculator.compute_reward_breakdown(task, _result(history))
+        self.assertEqual(reward.argument, 1.0)
+
+    def test_wrong_argument_values_receive_lower_score(self):
+        task = {
+            "id": "search",
+            "expected_tools": ["get_recently_submitted_cs_papers"],
+            "expected_tool_args": [
+                {"aspect": "AI", "days": 7, "max_results": 5}
+            ],
+        }
+        history = [
+            {
+                "action": '{"name":"get_recently_submitted_cs_papers",'
+                '"args":{"aspect":"CV","days":30,"max_results":20}}',
+                "observation": "ok",
+            },
+            {"action": "FINISH", "observation": "done"},
+        ]
+        reward, _ = self.calculator.compute_reward_breakdown(task, _result(history))
+        self.assertEqual(reward.argument, 0.0)
+
+    def test_missing_arguments_receive_lower_score(self):
+        task = {
+            "id": "search",
+            "expected_tools": ["get_recently_submitted_cs_papers"],
+            "expected_tool_args": [
+                {"aspect": "AI", "days": 7, "max_results": 5}
+            ],
+        }
+        history = [
+            {
+                "action": '{"name":"get_recently_submitted_cs_papers",'
+                '"args":{"aspect":"AI"}}',
+                "observation": "ok",
+            },
+            {"action": "FINISH", "observation": "done"},
+        ]
+        reward, _ = self.calculator.compute_reward_breakdown(task, _result(history))
+        self.assertAlmostEqual(reward.argument, -1.0 / 3.0, places=6)
+
+    def test_task_without_expected_args_keeps_argument_layer_inactive(self):
+        history = [
+            {"action": '{"name":"search","args":{}}', "observation": "ok"},
+            {"action": '{"name":"download","args":{}}', "observation": "ok"},
+            {"action": "FINISH", "observation": "done"},
+        ]
+        reward, _ = self.calculator.compute_reward_breakdown(
+            self.task, _result(history), training_step=30
+        )
+        self.assertEqual(reward.argument, 0.0)
+        self.assertEqual(reward.total, 1.0)
+
+    def test_composite_task_skips_dynamic_download_arguments(self):
+        task = get_task_by_id("composite_01")
+        self.assertEqual(
+            task["expected_tool_args"],
+            [{"aspect": "CV", "days": 7, "max_results": 3}, None],
+        )
+        history = [
+            {
+                "action": '{"name":"get_recently_submitted_cs_papers",'
+                '"args":{"aspect":"CV","days":7,"max_results":3}}',
+                "observation": "ok",
+            },
+            {
+                "action": '{"name":"download_arxiv_pdf",'
+                '"args":{"ref":"dynamic-search-result"}}',
+                "observation": "ok",
+            },
+            {"action": "FINISH", "observation": "done"},
+        ]
+        reward, _ = self.calculator.compute_reward_breakdown(task, _result(history))
+        self.assertEqual(reward.argument, 1.0)
+
+    def test_benchmark_search_tasks_define_static_argument_oracles(self):
+        expected = {
+            "search_01": {"aspect": "AI", "days": 7, "max_results": 5},
+            "search_02": {"aspect": "LG", "days": 3, "max_results": 10},
+            "search_03": {"aspect": "CL", "days": 7, "max_results": 5},
+        }
+        for task_id, args in expected.items():
+            with self.subTest(task_id=task_id):
+                self.assertEqual(get_task_by_id(task_id)["expected_tool_args"], [args])
+
+    def test_benchmark_aspect_oracles_match_arxiv_tool_schema(self):
+        utils_module = ModuleType("utils")
+        utils_module.__path__ = []
+        file_writer_module = ModuleType("utils.file_writer")
+        file_writer_module.save_papers_to_file = Mock()
+        modules = {
+            "arxiv": ModuleType("arxiv"),
+            "utils": utils_module,
+            "utils.file_writer": file_writer_module,
+        }
+        with patch.dict("sys.modules", modules):
+            from tools.arxiv_tool import ARXIV_TOOL_SCHEMA
+
+        valid_aspects = ARXIV_TOOL_SCHEMA["properties"]["aspect"]["enum"]
+        for task in BENCHMARK_TASKS:
+            for expected_args in task.get("expected_tool_args", []):
+                if expected_args is not None and "aspect" in expected_args:
+                    with self.subTest(task_id=task["id"]):
+                        self.assertIn(expected_args["aspect"], valid_aspects)
 
     def test_curriculum_delays_correctness_weight(self):
         early = self.calculator.schedule(0)

--- a/docs/multigranular_rl.md
+++ b/docs/multigranular_rl.md
@@ -20,6 +20,11 @@ Every active component is bounded to `[-1, 1]`:
 | `r_process` | 1 | Dense valid-step credit minus parse, execution, and unnecessary-call penalties. |
 | `r_outcome` | 3 | `1` for correct completion, `0.25` for completion with a wrong tool path, `-0.5` for forced stop, and `-1` for error. |
 
+Benchmark tasks provide `expected_tools` for tool selection verification and,
+where arguments are statically knowable, `expected_tool_args` for exact
+argument verification. A `None` entry skips a dynamic tool step whose arguments
+depend on an earlier result.
+
 The curriculum follows LLM-TIR's coarse-to-fine idea. Before step 30, tool,
 argument, and outcome weights are multiplied by `1/3`; format and process
 weights remain unchanged. From step 30 onward all weights are active. This


### PR DESCRIPTION
## Summary

Enable argument-level verification for benchmark rewards using statically verifiable tool arguments.

## Changes

- Add `expected_tool_args` to the search benchmark tasks.
- Verify static search arguments in `composite_01`.
- Allow `None` entries in `expected_tool_args` to skip dynamically resolved arguments such as download references.
- Preserve compatibility with both `args` and `parameters` action formats.
- Add tests for correct, incorrect, missing, absent, and dynamically skipped arguments.
- Add a schema-consistency test to ensure benchmark `aspect` oracles remain valid against `ARXIV_TOOL_SCHEMA`.
- Document argument-level benchmark verification behavior.

## Testing

- `python -m pytest tests/test_multigranular_reward.py -q` — 13 passed
- `python -m unittest tests.test_multigranular_reward -v` — 13 tests OK
- `python -m compileall -q .` — passed
- `git diff --check` — passed

Note: full test collection was previously blocked by the missing optional `arxiv` dependency in the local environment.