### PR TITLE
feat(rl): implement GRPO training with a verifiable reward

### DIFF
--- a/AgenticArxiv/rl/grpo_reward.py
+++ b/AgenticArxiv/rl/grpo_reward.py
@@ -1,0 +1,212 @@
+"""GRPO 的可验证奖励（RLVR）。
+
+TRL 的 GRPOTrainer 是「对同一 prompt 采样 N 条输出 → 逐条打分 → 组内相对优势」
+的结构，它只负责生成**一步**，不会替你跑完整的 ReAct 循环。
+
+这里把模型生成的一步补成一条**最小完整轨迹**，再交给项目已有的
+`RewardCalculator.compute_reward_breakdown()` 打分，从而复用现成的奖励定义：
+
+    模型输出  →  解析 Thought/Action
+              →  用 MockArxivEnv 执行工具拿到 observation（离线、确定性）
+              →  补一步 FINISH，构成完整轨迹
+              →  compute_reward_breakdown().total
+
+这样做的好处是**不引入第二套奖励标准**：format / tool / argument / process /
+outcome 五个分量、`expected_tool_args` 的参数校验、严格工具序列匹配，
+全都沿用 benchmark 与 rl/reward.py 里已有的实现。
+
+注意：组内相对优势由 GRPOTrainer 内部计算，这里只返回标量奖励，
+不要再调用 `compute_group_relative_advantages`（会重复归一化）。
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from rl.reward import RewardCalculator
+
+# 与 agents/agent_engine.py 的解析规则保持一致
+_THOUGHT_RE = re.compile(r"Thought:\s*(.*?)(?=\nAction:|$)", re.DOTALL)
+_ACTION_RE = re.compile(r"Action:\s*(.*?)(?=\nObservation:|$)", re.DOTALL)
+
+
+def parse_react_action(completion: str):
+    """从模型输出中解析动作。
+
+    返回 (kind, action)：
+        ("finish", None)          模型输出 FINISH
+        ("call",   {name, args})  合法工具调用
+        ("parse_error", None)     无法解析
+    """
+    if not completion:
+        return "parse_error", None
+
+    match = _ACTION_RE.search(completion)
+    if not match:
+        return "parse_error", None
+
+    action_text = match.group(1).strip()
+    if not action_text:
+        return "parse_error", None
+    if action_text.upper().startswith("FINISH"):
+        return "finish", None
+
+    json_match = re.search(r"(\{.*\})", action_text, re.DOTALL)
+    if not json_match:
+        return "parse_error", None
+    try:
+        parsed = json.loads(json_match.group(1))
+    except json.JSONDecodeError:
+        # prompt 明确要求严格 JSON，这里不做降级修复，否则格式惩罚会失效
+        return "parse_error", None
+
+    if not isinstance(parsed, dict) or not parsed.get("name"):
+        return "parse_error", None
+    return "call", {"name": parsed["name"], "args": parsed.get("args") or {}}
+
+
+def _thought_of(completion: str) -> str:
+    match = _THOUGHT_RE.search(completion or "")
+    return match.group(1).strip() if match else ""
+
+
+def synthesize_trajectory(
+    completion: str,
+    env: Any = None,
+    session_id: str = "grpo",
+) -> Dict[str, Any]:
+    """把「模型生成的一步」补成一条可打分的最小完整轨迹。
+
+    - 解析失败       → 记一步 PARSE_ERROR（parse_failed=True）
+    - 直接 FINISH    → 只有一步 FINISH（没有任何工具调用）
+    - 工具调用       → 执行取得 observation，再补一步 FINISH
+
+    env 为 None 时不执行工具，observation 留空；此时奖励仅由
+    格式 / 工具名 / 参数 决定，工具执行失败一项无法体现。
+    """
+    kind, action = parse_react_action(completion)
+    thought = _thought_of(completion)
+
+    if kind == "parse_error":
+        return {
+            "history": [{
+                "thought": thought,
+                "action": "PARSE_ERROR",
+                "observation": "无法解析 Action",
+                "parse_failed": True,
+            }],
+            "timing": {}, "token_usage": {}, "iteration_count": 1,
+        }
+
+    if kind == "finish":
+        return {
+            "history": [{"thought": thought, "action": "FINISH", "observation": "任务完成"}],
+            "timing": {}, "token_usage": {}, "iteration_count": 1,
+        }
+
+    observation = ""
+    if env is not None:
+        args = dict(action.get("args") or {})
+        args.setdefault("session_id", session_id)
+        try:
+            result = env.execute_tool(action["name"], args)
+            if isinstance(result, list):
+                observation = f"成功获取 {len(result)} 篇论文"
+            else:
+                observation = str(result)[:500]
+        except Exception as exc:                      # noqa: BLE001
+            observation = f"工具执行失败: {exc}"
+
+    return {
+        "history": [
+            {
+                "thought": thought,
+                "action": json.dumps(action, ensure_ascii=False),
+                "observation": observation,
+            },
+            {"thought": "", "action": "FINISH", "observation": "任务完成"},
+        ],
+        "timing": {}, "token_usage": {}, "iteration_count": 2,
+    }
+
+
+def _completion_text(completion: Any) -> str:
+    """会话式数据集下 completion 是消息列表，标准格式下是字符串。"""
+    if isinstance(completion, list):
+        return "\n".join(m.get("content", "") for m in completion if isinstance(m, dict))
+    return str(completion or "")
+
+
+def make_grpo_reward_fn(
+    tasks_by_id: Dict[str, Dict[str, Any]],
+    env: Any = None,
+    reward_calc: Optional[RewardCalculator] = None,
+) -> Callable[..., List[float]]:
+    """构造 TRL GRPOTrainer 用的 reward function。
+
+    TRL 会把数据集中除 prompt/completion 之外的列按列名作为关键字参数传入，
+    因此数据集需要带一个 `task_id` 列。
+    """
+    calc = reward_calc or RewardCalculator()
+
+    def grpo_reward_fn(completions=None, task_id=None, trainer_state=None,
+                       **kwargs) -> List[float]:
+        completions = completions or []
+        ids = task_id or [None] * len(completions)
+
+        # RewardCalculator 自带课程：训练早期把权重压在结构正确性上，
+        # 后期才给语义正确性满权重。TRL 会把 trainer_state 传进来，
+        # 顺手接上，让这套课程真正随训练推进（否则 training_step 恒为 0）。
+        step = int(getattr(trainer_state, "global_step", 0) or 0)
+
+        rewards: List[float] = []
+        for completion, tid in zip(completions, ids):
+            task_def = tasks_by_id.get(tid)
+            if task_def is None:
+                rewards.append(0.0)
+                continue
+            result = synthesize_trajectory(_completion_text(completion), env=env)
+            breakdown, _ = calc.compute_reward_breakdown(
+                task_def, result, training_step=step
+            )
+            rewards.append(float(breakdown.total))
+        return rewards
+
+    grpo_reward_fn.__name__ = "grpo_reward_fn"
+    return grpo_reward_fn
+
+
+def build_prompt_dataset(tasks: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """由任务集直接生成 GRPO 数据集。
+
+    GRPO 是在线算法：只需要 prompt 与可验证奖励，**不需要预先生成轨迹数据**，
+    因此这里不像 SFT/DPO 那样依赖 scripts/generate_*_data.py。
+
+    prompt 用的就是推理时真正送进模型的那段 ReAct prompt（含工具描述与格式约束），
+    保证训练与推理的输入分布一致。
+    """
+    from agents.prompt_templates import format_tool_description, get_react_prompt
+    from tools.tool_registry import registry
+
+    tools_description = format_tool_description(registry.list_tools())
+    rows = []
+    for task in tasks:
+        prompt = get_react_prompt(
+            task=task["task"], tools_description=tools_description, history=""
+        )
+        rows.append({
+            "prompt": [{"role": "user", "content": prompt}],
+            "task_id": task["id"],
+        })
+    return rows
+
+
+def load_mock_env(snapshot_path: Optional[Path] = None):
+    """有快照就用 MockArxivEnv 离线执行工具，否则返回 None（不执行）。"""
+    if snapshot_path is None or not Path(snapshot_path).exists():
+        return None
+    from rl.env import MockArxivEnv
+    return MockArxivEnv(snapshot_path=Path(snapshot_path), mode="replay")

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -2,13 +2,21 @@
 
 GRPO（Group Relative Policy Optimization）：
 - 目标：用 verifiable reward 在线训练
-- 优势：无需 value model（比 PPO 更轻量）
-- 数据：在线 rollout + reward 计算
+- 优势：无需 reward model、无需 value model（比 PPO 更轻量）
+- 数据：**不需要预先生成**。GRPO 是在线算法，只要 prompt + 可验证奖励，
+        数据集直接由 benchmark/tasks.py 派生
+
+奖励定义见 rl/grpo_reward.py：把模型生成的一步补成最小完整轨迹，
+再交给 rl/reward.py 已有的 RewardCalculator 打分，不引入第二套标准。
 
 使用方式：
     python -m AgenticArxiv.rl.train_grpo
+    python -m AgenticArxiv.rl.train_grpo --model outputs/sft/final --num_generations 8
 """
 
