### PR TITLE
fix(benchmark): make tool sequence matching strict

### DIFF
--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -141,14 +141,10 @@ def _extract_tool_sequence(history: List[Dict]) -> List[str]:
 
 
 def _check_tool_sequence(actual: List[str], expected: List[str]) -> bool:
-    """检查实际工具调用是否包含所有预期工具（顺序匹配）"""
+    """检查实际工具调用是否与预期序列完全一致（严格顺序、无多余/重复调用）"""
     if not expected:
         return True
-    ei = 0
-    for tool in actual:
-        if ei < len(expected) and tool == expected[ei]:
-            ei += 1
-    return ei == len(expected)
+    return actual == expected
 
 
 def _count_parse_failures(history: List[Dict]) -> int:

--- a/AgenticArxiv/tests/test_tool_sequence_strict.py
+++ b/AgenticArxiv/tests/test_tool_sequence_strict.py
@@ -1,0 +1,47 @@
+"""_check_tool_sequence 严格匹配的单元测试
+
+修复前：子序列匹配，中间插入错误工具或重复调用也会被判 accurate；
+修复后：实际工具序列必须与预期序列完全一致。
+"""
+
+import unittest
+
+from benchmark.metrics import _check_tool_sequence
+
+
+class StrictToolSequenceTest(unittest.TestCase):
+    EXPECTED = ["get_recently_submitted_cs_papers", "download_arxiv_pdf"]
+
+    def test_exact_match_is_accepted(self):
+        self.assertTrue(_check_tool_sequence(list(self.EXPECTED), self.EXPECTED))
+
+    def test_inserted_wrong_tool_is_rejected(self):
+        actual = [
+            "get_recently_submitted_cs_papers",
+            "get_paper_cache_status",
+            "download_arxiv_pdf",
+        ]
+        self.assertFalse(_check_tool_sequence(actual, self.EXPECTED))
+
+    def test_duplicate_call_is_rejected(self):
+        actual = [
+            "get_recently_submitted_cs_papers",
+            "get_recently_submitted_cs_papers",
+            "download_arxiv_pdf",
+        ]
+        self.assertFalse(_check_tool_sequence(actual, self.EXPECTED))
+
+    def test_reversed_order_is_rejected(self):
+        actual = ["download_arxiv_pdf", "get_recently_submitted_cs_papers"]
+        self.assertFalse(_check_tool_sequence(actual, self.EXPECTED))
+
+    def test_missing_tool_is_rejected(self):
+        actual = ["get_recently_submitted_cs_papers"]
+        self.assertFalse(_check_tool_sequence(actual, self.EXPECTED))
+
+    def test_empty_expected_always_ok(self):
+        self.assertTrue(_check_tool_sequence(["anything"], []))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem
`_check_tool_sequence` 只做子序列匹配：中间插入错误工具（如误调
`get_paper_cache_status`）或重复调用同一工具时，仍会被判
`tool_call_accurate=True`，可能造成 reward hacking（奖励被刷高）。

## Changes
- 改为严格匹配：实际工具调用序列必须与 `expected_tools` 完全一致
- 新增 `tests/test_tool_sequence_strict.py`（6 个用例：精确匹配/插入错误工具/重复调用/顺序颠倒/缺失工具/空预期）

## Verification
```
python -m unittest tests.test_tool_sequence_strict tests.test_multigranular_reward -v
# Ran 19 tests in 0.017s
# OK
```
