### PR TITLE
fix(scripts): build DPO preference pairs from the first tool call, no…

### DIFF
--- a/AgenticArxiv/tests/test_dpo_pairs.py
+++ b/AgenticArxiv/tests/test_dpo_pairs.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""DPO 偏好对构造的回归测试。
+
+不需要 LLM API、不需要网络、不需要 TRL —— 用合成轨迹直接验证配对逻辑。
+
+运行：
+    cd AgenticArxiv && python tests/test_dpo_pairs.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from generate_dpo_data import build_preference_pair, first_tool_action  # noqa: E402
+
+SEARCH = '{"name": "get_recently_submitted_cs_papers", "args": {"aspect": "AI"}}'
+DOWNLOAD = '{"name": "download_arxiv_pdf", "args": {"ref": 1}}'
+TASK = {"id": "search_01", "task": "检索最近7天内人工智能(cs.AI)方向的论文"}
+
+
+def traj(*actions):
+    """把动作序列包成 agent.run() 的返回结构。"""
+    return {"history": [{"thought": "", "action": a, "observation": ""} for a in actions]}
+
+
+def rollout(reward, *actions):
+    return {"reward": reward, "result": traj(*actions)}
+
+
+class TestFirstToolAction(unittest.TestCase):
+    def test_skips_terminal_markers(self):
+        self.assertEqual(first_tool_action(traj(SEARCH, "FINISH")), SEARCH)
+
+    def test_returns_first_of_several(self):
+        self.assertEqual(first_tool_action(traj(SEARCH, DOWNLOAD, "FINISH")), SEARCH)
+
+    def test_empty_when_no_tool_call(self):
+        self.assertEqual(first_tool_action(traj("FINISH")), "")
+        self.assertEqual(first_tool_action(traj("FORCE_STOP")), "")
+        self.assertEqual(first_tool_action(traj("ERROR")), "")
+        self.assertEqual(first_tool_action({"history": []}), "")
+
+
+class TestBuildPreferencePair(unittest.TestCase):
+    def test_regression_last_step_is_always_finish(self):
+        """回归：两条轨迹末步都是 FINISH，旧实现会因 chosen==rejected 全部跳过。"""
+        rollouts = [rollout(1.5, SEARCH, "FINISH"), rollout(0.5, DOWNLOAD, "FINISH")]
+
+        # 旧实现取 history[-1]，两边都是 "FINISH"
+        last_actions = {r["result"]["history"][-1]["action"] for r in rollouts}
+        self.assertEqual(last_actions, {"FINISH"})
+
+        # 新实现取首个工具调用，能构造出有效偏好对
+        pair = build_preference_pair(rollouts, TASK)
+        self.assertIsNotNone(pair)
+        self.assertEqual(pair["chosen"], SEARCH)
+        self.assertEqual(pair["rejected"], DOWNLOAD)
+        self.assertEqual(pair["prompt"], TASK["task"])
+
+    def test_picks_extremes_not_adjacent(self):
+        rollouts = [rollout(0.5, DOWNLOAD, "FINISH"),
+                    rollout(2.0, SEARCH, "FINISH"),
+                    rollout(1.0, SEARCH, DOWNLOAD, "FINISH")]
+        pair = build_preference_pair(rollouts, TASK)
+        self.assertEqual(pair["chosen"], SEARCH)
+        self.assertEqual(pair["rejected"], DOWNLOAD)
+
+    def test_none_when_actions_identical(self):
+        rollouts = [rollout(1.5, SEARCH, "FINISH"), rollout(0.5, SEARCH, "FINISH")]
+        self.assertIsNone(build_preference_pair(rollouts, TASK))
+
+    def test_none_when_rewards_tie(self):
+        rollouts = [rollout(1.0, SEARCH, "FINISH"), rollout(1.0, DOWNLOAD, "FINISH")]
+        self.assertIsNone(build_preference_pair(rollouts, TASK))
+
+    def test_none_when_a_trajectory_has_no_tool_call(self):
+        rollouts = [rollout(1.5, SEARCH, "FINISH"), rollout(0.0, "FINISH")]
+        self.assertIsNone(build_preference_pair(rollouts, TASK))
+
+    def test_none_when_fewer_than_two_rollouts(self):
+        self.assertIsNone(build_preference_pair([rollout(1.5, SEARCH, "FINISH")], TASK))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/generate_dpo_data.py
+++ b/scripts/generate_dpo_data.py
@@ -2,13 +2,22 @@
 
 DPO 数据格式：
 - 每条数据包含 (prompt, chosen, rejected)
-- chosen: reward 最高的 action
-- rejected: reward 最低的 action
+- chosen: reward 最高那条轨迹的首个工具调用
+- rejected: reward 最低那条轨迹的首个工具调用
 
 策略：
 1. 用 SFT 模型对每个 task rollout 多次（如 5 次）
-2. 按 reward 排序，reward 最高的作为 chosen，最低的作为 rejected
-3. 构造 DPO 格式
+2. 按 reward 排序，取最高与最低两条轨迹
+3. 从各自轨迹中取**首个工具调用**作为 chosen / rejected
+
+为什么取首个工具调用，而不是最后一步：
+    正常结束的轨迹，最后一步 action 恒为字符串 "FINISH"
+    （见 agents/base_agent.py 的执行循环），因此若取 history[-1]，
+    chosen 与 rejected 会同时等于 "FINISH"、被判为无效而全部跳过，
+    实际产出 0 条样本。
+
+    首个工具调用则是可比的：此时两条轨迹的历史都为空，
+    面对的是同一个状态，差异只来自策略选择的动作本身。
 
 运行方式：
     python scripts/generate_dpo_data.py
