### PR TITLE
Fix RL script paths from repo root

### DIFF
--- a/AgenticArxiv/rl/rollout.py
+++ b/AgenticArxiv/rl/rollout.py
@@ -7,7 +7,7 @@
 4. 保存 trajectory（JSONL 格式）
 
 使用方式：
-    python -m rl.rollout search_01 traces/train/
+    python -m AgenticArxiv.rl.rollout search_01 traces/train/
 """
 
 import sys
@@ -130,8 +130,8 @@ def main(
         all: 是否对所有任务执行 rollout
 
     Examples:
-        python -m rl.rollout search_01 traces/train/
-        python -m rl.rollout --all --output_dir traces/train/
+        python -m AgenticArxiv.rl.rollout search_01 traces/train/
+        python -m AgenticArxiv.rl.rollout --all --output_dir traces/train/
     """
     if all:
         rollout_all_tasks(output_dir)
@@ -139,8 +139,8 @@ def main(
         rollout_single_task(task_id, output_dir)
     else:
         print("用法:")
-        print("  python -m rl.rollout <task_id> <output_dir>")
-        print("  python -m rl.rollout --all --output_dir <output_dir>")
+        print("  python -m AgenticArxiv.rl.rollout <task_id> <output_dir>")
+        print("  python -m AgenticArxiv.rl.rollout --all --output_dir <output_dir>")
 
 
 if __name__ == "__main__":

--- a/AgenticArxiv/rl/train_dpo.py
+++ b/AgenticArxiv/rl/train_dpo.py
@@ -6,14 +6,17 @@ DPO（Direct Preference Optimization）：
 - 输出：DPO 模型（作为 GRPO 的起点）
 
 使用方式：
-    python -m rl.train_dpo
+    python -m AgenticArxiv.rl.train_dpo
 """
 
 import sys
 from pathlib import Path
 
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PACKAGE_ROOT.parent
+
 # 添加 AgenticArxiv 到 Python 路径
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(PACKAGE_ROOT))
 
 from trl import DPOConfig, DPOTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -24,14 +27,15 @@ def main():
     """DPO 训练主函数"""
 
     # 1. 配置
-    model_name = "./outputs/sft/final"  # 从 SFT 模型继续
-    train_data_path = "data/dpo/dpo_train.jsonl"
-    output_dir = "./outputs/dpo"
+    model_path = REPO_ROOT / "outputs" / "sft" / "final"  # 从 SFT 模型继续
+    model_name = str(model_path)
+    train_data_path = REPO_ROOT / "data" / "dpo" / "dpo_train.jsonl"
+    output_dir = REPO_ROOT / "outputs" / "dpo"
 
     print(f"📦 加载 SFT 模型: {model_name}")
-    if not Path(model_name).exists():
-        print(f"❌ SFT 模型不存在: {model_name}")
-        print(f"请先运行: python -m rl.train_sft")
+    if not model_path.exists():
+        print(f"❌ SFT 模型不存在: {model_path}")
+        print(f"请先运行: python -m AgenticArxiv.rl.train_sft")
         return
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
@@ -45,12 +49,12 @@ def main():
         print(f"请先运行: python scripts/generate_dpo_data.py")
         return
 
-    train_dataset = load_dataset("json", data_files=train_data_path, split="train")
+    train_dataset = load_dataset("json", data_files=str(train_data_path), split="train")
     print(f"   样本数: {len(train_dataset)}")
 
     # 3. 配置 DPO
     config = DPOConfig(
-        output_dir=output_dir,
+        output_dir=str(output_dir),
         num_train_epochs=3,
         per_device_train_batch_size=2,
         gradient_accumulation_steps=8,
@@ -74,8 +78,8 @@ def main():
     trainer.train()
 
     # 5. 保存
-    final_output_dir = f"{output_dir}/final"
-    trainer.save_model(final_output_dir)
+    final_output_dir = output_dir / "final"
+    trainer.save_model(str(final_output_dir))
     print(f"✅ DPO 训练完成，模型已保存: {final_output_dir}")
 
 

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -6,14 +6,17 @@ GRPO（Group Relative Policy Optimization）：
 - 数据：在线 rollout + reward 计算
 
 使用方式：
-    python -m rl.train_grpo
+    python -m AgenticArxiv.rl.train_grpo
 """
 
 import sys
 from pathlib import Path
 
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PACKAGE_ROOT.parent
+
 # 添加 AgenticArxiv 到 Python 路径
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(PACKAGE_ROOT))
 
 from trl import GRPOConfig, GRPOTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -24,14 +27,15 @@ def main():
     """GRPO 训练主函数"""
 
     # 1. 配置
