### PR TITLE
feat: add language switcher to README files

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <a href="README.md">🇨🇳 中文</a> | <a href="README.en.md">🇬🇧 English</a> | <a href="README.es-ES.md">🇪🇸 Español</a>
+</p>
+
 # AgenticArXiv-RL — Agentic RL Training Environment
 
 > **An Agentic RL training environment built on ReAct Agent + arXiv tools**  

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,5 +1,9 @@
 
 
+<p align="center">
+  <a href="README.md">🇨🇳 中文</a> | <a href="README.en.md">🇬🇧 English</a> | <a href="README.es-ES.md">🇪🇸 Español</a>
+</p>
+
 # AgenticArXiv-RL — Entorno de Entrenamiento para RL Agentic
 
 > **Entorno de entrenamiento de RL Agentic basado en Agente ReAct + herramientas de arXiv**  

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <a href="README.md">🇨🇳 中文</a> | <a href="README.en.md">🇬🇧 English</a> | <a href="README.es-ES.md">🇪🇸 Español</a>
+</p>
+
 # AgenticArXiv-RL — Agentic RL 训练环境
 
 > **基于 ReAct Agent + arXiv 工具的 Agentic RL 训练环境**  


### PR DESCRIPTION
## Summary

Add a language switcher bar to the top of all three README files so visitors can easily switch between Chinese, English, and Spanish versions.

## Changes
- `README.md`: Added 中文 | English | Español links
- `README.en.md`: Added 中文 | English | Español links
- `README.es-ES.md`: Added 中文 | English | Español links

## Motivation
The project already had three language versions of the README but there was no way to navigate between them from the GitHub page. This adds a simple language switcher bar to each file so readers can switch languages with one click.

## Testing
Verified the links render correctly in each file.