### PR TITLE
fix(rl): update SFT/DPO trainers to the current TRL API

### DIFF
--- a/AgenticArxiv/requirements.txt
+++ b/AgenticArxiv/requirements.txt
@@ -1,7 +1,9 @@
 # ===== RL 训练核心依赖 =====
 torch>=2.0.0
-transformers>=4.35.0
-trl>=0.8.0
+transformers>=4.45.0
+# 训练脚本使用 TRL 现行 API（SFTConfig.max_length、Trainer(processing_class=...)），
+# 这些在 trl<0.20 上不存在。下限按实际验证过的版本给出（已在 trl 0.29.1 上验证）。
+trl>=0.20.0
 datasets>=2.14.0
 accelerate>=0.25.0
 

--- a/AgenticArxiv/rl/train_dpo.py
+++ b/AgenticArxiv/rl/train_dpo.py
@@ -20,6 +20,12 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from datasets import load_dataset
 
 
+def _precision_flags():
+    """只有 CUDA 才开 fp16；CPU / Apple MPS 上开 fp16 会训练失败。"""
+    import torch
+    return {"fp16": True} if torch.cuda.is_available() else {}
+
+
 def main():
     """DPO 训练主函数"""
 
@@ -59,7 +65,7 @@ def main():
         logging_steps=10,
         save_steps=100,
         save_total_limit=3,
-        fp16=True,
+        **_precision_flags(),     # 只有 CUDA 才开 fp16
     )
 
     # 4. 训练
@@ -69,7 +75,7 @@ def main():
         ref_model=ref_model,
         args=config,
         train_dataset=train_dataset,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,   # TRL>=0.13 用 processing_class（旧名 tokenizer 已移除）
     )
     trainer.train()
 

--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -20,6 +20,12 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from datasets import load_dataset
 
 
+def _precision_flags():
+    """只有 CUDA 才开 fp16；CPU / Apple MPS 上开 fp16 会训练失败。"""
+    import torch
+    return {"fp16": True} if torch.cuda.is_available() else {}
+
+
 def main():
     """SFT 训练主函数"""
 
@@ -49,11 +55,11 @@ def main():
         per_device_train_batch_size=4,
         gradient_accumulation_steps=4,
         learning_rate=2e-5,
-        max_seq_length=1024,
+        max_length=1024,          # TRL>=0.20 用 max_length（旧名 max_seq_length 已移除）
         logging_steps=10,
         save_steps=100,
         save_total_limit=3,
-        fp16=True,  # 混合精度训练
+        **_precision_flags(),     # 只有 CUDA 才开 fp16
     )
 
     # 4. 训练
@@ -62,7 +68,7 @@ def main():
         model=model,
         args=config,
         train_dataset=train_dataset,
-        tokenizer=tokenizer,
+        processing_class=tokenizer,   # TRL>=0.13 用 processing_class（旧名 tokenizer 已移除）
     )
     trainer.train()
 


### PR DESCRIPTION
## Problem

Both training scripts fail immediately on any recent TRL release, because they
use argument names that no longer exist:

```
SFTConfig(max_seq_length=1024)
TypeError: SFTConfig.__init__() got an unexpected keyword argument
'max_seq_length'. Did you mean 'max_length'?
```

```
SFTTrainer(..., tokenizer=tokenizer)
TypeError: SFTTrainer.__init__() got an unexpected keyword argument 'tokenizer'
```

`max_seq_length` was renamed to `max_length` in `SFTConfig`, and `tokenizer=`
was replaced by `processing_class=` on both `SFTTrainer` and `DPOTrainer`.

## Changes

- `rl/train_sft.py` — `max_seq_length` → `max_length`, `tokenizer` →
  `processing_class`
- `rl/train_dpo.py` — `tokenizer` → `processing_class`
- both — pass `fp16=True` only when CUDA is available. It was unconditional,
  which breaks training on CPU and on Apple MPS.
- `requirements.txt` — raise the floor to `trl>=0.20.0` and
  `transformers>=4.45.0`

The default base model is unchanged (`Qwen/Qwen2.5-1.5B-Instruct`).

### On the version floor

The previous floor of `trl>=0.8.0` was nominal rather than real: `GRPOTrainer`,
which `rl/train_grpo.py` imports, does not exist in 0.8 at all, so the project
could never actually have run on it. The new floor reflects a version the
scripts are verified to work on.

If you would rather keep older TRL releases working, I can add a small shim that
picks the argument names at runtime instead (filtering against
`dataclasses.fields(SFTConfig)` and the trainer signature). Happy to switch —
just say which you prefer.

## Verification

Ran both scripts end to end for one optimizer step, against
trl 0.29.1 / transformers 5.10.4 / torch 2.11.0 on Apple MPS, using a minimal
synthetic dataset and a small base model (SmolLM2-135M-Instruct substituted for
Qwen2.5-1.5B purely to keep the smoke test fast):

```
SFT: train_loss 3.855   → outputs/sft/final
DPO: train_loss 0.7227  → outputs/dpo/final   (resumed from the SFT checkpoint)
```

Before this change both scripts raise `TypeError` before constructing a trainer.

## Not included

`rl/train_grpo.py` has the same class of problem — `GRPOConfig(model_name=...,
num_sample_generations=...)` are not fields of the current `GRPOConfig` — plus
its `reward_fn` is still a placeholder returning zeros and the `GRPOTrainer`
call is commented out. That needs its own change and is not touched here.