+import argparse
+import dataclasses
+import os
 import sys
 from pathlib import Path
 
@@ -18,80 +26,166 @@ REPO_ROOT = PACKAGE_ROOT.parent
 # 添加 AgenticArxiv 到 Python 路径
 sys.path.insert(0, str(PACKAGE_ROOT))
 
-from trl import GRPOConfig, GRPOTrainer
+# 奖励计算要执行工具，会话状态走内存，不依赖数据库
+os.environ.setdefault("STORE_BACKEND", "memory")
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+from datasets import Dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer
-from rl.reward import RewardCalculator
+from trl import GRPOConfig, GRPOTrainer
+
+import tools.arxiv_tool  # noqa: F401  触发工具注册
+import tools.cache_status_tool  # noqa: F401
+import tools.pdf_download_tool  # noqa: F401
+import tools.pdf_translate_tool  # noqa: F401
+
+from benchmark.tasks import get_all_tasks
+from rl.grpo_reward import (
+    build_prompt_dataset,
+    load_mock_env,
+    make_grpo_reward_fn,
+    parse_react_action,
+)
+
+DEFAULT_SNAPSHOT = REPO_ROOT / "data" / "mock_arxiv_snapshot.json"
 
 
-def main():
-    """GRPO 训练主函数"""
+def _precision_flags():
+    """只有 CUDA 才开 bf16/fp16；CPU / Apple MPS 上开混合精度会训练失败。"""
+    import torch
+    if torch.cuda.is_available():
+        return {"bf16": torch.cuda.is_bf16_supported(), "fp16": not torch.cuda.is_bf16_supported()}
+    return {}
 