-    model_name = "./outputs/dpo/final"  # 从 DPO 模型继续
-    output_dir = "./outputs/grpo"
+    model_path = REPO_ROOT / "outputs" / "dpo" / "final"  # 从 DPO 模型继续
+    model_name = str(model_path)
+    output_dir = REPO_ROOT / "outputs" / "grpo"
 
     print(f"📦 加载 DPO 模型: {model_name}")
-    if not Path(model_name).exists():
-        print(f"❌ DPO 模型不存在: {model_name}")
-        print(f"请先运行: python -m rl.train_dpo")
-        print(f"或者直接从 SFT 模型开始: 修改 model_name = './outputs/sft/final'")
+    if not model_path.exists():
+        print(f"❌ DPO 模型不存在: {model_path}")
+        print(f"请先运行: python -m AgenticArxiv.rl.train_dpo")
+        print(f"或者直接从 SFT 模型开始: 修改 model_path = REPO_ROOT / 'outputs' / 'sft' / 'final'")
         return
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
@@ -84,8 +88,8 @@ def main():
     # trainer.train()
 
     # 5. 保存
-    # final_output_dir = f"{output_dir}/final"
-    # trainer.save_model(final_output_dir)
+    # final_output_dir = output_dir / "final"
+    # trainer.save_model(str(final_output_dir))
     # print(f"✅ GRPO 训练完成，模型已保存: {final_output_dir}")
 
 

--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -6,14 +6,17 @@ SFT（Supervised Fine-Tuning）：
 - 输出：SFT 模型（作为 DPO/GRPO 的起点）
 
 使用方式：
-    python -m rl.train_sft
+    python -m AgenticArxiv.rl.train_sft
 """
 
 import sys
 from pathlib import Path
 
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PACKAGE_ROOT.parent
+
 # 添加 AgenticArxiv 到 Python 路径
-sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(PACKAGE_ROOT))
 
 from trl import SFTConfig, SFTTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
@@ -25,8 +28,8 @@ def main():
 
     # 1. 配置
     model_name = "Qwen/Qwen2.5-1.5B-Instruct"  # 基座模型
-    train_data_path = "data/sft/sft_train.jsonl"
-    output_dir = "./outputs/sft"
+    train_data_path = REPO_ROOT / "data" / "sft" / "sft_train.jsonl"
+    output_dir = REPO_ROOT / "outputs" / "sft"
 
     print(f"📦 加载模型: {model_name}")
     tokenizer = AutoTokenizer.from_pretrained(model_name)
@@ -39,12 +42,12 @@ def main():
         print(f"请先运行: python scripts/generate_sft_data.py")
         return
 
-    train_dataset = load_dataset("json", data_files=train_data_path, split="train")
+    train_dataset = load_dataset("json", data_files=str(train_data_path), split="train")
     print(f"   样本数: {len(train_dataset)}")
 
     # 3. 配置 SFT
     config = SFTConfig(
-        output_dir=output_dir,
+        output_dir=str(output_dir),
         num_train_epochs=3,
         per_device_train_batch_size=4,
         gradient_accumulation_steps=4,
@@ -67,8 +70,8 @@ def main():
     trainer.train()
 
     # 5. 保存
-    final_output_dir = f"{output_dir}/final"
-    trainer.save_model(final_output_dir)
+    final_output_dir = output_dir / "final"
+    trainer.save_model(str(final_output_dir))
     print(f"✅ SFT 训练完成，模型已保存: {final_output_dir}")
 
 

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ EOF
 ### 3️⃣ 测试 Rollout
 
 ```bash
-cd AgenticArxiv
-python -m rl.rollout search_01 ../traces/train/
+python -m AgenticArxiv.rl.rollout search_01 traces/train/
 ```
 
 **期望输出**：
@@ -123,7 +122,7 @@ python -m rl.rollout search_01 ../traces/train/
    ```
 2. 训练：
    ```bash
-   python -m rl.train_sft
+   python -m AgenticArxiv.rl.train_sft
    ```
 3. 产出：`./outputs/sft/final` 模型
 
@@ -151,7 +150,7 @@ python -m rl.rollout search_01 ../traces/train/
    ```
 2. 训练：
    ```bash
-   python -m rl.train_dpo
+   python -m AgenticArxiv.rl.train_dpo
    ```
 3. 产出：`./outputs/dpo/final` 模型
 
@@ -172,7 +171,7 @@ python -m rl.rollout search_01 ../traces/train/
 
 **步骤**：
 ```bash
-python -m rl.train_grpo
+python -m AgenticArxiv.rl.train_grpo
 ```
 
 **产出**：`./outputs/grpo/final` 模型
@@ -249,13 +248,11 @@ AgenticArXiv-RL/
 ### 1. Rollout（收集 trajectory）
 
 ```bash
-cd AgenticArxiv
-
 # 单个任务
-python -m rl.rollout search_01 ../traces/train/
+python -m AgenticArxiv.rl.rollout search_01 traces/train/
 
 # 批量 rollout
-python -m rl.rollout --all ../traces/train/
+python -m AgenticArxiv.rl.rollout --all --output_dir traces/train/
 ```
 
 ### 2. 训练流程（SFT → DPO → GRPO）
@@ -265,16 +262,16 @@ python -m rl.rollout --all ../traces/train/
 python scripts/generate_sft_data.py
 
 # Step 2: SFT 训练
-python -m rl.train_sft
+python -m AgenticArxiv.rl.train_sft
 
 # Step 3: 生成 DPO 数据（需要 SFT 模型）
 python scripts/generate_dpo_data.py
 
 # Step 4: DPO 训练
-python -m rl.train_dpo
+python -m AgenticArxiv.rl.train_dpo
 
 # Step 5: GRPO 训练
-python -m rl.train_grpo
+python -m AgenticArxiv.rl.train_grpo
 ```
 
 ### 3. Reward 计算测试

--- a/scripts/generate_dpo_data.py
+++ b/scripts/generate_dpo_data.py
@@ -18,8 +18,11 @@ import sys
 import json
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACKAGE_ROOT = REPO_ROOT / "AgenticArxiv"
+
 # 添加 AgenticArxiv 到 Python 路径
-sys.path.insert(0, str(Path(__file__).parent.parent / "AgenticArxiv"))
+sys.path.insert(0, str(PACKAGE_ROOT))
 
 from benchmark.tasks import get_all_tasks
 from agents.agent_engine import ReActAgent
@@ -36,10 +39,10 @@ def generate_dpo_dataset(num_rollouts_per_task: int = 5):
         num_rollouts_per_task: 每个任务 rollout 次数
     """
 
