### PR TITLE
Fix/json wrapped terminal action

### DIFF
--- a/AgenticArxiv/agents/agent_engine.py
+++ b/AgenticArxiv/agents/agent_engine.py
@@ -17,8 +17,9 @@ from utils.logger import log
 class ReActAgent(BaseAgent):
     """方案 A: ReAct + 正则解析 Agent"""
 
-    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5):
-        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env, max_iterations=max_iterations)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5, llm_extra=None):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env,
+                         max_iterations=max_iterations, llm_extra=llm_extra)
         try:
             import tools.arxiv_tool  # noqa: F401
             import tools.pdf_download_tool  # noqa: F401

--- a/AgenticArxiv/agents/agent_engine.py
+++ b/AgenticArxiv/agents/agent_engine.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils.llm_client import LLMClient
 from tools.tool_registry import registry
-from agents.base_agent import BaseAgent
+from agents.base_agent import BaseAgent, is_terminal_action
 from agents.prompt_templates import get_react_prompt, format_tool_description
 from utils.logger import log
 
@@ -71,7 +71,7 @@ class ReActAgent(BaseAgent):
 
         log.info(f"提取到的Action文本: {action_text}")
 
-        if action_text.upper() == "FINISH":
+        if is_terminal_action(action_text):
             log.info("Agent决定结束任务")
             return thought, None
 
@@ -81,6 +81,10 @@ class ReActAgent(BaseAgent):
             if json_match:
                 action_json = json.loads(json_match.group(1))
                 if isinstance(action_json, dict):