-    # 1. 配置
-    model_path = REPO_ROOT / "outputs" / "dpo" / "final"  # 从 DPO 模型继续
-    model_name = str(model_path)
-    output_dir = REPO_ROOT / "outputs" / "grpo"
 
-    print(f"📦 加载 DPO 模型: {model_name}")
-    if not model_path.exists():
-        print(f"❌ DPO 模型不存在: {model_path}")
-        print(f"请先运行: python -m AgenticArxiv.rl.train_dpo")
-        print(f"或者直接从 SFT 模型开始: 修改 model_path = REPO_ROOT / 'outputs' / 'sft' / 'final'")
-        return
+def _gold_completion_tokens(tokenizer, tasks) -> int:
+    """标准动作渲染成 ReAct 文本后的最大 token 数。
 
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForCausalLM.from_pretrained(model_name)
-    ref_model = AutoModelForCausalLM.from_pretrained(model_name)
+    用于校验 max_completion_length：设小了模型永远吐不出完整动作，
+    奖励恒为下限、组内方差为 0、梯度为 0，而日志上只表现为
+    completions/clipped_ratio=1，很容易被误读成「模型太差」。
+    """
+    import json as _json
+    lengths = [0]
+    for task in tasks:
+        for name in task.get("expected_tools", []) or []:
+            text = f'Thought: xxx\nAction: {_json.dumps({"name": name, "args": {}}, ensure_ascii=False)}'
+            lengths.append(len(tokenizer(text)["input_ids"]))
+    return max(lengths)
 