-    sft_model_path = Path("outputs/sft/final")
+    sft_model_path = REPO_ROOT / "outputs" / "sft" / "final"
     if not sft_model_path.exists():
         print(f"❌ SFT 模型不存在: {sft_model_path}")
-        print(f"请先运行: python -m rl.train_sft")
+        print(f"请先运行: python -m AgenticArxiv.rl.train_sft")
         return
 
     # TODO: 加载 SFT 模型（需要修改 llm_client 支持本地模型）
@@ -103,7 +106,7 @@ def generate_dpo_dataset(num_rollouts_per_task: int = 5):
         print(f"   ✅ chosen_reward={best['reward']:.2f}, rejected_reward={worst['reward']:.2f}")
 
     # 保存到 JSONL
-    output_path = Path("data/dpo/dpo_train.jsonl")
+    output_path = REPO_ROOT / "data" / "dpo" / "dpo_train.jsonl"
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "w", encoding="utf-8") as f:

--- a/scripts/generate_sft_data.py
+++ b/scripts/generate_sft_data.py
@@ -13,8 +13,11 @@ import sys
 import json
 from pathlib import Path
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACKAGE_ROOT = REPO_ROOT / "AgenticArxiv"
+
 # 添加 AgenticArxiv 到 Python 路径
-sys.path.insert(0, str(Path(__file__).parent.parent / "AgenticArxiv"))
+sys.path.insert(0, str(PACKAGE_ROOT))
 
 from benchmark.tasks import get_all_tasks
 from agents.agent_engine import ReActAgent
@@ -72,7 +75,7 @@ def generate_sft_dataset():
             print(f"   ❌ 执行出错: {e}")
 
     # 保存到 JSONL
-    output_path = Path("data/sft/sft_train.jsonl")
+    output_path = REPO_ROOT / "data" / "sft" / "sft_train.jsonl"
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- resolve RL data/model paths relative to the repository root instead of the current working directory
- update README and CLI usage examples to run modules from the repository root
- pass dataset paths as strings for compatibility with datasets.load_dataset

## Testing
- python -m compileall -q AgenticArxiv scripts
- git diff --check

Note: full training commands were not run locally because this environment is missing project dependencies such as trl/fire.