+                    # 终止动作也可能被包成 JSON，先拦下来，别当工具调用
+                    if is_terminal_action(action_json.get("name")):
+                        log.info("Agent决定结束任务（JSON 形式的终止动作）")
+                        return thought, None
                     if "name" in action_json and "args" in action_json:
                         action_dict = {
                             "name": action_json["name"],

--- a/AgenticArxiv/agents/base_agent.py
+++ b/AgenticArxiv/agents/base_agent.py
@@ -18,12 +18,25 @@ class BaseAgent(ABC):
 
     agent_type: str = "regex"  # 子类覆写
 
+    # ReAct 循环里，Observation 必须由工具真实执行产生。
+    # 不设 stop 时模型会自己往下编造 Observation 与后续步骤，例如：
+    #     Action: {...}
+    #     Observation: 成功获取5篇论文列表，已保存至 output/...   ← 编的
+    #     Thought: 任务已完成
+    #     Action: FINISH
+    # 解析用的正则恰好在 Observation 前截断，所以第一个动作仍能取出，
+    # 但这些续写既浪费 token（实测多耗约一倍），也让"多跳任务"退化成
+    # 模型自说自话，而非真的与环境交互。三种 Agent 的 prompt 都用
+    # Observation: 作分隔，故在此统一设置。
+    stop_sequences: Tuple[str, ...] = ("Observation:",)
+
     def __init__(
         self,
         llm_client: LLMClient,
         side_effect_mgr: Optional[SideEffectManager] = None,
         env: Optional[Any] = None,
         max_iterations: int = 5,
+        llm_extra: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -33,11 +46,17 @@ class BaseAgent(ABC):
             env: 可选的工具执行环境（需实现 execute_tool(name, args)）。
                 传入 MockArxivEnv 即可让 rollout 走快照回放而非真实 API。
             max_iterations: ReAct 最大迭代轮数
+            llm_extra: 透传给 LLM 接口的额外参数，会合并进每次请求。
+                例如关闭 Qwen3 系列的思维链：
+                    {"chat_template_kwargs": {"enable_thinking": False}}
+                思维链会让生成 token 数翻倍，而 token 用量是 benchmark 的
+                核心对比指标之一，混入后三种范式之间的差异会被淹没。
         """
         self.llm_client = llm_client
         self.side_effects = side_effect_mgr or LocalSideEffectManager()
         self.env = env
         self.max_iterations = max_iterations
+        self.llm_extra = dict(llm_extra or {})
         self.session_id = "default"
 
     # ---------- 子类必须实现 ----------
@@ -111,6 +130,7 @@ class BaseAgent(ABC):
 
             history_text = self.format_history(history)
             messages, extra = self.build_messages(enriched_task, tools_description, history_text)
+            extra = self._merge_llm_extra(extra)
 
             llm_ms = 0
             tool_ms = 0
@@ -218,6 +238,17 @@ class BaseAgent(ABC):
         log.info(f"任务执行完成，共 {len(history)} 步, 总耗时 {total_time_ms}ms (LLM {total_llm_ms}ms + Tool {total_tool_ms}ms)")
         log.info("-" * 80)
         return result
+
+    # ---------- LLM 请求参数 ----------
+
+    def _merge_llm_extra(self, extra: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """合并 stop 序列与 llm_extra；build_messages 返回的 extra 优先级最高。"""
+        merged: Dict[str, Any] = {}
+        if self.stop_sequences:
+            merged["stop"] = list(self.stop_sequences)
+        merged.update(self.llm_extra)
+        merged.update(extra or {})
+        return merged
 
     # ---------- 会话上下文 ----------
 

--- a/AgenticArxiv/agents/base_agent.py
+++ b/AgenticArxiv/agents/base_agent.py
@@ -13,6 +13,19 @@ from tools.tool_registry import registry
 from agents.side_effects import SideEffectManager, LocalSideEffectManager
 
 
+# 循环终止标记。模型有时不写裸 `Action: FINISH`，而是套上和其他动作一样的
+# JSON 外壳 `{"name": "FINISH", "args": {}}` —— prompt 里其余动作都是 JSON，
+# 这么写很自然。若不识别，它会被当成一次工具调用：白跑一轮迭代，
+# 还会在 benchmark 的 tool_call_sequence 里多出一个 "FINISH"，
+# 把本来完全正确的轨迹判成 accurate=False。
+TERMINAL_ACTIONS = ("FINISH", "FORCE_STOP", "ERROR")
+
+
+def is_terminal_action(name: Any) -> bool:
+    """判断解析出的动作名是否代表「结束」而非一次工具调用。"""
+    return isinstance(name, str) and name.strip().upper() in TERMINAL_ACTIONS
+
+
 class BaseAgent(ABC):
     """所有 Agent 方案的基类，封装通用的循环控制、日志、SSE、副作用逻辑"""
 

--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass, field, asdict
 from typing import List, Dict, Any, Optional
 
 
+# 非工具调用的动作标记
+NON_TOOL_ACTIONS = ("FINISH", "FORCE_STOP", "ERROR")
+
+
 @dataclass
 class TaskMetrics:
     """单次任务执行的完整指标"""
@@ -123,20 +127,43 @@ def _get_termination_type(history: List[Dict]) -> str:
     return "INCOMPLETE"
 
 
+def _parse_tool_action(action: Any) -> Optional[Dict[str, Any]]:
+    """把 history 里的 action 解析成工具调用 dict；不是工具调用则返回 None。
+
+    终止动作既可能是裸字符串 `FINISH`，也可能被模型包成和其他动作一样的
+    JSON 外壳 `{"name": "FINISH", "args": {}}`。后者若不排除，会在
+    tool_call_sequence 里多出一个 "FINISH"，把完全正确的轨迹判成
+    accurate=False。Agent 侧已在解析阶段拦截（见
+    agents/base_agent.py::is_terminal_action），这里再兜一层，
+    以便正确处理历史结果文件和第三方 Agent 的轨迹。
+    """
+    if isinstance(action, str) and action.strip().upper() in NON_TOOL_ACTIONS:
+        return None
+    if isinstance(action, dict):
+        parsed = action
+    else:
+        try:
+            parsed = json.loads(action)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if not isinstance(parsed, dict):
+        return None
+    name = parsed.get("name")
+    if isinstance(name, str) and name.strip().upper() in NON_TOOL_ACTIONS:
+        return None
+    return parsed
+
+
 def _extract_tool_sequence(history: List[Dict]) -> List[str]:
     """从 history 中提取实际调用的工具名序列"""
     tools = []
     for step in history:
-        action = step.get("action", "")
-        if action in ("FINISH", "FORCE_STOP", "ERROR"):
+        parsed = _parse_tool_action(step.get("action", ""))
+        if parsed is None:
             continue
-        try:
-            action_dict = json.loads(action)
-            name = action_dict.get("name", "")
-            if name:
-                tools.append(name)
-        except (json.JSONDecodeError, TypeError):
-            pass
+        name = parsed.get("name", "")
+        if name:
+            tools.append(name)
     return tools
 
 
@@ -167,7 +194,7 @@ def _count_tool_failures(history: List[Dict]) -> int:
     error_markers = ["错误:", "工具执行失败:", "命令失败", "命令执行超时", "命令执行异常"]
     for step in history:
         action = step.get("action", "")
-        if action in ("FINISH", "FORCE_STOP", "ERROR"):
+        if action in NON_TOOL_ACTIONS:
             continue
         obs = step.get("observation", "")
         if any(marker in obs for marker in error_markers):

--- a/AgenticArxiv/benchmark/run_benchmark.py
+++ b/AgenticArxiv/benchmark/run_benchmark.py
@@ -61,7 +61,17 @@ def main():
         "--prefix", type=str, default=None,
         help="Session ID 前缀，用于区分不同测试轮次 (默认: bench_r<timestamp>)",
     )
+    parser.add_argument(
+        "--no-thinking", action="store_true",
+        help="关闭 Qwen3 等推理模型的思维链。思维链会让生成 token 数翻倍，"
+             "而 token 用量是本 benchmark 的核心对比指标之一，"
+             "混入后三种范式之间的差异会被淹没。",
+    )
     args = parser.parse_args()
+
+    llm_extra = {}
+    if args.no_thinking:
+        llm_extra["chat_template_kwargs"] = {"enable_thinking": False}
 
     # 筛选任务
     if args.task_ids:
@@ -84,6 +94,7 @@ def main():
         repeat=args.repeat,
         model=model,
         session_prefix=args.prefix,
+        llm_extra=llm_extra,
     )
 
     print("=" * 60)

--- a/AgenticArxiv/benchmark/runner.py
+++ b/AgenticArxiv/benchmark/runner.py
@@ -42,10 +42,12 @@ class BenchmarkRunner:
         repeat: int = 3,
         model: Optional[str] = None,
         session_prefix: Optional[str] = None,
+        llm_extra: Optional[Dict[str, Any]] = None,
     ):
         self.agent_types = agent_types or self.AGENT_TYPES
         self.repeat = repeat
         self.model = model
+        self.llm_extra = dict(llm_extra or {})
         if session_prefix is None:
             from datetime import datetime
             session_prefix = f"bench_r{datetime.now().strftime('%Y%m%d_%H%M%S')}"
@@ -127,13 +129,13 @@ class BenchmarkRunner:
         side_fx = self._side_effects()
         if agent_type == "mcp":
             from mcp_protocol.mcp_agent import MCPAgent
-            return MCPAgent(self.llm_client, side_effect_mgr=side_fx)
+            return MCPAgent(self.llm_client, side_effect_mgr=side_fx, llm_extra=self.llm_extra)
         elif agent_type == "skill_cli":
             from skill_cli.skill_agent import SkillAgent
-            return SkillAgent(self.llm_client, side_effect_mgr=side_fx)
+            return SkillAgent(self.llm_client, side_effect_mgr=side_fx, llm_extra=self.llm_extra)
         else:
             from agents.agent_engine import ReActAgent
-            return ReActAgent(self.llm_client, side_effect_mgr=side_fx)
+            return ReActAgent(self.llm_client, side_effect_mgr=side_fx, llm_extra=self.llm_extra)
 
     @staticmethod
     def _cleanup_paper_artifacts(session_id: str):

--- a/AgenticArxiv/mcp_protocol/mcp_agent.py
+++ b/AgenticArxiv/mcp_protocol/mcp_agent.py
@@ -18,7 +18,7 @@ if PROJECT_ROOT not in sys.path:
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-from agents.base_agent import BaseAgent
+from agents.base_agent import BaseAgent, is_terminal_action
 from agents.prompt_templates import get_react_prompt, format_tool_description
 from utils.llm_client import LLMClient
 from utils.logger import log
@@ -178,7 +178,7 @@ class MCPAgent(BaseAgent):
         )
         action_text = action_match.group(1).strip() if action_match else ""
 
-        if action_text.upper() == "FINISH":
+        if is_terminal_action(action_text):
             return thought, None
 
         try:
@@ -186,6 +186,9 @@ class MCPAgent(BaseAgent):
             if json_match:
                 action_json = json.loads(json_match.group(1))
                 if isinstance(action_json, dict):
+                    # 终止动作也可能被包成 JSON，先拦下来，别当工具调用
+                    if is_terminal_action(action_json.get("name")):
+                        return thought, None
                     if "name" in action_json and "args" in action_json:
                         return thought, {"name": action_json["name"], "args": action_json["args"]}
                     else:

--- a/AgenticArxiv/mcp_protocol/mcp_agent.py
+++ b/AgenticArxiv/mcp_protocol/mcp_agent.py
@@ -31,8 +31,9 @@ class MCPAgent(BaseAgent):
     """通过 MCP 协议调用工具的 Agent"""
     agent_type = "mcp"
 
-    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5):
-        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env, max_iterations=max_iterations)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5, llm_extra=None):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env,
+                         max_iterations=max_iterations, llm_extra=llm_extra)
         self._session: Optional[ClientSession] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._mcp_tools: List[Dict[str, Any]] = []

--- a/AgenticArxiv/skill_cli/skill_agent.py
+++ b/AgenticArxiv/skill_cli/skill_agent.py
@@ -38,8 +38,9 @@ class SkillAgent(BaseAgent):
     """通过 Skill 文档 + CLI 子进程执行工具的 Agent"""
     agent_type = "skill_cli"
 
-    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5):
-        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env, max_iterations=max_iterations)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5, llm_extra=None):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env,
+                         max_iterations=max_iterations, llm_extra=llm_extra)
         self._skill_doc = self._load_skill_doc()
 
         # 确保底层工具已注册（供 _execute_with_side_effects 使用）

--- a/AgenticArxiv/tests/test_llm_request_params.py
+++ b/AgenticArxiv/tests/test_llm_request_params.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""stop 序列与 llm_extra 透传的测试。
+
+不需要 LLM、网络或 GPU —— 用假的 client 捕获实际发出的请求参数。
+
+运行：
+    cd AgenticArxiv && python tests/test_llm_request_params.py
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+import tools.arxiv_tool  # noqa: F401,E402
+import tools.cache_status_tool  # noqa: F401,E402
+import tools.pdf_download_tool  # noqa: F401,E402
+import tools.pdf_translate_tool  # noqa: F401,E402
+
+from agents.agent_engine import ReActAgent  # noqa: E402
+from agents.side_effects import LocalSideEffectManager  # noqa: E402
+
+
+class CapturingClient:
+    """记录每次请求收到的参数，并立即返回 FINISH 结束循环。"""
+
+    def __init__(self):
+        self.calls = []
+
+    def chat_completions(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"choices": [{"message": {"content": "Thought: done\nAction: FINISH"}}],
+                "usage": {}}
+
+
+def run_once(**agent_kwargs):
+    client = CapturingClient()
+    agent = ReActAgent(client, side_effect_mgr=LocalSideEffectManager(), **agent_kwargs)
+    agent.run("检索最近7天AI论文", session_id="t")
+    return client.calls[0]
+
+
+class TestStopSequences(unittest.TestCase):
+    def test_stop_is_sent_by_default(self):
+        """Observation 必须由工具产生；不设 stop 时模型会自行续写整段交互。"""
+        self.assertEqual(run_once()["extra"]["stop"], ["Observation:"])
+
+    def test_stop_can_be_disabled(self):
+        class NoStop(ReActAgent):
+            stop_sequences = ()
+        client = CapturingClient()
+        NoStop(client, side_effect_mgr=LocalSideEffectManager()).run("x", session_id="t")
+        # 无任何额外参数时 BaseAgent 传 None（保持改动前的行为）
+        extra = client.calls[0]["extra"]
+        self.assertTrue(extra is None or "stop" not in extra, f"意外携带 stop: {extra}")
+
+
+class TestLlmExtra(unittest.TestCase):
+    def test_extra_is_forwarded(self):
+        extra = run_once(llm_extra={"chat_template_kwargs": {"enable_thinking": False}})["extra"]
+        self.assertEqual(extra["chat_template_kwargs"], {"enable_thinking": False})
+        self.assertEqual(extra["stop"], ["Observation:"])   # 与 stop 共存
+
+    def test_llm_extra_can_override_stop(self):
+        extra = run_once(llm_extra={"stop": ["###"]})["extra"]
+        self.assertEqual(extra["stop"], ["###"])
+
+    def test_default_is_empty_dict_not_none(self):
+        agent = ReActAgent(CapturingClient(), side_effect_mgr=LocalSideEffectManager())
+        self.assertEqual(agent.llm_extra, {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/AgenticArxiv/tests/test_terminal_action.py
+++ b/AgenticArxiv/tests/test_terminal_action.py
@@ -1,0 +1,109 @@
+"""JSON 外壳包裹的终止动作不应被当成工具调用。
+
+模型有时不写裸 `Action: FINISH`，而是套上和其他动作一样的 JSON 外壳
+`{"name": "FINISH", "args": {}}` —— prompt 里其余动作都是 JSON，这么写很自然。
+修复前它会被当成一次工具调用：白跑一轮迭代（工具执行失败，错误再喂回模型），
+并在 tool_call_sequence 里多出一个 "FINISH"，把本来完全正确的轨迹判成
+accurate=False。
+
+实测（Qwen3.5-9B，43 任务 × 3 范式 × 2 次 = 258 次运行）：命中 5 次
+（regex 3 / mcp 2），5 次全部被误判为 accurate=False，其中至少 2 次实际已
+正确完成任务，例如：
+
+    get_recently_submitted_cs_papers,download_arxiv_pdf,get_paper_cache_status,
+    translate_arxiv_pdf,FINISH        <- 完整正确序列，仅多出末尾的 FINISH
+
+分布并不均匀：在需要条件分支的任务上命中率可达 50%（8/16），足以把该任务的
+成功率整体压到 0。skill_cli 不受影响 —— 它的解析器要求子命令必须是 4 个
+CLI 名之一，"FINISH" 匹配不上就走终止分支；实测 0 次命中，与此一致。
+"""
+
+import json
+import unittest
+
+from agents.base_agent import TERMINAL_ACTIONS, is_terminal_action
+from agents.agent_engine import ReActAgent
+from benchmark.metrics import _check_tool_sequence, _extract_tool_sequence
+
+
+def _step(action, observation=""):
+    return {"thought": "t", "action": action, "observation": observation}
+
+
+class IsTerminalActionTest(unittest.TestCase):
+    def test_accepts_every_terminal_marker(self):
+        for name in TERMINAL_ACTIONS:
+            self.assertTrue(is_terminal_action(name), name)
+
+    def test_is_case_and_whitespace_insensitive(self):
+        for text in ("finish", " FINISH ", "Finish\n"):
+            self.assertTrue(is_terminal_action(text), repr(text))
+
+    def test_rejects_tool_names_and_non_strings(self):
+        for value in ("download_arxiv_pdf", "", None, 123, {"name": "FINISH"}):
+            self.assertFalse(is_terminal_action(value), repr(value))
+
+
+class ReActParseTerminalTest(unittest.TestCase):
+    """_parse_react_text 不使用 self，可用哑实例直接调用。"""
+
+    def _parse(self, response):
+        return ReActAgent._parse_react_text(None, response)
+
+    def test_bare_finish_terminates(self):
+        _, action = self._parse("Thought: 完成了\nAction: FINISH")
+        self.assertIsNone(action)
+
+    def test_json_wrapped_finish_terminates(self):
+        _, action = self._parse(
+            'Thought: 完成了\nAction: {"name": "FINISH", "args": {}}'
+        )
+        self.assertIsNone(action)
+
+    def test_json_wrapped_force_stop_terminates(self):
+        _, action = self._parse(
+            'Thought: 停\nAction: {"name": "FORCE_STOP", "args": {}}'
+        )
+        self.assertIsNone(action)
+
+    def test_real_tool_call_still_parses(self):
+        _, action = self._parse(
+            'Thought: 下载\nAction: {"name": "download_arxiv_pdf", "args": {"ref": 1}}'
+        )
+        self.assertEqual(action, {"name": "download_arxiv_pdf", "args": {"ref": 1}})
+
+
+class MetricsTerminalActionTest(unittest.TestCase):
+    """兜底层：历史结果文件和第三方 Agent 的轨迹仍可能带 JSON 终止动作。"""
+
+    FINISH_JSON = json.dumps({"name": "FINISH", "args": {}})
+
+    def test_json_finish_is_not_counted_as_a_tool(self):
+        history = [
+            _step(json.dumps({"name": "download_arxiv_pdf", "args": {"ref": 1}})),
+            _step(self.FINISH_JSON),
+        ]
+        self.assertEqual(_extract_tool_sequence(history), ["download_arxiv_pdf"])
+
+    def test_bare_terminal_actions_still_excluded(self):
+        history = [
+            _step(json.dumps({"name": "download_arxiv_pdf", "args": {"ref": 1}})),
+            _step("FINISH"),
+        ]
+        self.assertEqual(_extract_tool_sequence(history), ["download_arxiv_pdf"])
+
+    def test_correct_trajectory_is_no_longer_judged_inaccurate(self):
+        # 实测样本 ref_stress_image_restoration/regex：正确完成却被判 False
+        history = [
+            _step(json.dumps({"name": "download_arxiv_pdf", "args": {"ref": 1}})),
+            _step(self.FINISH_JSON),
+        ]
+        self.assertTrue(
+            _check_tool_sequence(
+                _extract_tool_sequence(history), ["download_arxiv_pdf"]
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Stacks on #<PR7>. Please merge that one first; this branch is rebased on it.

## Problem

The ReAct prompt shows every action as JSON, so the model sometimes ends a task with

```
Action: {"name": "FINISH", "args": {}}
```

instead of the bare `Action: FINISH` the parser expects. The bare form is matched first and the JSON form falls straight through to the tool-call branch, so the loop tries to execute a tool named `FINISH`. One iteration is burnt, the failure is fed back to the model, and `"FINISH"` lands in the trajectory as if it were a tool call.

Measured on Qwen3.5-9B over 258 benchmark runs (43 tasks x 3 agents x 2 trials): 5 runs hit this, all 5 scored `tool_call_accurate=False`, and at least 2 of them had in fact completed the task correctly. For example:

```
get_recently_submitted_cs_papers,download_arxiv_pdf,get_paper_cache_status,translate_arxiv_pdf,FINISH
```

That is the full expected sequence plus a spurious `FINISH`.

The rate is not uniform. On a task that needs a conditional branch it reached 50% (8 of 16 runs), which was enough to hold that task's measured success rate at 0 and make a parser defect look like a capability ceiling.

## Change

- `agents/base_agent.py`: `TERMINAL_ACTIONS` and `is_terminal_action()` as the single place that decides what counts as termination. Also covers `FORCE_STOP` and `ERROR`, and is case/whitespace insensitive.
- `agents/agent_engine.py`, `mcp_protocol/mcp_agent.py`: check the parsed JSON's `name` before treating it as a tool call.
- `benchmark/metrics.py`: `_parse_tool_action()` applies the same rule when reading trajectories, so existing result files and third-party agents are scored correctly too.

`skill_cli` needs no change. Its parser only accepts one of the four CLI subcommand names, so `FINISH` already falls through to termination — and it hit this 0 times in the same 258 runs, which matches.

## Tests

`tests/test_terminal_action.py`, 10 tests, no LLM or network needed. Two are regressions built from the observed failing trajectories.