-    # 2. 定义 reward_model
-    reward_calc = RewardCalculator()
 
-    def reward_fn(responses, prompts):
-        """
-        GRPO reward 函数
+def main(
+    model: str = "outputs/dpo/final",
+    output_dir: str = "outputs/grpo",
+    epochs: int = 1,
+    batch_size: int = 4,
+    grad_accum: int = 1,
+    lr: float = 1e-5,
+    beta: float = 0.04,
+    num_generations: int = 4,
+    max_completion_length: int = 256,
+    temperature: float = 1.0,
+    snapshot: str = None,
+):
+    model_path = REPO_ROOT / model
+    if model_path.exists():
+        resolved = str(model_path)
+    elif "/" in model and not model.startswith(("outputs/", "./", "/")):
+        resolved = model                    # 形如 org/name 的 HF 仓库
+    else:
+        raise SystemExit(
+            f"❌ 未找到本地模型 {model_path}\n"
+            f"请先运行 train_sft / train_dpo，或用 --model 指定其它检查点"
+        )
 
-        Args:
-            responses: 模型生成的响应列表
-            prompts: 对应的 prompt 列表
+    print(f"📦 加载模型: {resolved}")
+    tokenizer = AutoTokenizer.from_pretrained(resolved)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    policy = AutoModelForCausalLM.from_pretrained(resolved)
 
-        Returns:
-            List[float]: 每个响应的奖励
-        """
-        # TODO: 实现 reward 计算逻辑
-        # 1. 解析 responses 为 action
-        # 2. 执行工具得到 observation
-        # 3. 调用 reward_calc.compute_reward()
-        # 4. 返回 reward 列表
+    # --- 数据集：直接由任务集派生，无需预生成 ---
+    tasks = get_all_tasks()
+    rows = build_prompt_dataset(tasks)
+    train_dataset = Dataset.from_list(rows)
+    print(f"📚 任务数: {len(tasks)}（GRPO 为在线算法，无需预生成轨迹数据）")
 
-        # 占位实现
-        return [0.0 for _ in responses]
+    # --- 生成长度守卫 ---
+    need = _gold_completion_tokens(tokenizer, tasks)
+    if max_completion_length < need:
+        raise SystemExit(
+            f"❌ max_completion_length={max_completion_length} 小于标准动作所需的 {need} tokens，"
+            f"模型不可能生成完整动作，奖励会恒为下限、梯度为 0。\n"
+            f"请改用 --max_completion_length {need + 64}"
+        )
 