@@ -30,6 +39,45 @@ from agents.agent_engine import ReActAgent
 from agents.side_effects import LocalSideEffectManager
 from utils.llm_client import get_env_llm_client
 from rl.reward import RewardCalculator
+
+
+# 终止标记，不是真实的工具调用
+TERMINAL_ACTIONS = ("FINISH", "FORCE_STOP", "ERROR")
+
+
+def first_tool_action(result: dict) -> str:
+    """取轨迹中第一个真实的工具调用 action（JSON 字符串）。
+
+    没有任何工具调用时返回空字符串（例如模型直接 FINISH）。
+    """
+    for step in (result or {}).get("history", []) or []:
+        action = step.get("action", "")
+        if action and action not in TERMINAL_ACTIONS:
+            return action
+    return ""
+
+
+def build_preference_pair(rollouts: list, task_def: dict):
+    """从同一任务的多条 rollout 构造一条偏好样本，无法构造时返回 None。"""
+    if len(rollouts) < 2:
+        return None
+
+    ordered = sorted(rollouts, key=lambda x: x["reward"], reverse=True)
+    best, worst = ordered[0], ordered[-1]
+
+    chosen = first_tool_action(best["result"])
+    rejected = first_tool_action(worst["result"])
+
+    if not chosen or not rejected or chosen == rejected:
+        return None
+    if best["reward"] <= worst["reward"]:
+        return None      # 奖励无差异，没有偏好信息
+
+    return {
+        "prompt": task_def["task"],
+        "chosen": chosen,
+        "rejected": rejected,
+    }
 
 
 def generate_dpo_dataset(num_rollouts_per_task: int = 5):
@@ -83,28 +131,15 @@ def generate_dpo_dataset(num_rollouts_per_task: int = 5):
             print(f"   ⚠️  rollout 数量不足，跳过")
             continue
 
-        # 排序
-        rollouts.sort(key=lambda x: x["reward"], reverse=True)
-
-        # 取最优和最差
-        best = rollouts[0]
-        worst = rollouts[-1]
-
-        # 提取最后一步的 action（或第一步，取决于策略）
-        best_action = best["result"]["history"][-1].get("action", "") if best["result"]["history"] else ""
-        worst_action = worst["result"]["history"][-1].get("action", "") if worst["result"]["history"] else ""
-
-        if not best_action or not worst_action or best_action == worst_action:
-            print(f"   ⚠️  chosen/rejected 无效，跳过")
+        pair = build_preference_pair(rollouts, task_def)
+        if pair is None:
+            print(f"   ⚠️  chosen/rejected 无效（无工具调用、动作相同或奖励无差异），跳过")
             continue
 
-        dpo_data.append({
-            "prompt": task_def["task"],
-            "chosen": best_action,
-            "rejected": worst_action,
-        })
+        dpo_data.append(pair)
+        rewards = [r["reward"] for r in rollouts]
 
-        print(f"   ✅ chosen_reward={best['reward']:.2f}, rejected_reward={worst['reward']:.2f}")
+        print(f"   ✅ chosen_reward={max(rewards):.2f}, rejected_reward={min(rewards):.2f}")
 
     # 保存到 JSONL
     output_path = Path("data/dpo/dpo_train.jsonl")


### PR DESCRIPTION
## Problem

`scripts/generate_dpo_data.py` produces **zero samples** for any task that
completes normally, so the DPO stage has no data to train on.

It takes the last step of each trajectory as the action to compare:

```python
best_action  = best["result"]["history"][-1].get("action", "")
worst_action = worst["result"]["history"][-1].get("action", "")

if not best_action or not worst_action or best_action == worst_action:
    print(f"   ⚠️  chosen/rejected 无效，跳过")
    continue
```

But a trajectory that terminates normally always ends with the literal string
`"FINISH"` — see the execution loop in `agents/base_agent.py`:

```python
history.append({"thought": thought, "action": "FINISH", "observation": observation})
```

So `best_action` and `worst_action` are both `"FINISH"`, the
`best_action == worst_action` guard fires, and **every task is skipped**.

Even in the rare case where a pair does get emitted (one trajectory ending in
`FORCE_STOP` or `ERROR`), it compares *termination markers* rather than tool
choices — which is not the preference the DPO stage is meant to learn.

## Fix

Take the **first real tool call** of each trajectory instead. At that point both
trajectories have an empty history and therefore face the same state, so the two
actions are directly comparable and the difference comes only from what the
policy chose to do.

- extract `first_tool_action()` and `build_preference_pair()` as pure functions,
  so the logic can be tested without an LLM
- skip a task when either trajectory made no tool call at all, when the two
  actions are identical, or when the two rewards are equal (no preference
  information to learn from)

## Tests

New `AgenticArxiv/tests/test_dpo_pairs.py` — 9 deterministic tests over
synthetic trajectories. **No API key, no network, no TRL required**, so this can
run in CI:

```
cd AgenticArxiv && python tests/test_dpo_pairs.py
Ran 9 tests in 0.000s
OK
```

One of them is an explicit regression test: it first asserts that both
trajectories' last actions really are `"FINISH"` (reproducing the old failure),
then asserts the new logic yields a usable pair.

## Out of scope

The `prompt` field is still the bare task description, while at inference time
the model receives the full ReAct prompt (tool descriptions, format constraints,
history). That mismatch is worth fixing too, but it is a separate design change
and this PR is deliberately limited to the zero-samples bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