-    # 3. 配置 GRPO
-    config = GRPOConfig(
-        model_name=model_name,
-        learning_rate=1e-5,
-        num_train_epochs=3,
-        per_device_train_batch_size=4,
-        num_sample_generations=4,  # 每个 prompt 采样 4 条 trajectory
+    # --- 奖励函数 ---
+    snapshot_path = Path(snapshot) if snapshot else DEFAULT_SNAPSHOT
+    env = load_mock_env(snapshot_path)
+    if env is None:
+        print(f"⚠️  未找到快照 {snapshot_path}，奖励将不执行工具"
+              f"（仅由格式/工具名/参数决定）。生成快照: python -m AgenticArxiv.rl.build_snapshot")
+    else:
+        print(f"🗂  使用离线快照执行工具: {snapshot_path}")
+    reward_fn = make_grpo_reward_fn({t["id"]: t for t in tasks}, env=env)
+
+    # GRPO 要求生成批量能被 num_generations 整除
+    if batch_size % num_generations != 0:
+        batch_size = num_generations
+        print(f"  调整 per_device_train_batch_size = {batch_size}（需被 num_generations 整除）")
+
+    cfg_kwargs = {
+        "output_dir": str(REPO_ROOT / output_dir),
+        "num_train_epochs": epochs,
+        "per_device_train_batch_size": batch_size,
+        "gradient_accumulation_steps": grad_accum,
+        "learning_rate": lr,
+        "beta": beta,
+        "num_generations": num_generations,
+        "max_completion_length": max_completion_length,
+        "temperature": temperature,
+        "logging_steps": 1,
+        "save_strategy": "no",
+        "report_to": [],
+        **_precision_flags(),
+    }
+    # GRPOConfig 的字段在 TRL 各版本间有增删，按实际安装版本过滤，
+    # 避免因为一个参数名不存在就整个训练起不来
+    valid = {f.name for f in dataclasses.fields(GRPOConfig)}
+    dropped = sorted(k for k in cfg_kwargs if k not in valid)
+    if dropped:
+        print(f"  提示：当前 TRL 不支持这些 GRPOConfig 参数，已忽略 -> {dropped}")
+    config = GRPOConfig(**{k: v for k, v in cfg_kwargs.items() if k in valid})
+
+    print(f"🚀 开始 GRPO 训练（每个 prompt 采样 {num_generations} 条，规则奖励）")
+    trainer = GRPOTrainer(
+        model=policy,
+        reward_funcs=reward_fn,
+        args=config,
+        train_dataset=train_dataset,
+        processing_class=tokenizer,
     )
+    trainer.train()
 
-    # 4. 训练
-    print(f"🚀 开始 GRPO 训练...")
-    print(f"⚠️  GRPO 训练脚本骨架已就绪，需完成 reward_fn TODO")
-
-    # trainer = GRPOTrainer(
-    #     model=model,
-    #     ref_model=ref_model,
-    #     args=config,
-    #     reward_model=reward_fn,
-    #     tokenizer=tokenizer,
-    # )
-    # trainer.train()
-
-    # 5. 保存
-    # final_output_dir = output_dir / "final"
-    # trainer.save_model(str(final_output_dir))
-    # print(f"✅ GRPO 训练完成，模型已保存: {final_output_dir}")
+    final_dir = REPO_ROOT / output_dir / "final"
+    trainer.save_model(str(final_dir))
+    tokenizer.save_pretrained(str(final_dir))
+    print(f"✅ GRPO 训练完成，模型已保存: {final_dir}")
 
 
 if __name__ == "__main__":
-    main()
+    p = argparse.ArgumentParser(description="GRPO 训练")
+    p.add_argument("--model", default="outputs/dpo/final")
+    p.add_argument("--output_dir", default="outputs/grpo")
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--batch_size", type=int, default=4)
+    p.add_argument("--grad_accum", type=int, default=1)
+    p.add_argument("--lr", type=float, default=1e-5)
+    p.add_argument("--beta", type=float, default=0.04)
+    p.add_argument("--num_generations", type=int, default=4)
+    p.add_argument("--max_completion_length", type=int, default=256)
+    p.add_argument("--temperature", type=float, default=1.0)
+    p.add_argument("--snapshot", default=None)
+    a = p.parse_args()
+    main(a.model, a.output_dir, a.epochs, a.batch_size, a.grad_accum, a.lr, a.beta,
+         a.num_generations, a.max_completion_length, a.temperature, a.snapshot)

--- a/AgenticArxiv/tests/test_grpo_reward.py
+++ b/AgenticArxiv/tests/test_grpo_reward.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""GRPO 奖励函数测试。
+
+不需要 GPU、不需要 LLM、不需要网络（工具执行走离线快照，缺快照时自动跳过相关用例）。
+
+运行：
+    cd AgenticArxiv && python tests/test_grpo_reward.py
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PACKAGE_ROOT))
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+import tools.arxiv_tool  # noqa: F401,E402
+import tools.cache_status_tool  # noqa: F401,E402
+import tools.pdf_download_tool  # noqa: F401,E402
+import tools.pdf_translate_tool  # noqa: F401,E402
+
+from benchmark.tasks import get_all_tasks  # noqa: E402
+from rl.grpo_reward import (  # noqa: E402
+    build_prompt_dataset,
+    make_grpo_reward_fn,
+    parse_react_action,
+    synthesize_trajectory,
+)
+
+TASKS = {t["id"]: t for t in get_all_tasks()}
+TASK_ID = "search_01"
+
+CORRECT = ('Thought: 需要检索\n'
+           'Action: {"name":"get_recently_submitted_cs_papers",'
+           '"args":{"aspect":"AI","days":7,"max_results":5}}')
+WRONG_ARGS = ('Thought: 需要检索\n'
+              'Action: {"name":"get_recently_submitted_cs_papers",'
+              '"args":{"aspect":"CR","days":30,"max_results":99}}')
+WRONG_TOOL = 'Thought: 下载\nAction: {"name":"download_arxiv_pdf","args":{"ref":1}}'
+BARE_FINISH = 'Thought: 完成了\nAction: FINISH'
+BAD_JSON = "Thought: t\nAction: {'name': 'get_recently_submitted_cs_papers',}"
+NO_ACTION = "Thought: 我先想想该怎么做"
+
+
+class FakeState:
+    def __init__(self, step): self.global_step = step
+
+
+class TestParseReactAction(unittest.TestCase):
+    def test_tool_call(self):
+        kind, action = parse_react_action(CORRECT)
+        self.assertEqual(kind, "call")
+        self.assertEqual(action["name"], "get_recently_submitted_cs_papers")
+        self.assertEqual(action["args"]["aspect"], "AI")
+
+    def test_finish(self):
+        self.assertEqual(parse_react_action(BARE_FINISH)[0], "finish")
+
+    def test_bad_json_is_parse_error(self):
+        """prompt 要求严格 JSON，坏 JSON 不应被降级修复，否则格式惩罚失效。"""
+        self.assertEqual(parse_react_action(BAD_JSON)[0], "parse_error")
+
+    def test_missing_action_section(self):
+        self.assertEqual(parse_react_action(NO_ACTION)[0], "parse_error")
+
+    def test_empty(self):
+        self.assertEqual(parse_react_action("")[0], "parse_error")
+
+
+class TestSynthesizeTrajectory(unittest.TestCase):
+    def test_tool_call_becomes_two_steps(self):
+        traj = synthesize_trajectory(CORRECT)
+        actions = [s["action"] for s in traj["history"]]
+        self.assertEqual(len(actions), 2)
+        self.assertIn("get_recently_submitted_cs_papers", actions[0])
+        self.assertEqual(actions[1], "FINISH")
+
+    def test_finish_is_single_step(self):
+        traj = synthesize_trajectory(BARE_FINISH)
+        self.assertEqual([s["action"] for s in traj["history"]], ["FINISH"])
+
+    def test_parse_error_marked(self):
+        traj = synthesize_trajectory(BAD_JSON)
+        self.assertEqual(traj["history"][0]["action"], "PARSE_ERROR")
+        self.assertTrue(traj["history"][0]["parse_failed"])
+
+
+class TestRewardOrdering(unittest.TestCase):
+    def setUp(self):
+        self.fn = make_grpo_reward_fn(TASKS, env=None)
+
+    def r(self, completion, step=0):
+        return self.fn(completions=[completion], task_id=[TASK_ID],
+                       trainer_state=FakeState(step))[0]
+
+    def test_not_a_placeholder(self):
+        """回归：原实现是 `return [0.0 for _ in responses]`，奖励恒为 0。"""
+        rewards = [self.r(c) for c in (CORRECT, WRONG_TOOL, BAD_JSON)]
+        self.assertNotEqual(len(set(rewards)), 1, "奖励不应恒为常数")
+        self.assertTrue(any(x != 0.0 for x in rewards))
+
+    def test_correct_beats_wrong_arguments(self):
+        self.assertGreater(self.r(CORRECT), self.r(WRONG_ARGS))
+
+    def test_correct_beats_wrong_tool(self):
+        self.assertGreater(self.r(CORRECT), self.r(WRONG_TOOL))
+
+    def test_valid_format_beats_unparseable(self):
+        self.assertGreater(self.r(WRONG_TOOL), self.r(BAD_JSON))
+        self.assertGreater(self.r(BARE_FINISH), self.r(NO_ACTION))
+
+    def test_batch_matches_elementwise(self):
+        batch = self.fn(completions=[CORRECT, WRONG_TOOL, BAD_JSON],
+                        task_id=[TASK_ID] * 3, trainer_state=FakeState(0))
+        self.assertEqual(len(batch), 3)
+        self.assertEqual(batch, [self.r(CORRECT), self.r(WRONG_TOOL), self.r(BAD_JSON)])
+
+    def test_unknown_task_id_is_neutral(self):
+        self.assertEqual(
+            self.fn(completions=[CORRECT], task_id=["nope"], trainer_state=FakeState(0)),
+            [0.0],
+        )
+
+
+class TestCurriculum(unittest.TestCase):
+    def test_correctness_gap_widens_after_curriculum(self):
+        """RewardCalculator 的课程：早期压低语义正确性权重，后期给满。
+
+        接上 trainer_state 后 training_step 才会推进；否则恒为 0、课程从不生效。
+        """
+        fn = make_grpo_reward_fn(TASKS, env=None)
+
+        def gap(step):
+            good = fn(completions=[CORRECT], task_id=[TASK_ID],
+                      trainer_state=FakeState(step))[0]
+            bad = fn(completions=[WRONG_ARGS], task_id=[TASK_ID],
+                     trainer_state=FakeState(step))[0]
+            return good - bad
+
+        self.assertGreater(gap(60), gap(0))
+
+
+class TestPromptDataset(unittest.TestCase):
+    def test_prompt_is_full_react_prompt(self):
+        rows = build_prompt_dataset(get_all_tasks())
+        self.assertEqual(len(rows), len(get_all_tasks()))
+        content = rows[0]["prompt"][0]["content"]
+        # 训练输入必须与推理时一致：含工具描述与格式约束，而不是裸任务描述
+        self.assertIn("Thought:", content)
+        self.assertIn("Action:", content)
+        self.assertIn("get_recently_submitted_cs_papers", content)
+        self.assertIn("task_id", rows[0])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Completes the last unimplemented stage of the SFT → DPO → GRPO path. Based on
current `main` (864785c).

## Problem

`rl/train_grpo.py` is a skeleton. The reward function returns zeros:

```python
def reward_fn(responses, prompts):
    # TODO: 实现 reward 计算逻辑
    return [0.0 for _ in responses]
```

the trainer construction and `trainer.train()` are commented out, and the config
passes `model_name` / `num_sample_generations`, neither of which is a field of
`GRPOConfig` in any current TRL release. Running the script only prints:

```
⚠️  GRPO 训练脚本骨架已就绪，需完成 reward_fn TODO
```

## Reward: reuse the existing definition rather than add a second one

`GRPOTrainer` generates a **single step**, while `RewardCalculator` scores a
**whole trajectory**. Instead of introducing a competing action-level reward,
the generated step is completed into a minimal trajectory and handed to the
existing calculator:

```
completion → parse Thought/Action
           → execute the tool through MockArxivEnv (offline, deterministic)
           → append a FINISH step
           → compute_reward_breakdown().total
```

The upside is that everything already in the repo applies automatically:

- the format / tool / argument / process / outcome components from #4
- the `expected_tool_args` verification from #9
- the strict tool-sequence matching from #13

so there stays exactly one definition of "good behaviour" in the project.

Measured discrimination on `search_01`:

| behaviour | reward |
|---|---|
| correct tool and arguments | +1.0000 |
| correct tool, some arguments wrong | +0.9048 |
| correct tool, all arguments wrong | +0.8571 |
| bare `FINISH`, no tool call | +0.1250 |
| wrong tool | +0.0714 |
| malformed JSON / missing `Action:` | −0.8393 |

## Activating the existing curriculum

`RewardCalculator` implements a 30-step curriculum — structure first, semantic
correctness at full weight later — but `training_step` defaulted to `0`
everywhere, so it never advanced. TRL passes `trainer_state` into reward
functions, so it is now threaded through:

```
step  0   correct +1.0000   wrong-args +0.8571   gap 0.1429
step 30   correct +1.0000   wrong-args +0.8000   gap 0.2000
```

## No pre-generated data

GRPO is on-policy: it needs prompts and a verifiable reward, nothing else. The
dataset is derived directly from `benchmark/tasks.py`, so unlike SFT/DPO there
is no `scripts/generate_*_data.py` step. Prompts are built with the same
`get_react_prompt()` used at inference time, so training and inference input
distributions match.

## Other changes

- `GRPOConfig` kwargs are filtered against `dataclasses.fields()` at runtime,
  because the field set differs between TRL releases (verified on both 0.29.1
  and 1.10.0)
- a guard refuses to start when `max_completion_length` is below the tokens a
  gold action needs. Otherwise the model can never emit a complete action, every
  reward pins to the floor, within-group variance is zero and there is no
  gradient — a failure that surfaces only as `completions/clipped_ratio=1` and
  is easily misread as "the model is bad"
- `bf16`/`fp16` only when CUDA is available
- new `tests/test_grpo_reward.py` — 16 tests, no GPU / LLM / network required

## Verification

Trained on one NVIDIA A40 with the project's default base model
(`Qwen/Qwen2.5-1.5B-Instruct`), 7 tasks × 2 epochs = 14 steps,
`num_generations=8`, trl 1.10.0 / transformers 5.8.1 / torch 2.11.0+cu129:

```
step  1  reward=+0.7165  std=0.6295  grad_norm= 5.375
step  4  reward=+0.7031  std=0.3235  grad_norm=12.620
step  8  reward=+0.9531  std=0.0289  grad_norm= 6.938
step 13  reward=+0.6868  std=0.6224  grad_norm= 5.719
step 14  reward=+0.6488  std=0.0000  grad_norm= 0.239
---- mean reward +0.5885, non-zero within-group variance in 13/14 steps
```

Step 14 is a useful illustration of the algorithm: all 8 samples happened to
receive the same reward, the group-relative advantage collapsed to zero, and
`grad_norm` dropped from ~6 to 0.239 even though the reward itself was not low.
Gradient in GRPO comes from **within-group spread**, not from reward magnitude —
which is why `frac_reward_zero_std` is the metric worth watching.

For contrast, the same code run against a 135M model produces
`reward = −0.8393, reward_std = 0, frac_reward_zero_std = 1` at every step: the
model never emits parseable ReAct output, so every sample pins to the floor and
there is no gradient at all.

## Scope and caveats

- **This validates the mechanism, not model quality.** 14 steps over 7 tasks is
  far too little to improve a policy.
- **The task set is the real bottleneck.** With only 7 tasks — and the recorded
  benchmark showing 100% completion across all three agent modes — reward
  variance is easy to lose. Expanding and stratifying the task set matters more
  for GRPO than any trainer detail, but that changes the experimental setup, so
  I would rather discuss it separately than bundle it here.
- **`compute_group_relative_advantages` is deliberately not used here.**
  `GRPOTrainer` computes group-relative advantages internally; calling it inside
  the reward function would normalise twice. It remains useful for lightweight
  custom trainers and for tests.
- One observation, not changed in this PR: a bare `FINISH` (+0.1250) currently
  scores slightly higher than calling the wrong tool (+0.0714), because
  `_outcome_score` gives 0.25 for a clean termination regardless of whether any
  tool was called. Worth a look, but it is an existing reward-design decision
  and not mine to change unilaterally.
