### PR TITLE
Feat/offline benchmark replay

### DIFF
--- a/AgenticArxiv/agents/agent_engine.py
+++ b/AgenticArxiv/agents/agent_engine.py
@@ -17,8 +17,9 @@ from utils.logger import log
 class ReActAgent(BaseAgent):
     """方案 A: ReAct + 正则解析 Agent"""
 
-    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5):
-        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env, max_iterations=max_iterations)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5, llm_extra=None):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env,
+                         max_iterations=max_iterations, llm_extra=llm_extra)
         try:
             import tools.arxiv_tool  # noqa: F401
             import tools.pdf_download_tool  # noqa: F401

--- a/AgenticArxiv/agents/agent_engine.py
+++ b/AgenticArxiv/agents/agent_engine.py
@@ -9,7 +9,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils.llm_client import LLMClient
 from tools.tool_registry import registry
-from agents.base_agent import BaseAgent
+from agents.base_agent import BaseAgent, is_terminal_action
 from agents.prompt_templates import get_react_prompt, format_tool_description
 from utils.logger import log
 
@@ -71,7 +71,7 @@ class ReActAgent(BaseAgent):
 
         log.info(f"提取到的Action文本: {action_text}")
 
-        if action_text.upper() == "FINISH":
+        if is_terminal_action(action_text):
             log.info("Agent决定结束任务")
             return thought, None
 
@@ -81,6 +81,10 @@ class ReActAgent(BaseAgent):
             if json_match:
                 action_json = json.loads(json_match.group(1))
                 if isinstance(action_json, dict):
+                    # 终止动作也可能被包成 JSON，先拦下来，别当工具调用
+                    if is_terminal_action(action_json.get("name")):
+                        log.info("Agent决定结束任务（JSON 形式的终止动作）")
+                        return thought, None
                     if "name" in action_json and "args" in action_json:
                         action_dict = {
                             "name": action_json["name"],

--- a/AgenticArxiv/agents/base_agent.py
+++ b/AgenticArxiv/agents/base_agent.py
@@ -18,12 +18,25 @@ class BaseAgent(ABC):
 
     agent_type: str = "regex"  # 子类覆写
 
+    # ReAct 循环里，Observation 必须由工具真实执行产生。
+    # 不设 stop 时模型会自己往下编造 Observation 与后续步骤，例如：
+    #     Action: {...}
+    #     Observation: 成功获取5篇论文列表，已保存至 output/...   ← 编的
+    #     Thought: 任务已完成
+    #     Action: FINISH
+    # 解析用的正则恰好在 Observation 前截断，所以第一个动作仍能取出，
+    # 但这些续写既浪费 token（实测多耗约一倍），也让"多跳任务"退化成
+    # 模型自说自话，而非真的与环境交互。三种 Agent 的 prompt 都用
+    # Observation: 作分隔，故在此统一设置。
+    stop_sequences: Tuple[str, ...] = ("Observation:",)
+
     def __init__(
         self,
         llm_client: LLMClient,
         side_effect_mgr: Optional[SideEffectManager] = None,
         env: Optional[Any] = None,
         max_iterations: int = 5,
+        llm_extra: Optional[Dict[str, Any]] = None,
     ):
         """
         Args:
@@ -33,11 +46,17 @@ class BaseAgent(ABC):
             env: 可选的工具执行环境（需实现 execute_tool(name, args)）。
                 传入 MockArxivEnv 即可让 rollout 走快照回放而非真实 API。
             max_iterations: ReAct 最大迭代轮数
+            llm_extra: 透传给 LLM 接口的额外参数，会合并进每次请求。
+                例如关闭 Qwen3 系列的思维链：
+                    {"chat_template_kwargs": {"enable_thinking": False}}
+                思维链会让生成 token 数翻倍，而 token 用量是 benchmark 的
+                核心对比指标之一，混入后三种范式之间的差异会被淹没。
         """
         self.llm_client = llm_client
         self.side_effects = side_effect_mgr or LocalSideEffectManager()
         self.env = env
         self.max_iterations = max_iterations
+        self.llm_extra = dict(llm_extra or {})
         self.session_id = "default"
 
     # ---------- 子类必须实现 ----------
@@ -111,6 +130,7 @@ class BaseAgent(ABC):
 
             history_text = self.format_history(history)
             messages, extra = self.build_messages(enriched_task, tools_description, history_text)
+            extra = self._merge_llm_extra(extra)
 
             llm_ms = 0
             tool_ms = 0
@@ -218,6 +238,17 @@ class BaseAgent(ABC):
         log.info(f"任务执行完成，共 {len(history)} 步, 总耗时 {total_time_ms}ms (LLM {total_llm_ms}ms + Tool {total_tool_ms}ms)")
         log.info("-" * 80)
         return result
+
+    # ---------- LLM 请求参数 ----------
+
+    def _merge_llm_extra(self, extra: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """合并 stop 序列与 llm_extra；build_messages 返回的 extra 优先级最高。"""
+        merged: Dict[str, Any] = {}
+        if self.stop_sequences:
+            merged["stop"] = list(self.stop_sequences)
+        merged.update(self.llm_extra)
+        merged.update(extra or {})
+        return merged
 
     # ---------- 会话上下文 ----------
 

--- a/AgenticArxiv/agents/base_agent.py
+++ b/AgenticArxiv/agents/base_agent.py
@@ -13,6 +13,19 @@ from tools.tool_registry import registry
 from agents.side_effects import SideEffectManager, LocalSideEffectManager
 
 
+# 循环终止标记。模型有时不写裸 `Action: FINISH`，而是套上和其他动作一样的
+# JSON 外壳 `{"name": "FINISH", "args": {}}` —— prompt 里其余动作都是 JSON，
+# 这么写很自然。若不识别，它会被当成一次工具调用：白跑一轮迭代，
+# 还会在 benchmark 的 tool_call_sequence 里多出一个 "FINISH"，
+# 把本来完全正确的轨迹判成 accurate=False。
+TERMINAL_ACTIONS = ("FINISH", "FORCE_STOP", "ERROR")
+
+
+def is_terminal_action(name: Any) -> bool:
+    """判断解析出的动作名是否代表「结束」而非一次工具调用。"""
+    return isinstance(name, str) and name.strip().upper() in TERMINAL_ACTIONS
+
+
 class BaseAgent(ABC):
     """所有 Agent 方案的基类，封装通用的循环控制、日志、SSE、副作用逻辑"""
 

--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -38,6 +38,10 @@ class TaskMetrics:
     tool_call_accurate: bool = False
     parse_failures: int = 0
     tool_exec_failures: int = 0
+    # 参数级准确率（0~1）。没有 expected_tool_args 的任务恒为 1.0，不参与扣分。
+    # 只看工具名的话，「下载标题含 X 的那篇」即使下错论文，
+    # 工具序列仍是 [download_arxiv_pdf]，会被判为准确。
+    arg_score: float = 1.0
 
     # --- 原始数据 ---
     error: Optional[str] = None
@@ -83,6 +87,10 @@ def extract_metrics(
     parse_failures = _count_parse_failures(history)
     tool_exec_failures = _count_tool_failures(history)
 
+    arg_score = argument_match_score(history, task_def.get("expected_tool_args"))
+    if arg_score is None:
+        arg_score = 1.0
+
     error = None
     if termination_type == "ERROR" and history:
         error = history[-1].get("observation", "")
@@ -109,6 +117,7 @@ def extract_metrics(
         tool_call_accurate=tool_call_accurate,
         parse_failures=parse_failures,
         tool_exec_failures=tool_exec_failures,
+        arg_score=arg_score,
         error=error,
     )
 
@@ -172,6 +181,41 @@ def _check_tool_sequence(actual: List[str], expected: List[str]) -> bool:
     if not expected:
         return True
     return actual == expected
+
+
+def argument_match_score(history, expected_args):
+    """参数级匹配度，返回 [0,1] 或 None（任务未声明 expected_tool_args）。
+
+    从 rl/reward.py 的 _argument_score 提取，语义保持一致：
+    每一步取 (键覆盖率 + 取值正确率) / 2，再对各步取平均。
+    expected_args 中为 None 的项表示该步不校验参数。
+
+    提取到此处是为了让 benchmark 报告也能反映参数准确率 ——
+    此前它只存在于 RL 奖励里，TaskMetrics 中没有对应字段，
+    于是「工具选对了但参数选错了」在 benchmark 里完全不可见。
+    """
+    if expected_args is None:
+        return None
+
+    actual = []
+    for step in history or []:
+        parsed = _parse_tool_action(step.get("action", ""))
+        if parsed is not None:
+            actual.append(parsed.get("parameters", parsed.get("args", {})) or {})
+
+    scores = []
+    for index, expected in enumerate(expected_args):
+        if expected is None:
+            continue
+        predicted = actual[index] if index < len(actual) else {}
+        keys = set(expected)
+        if not keys:
+            scores.append(1.0 if not predicted else 0.0)
+            continue
+        key_recall = len(keys & set(predicted)) / len(keys)
+        value_accuracy = sum(predicted.get(k) == v for k, v in expected.items()) / len(keys)
+        scores.append((key_recall + value_accuracy) / 2)
+    return sum(scores) / len(scores) if scores else 1.0
 
 
 def _count_parse_failures(history: List[Dict]) -> int:

--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass, field, asdict
 from typing import List, Dict, Any, Optional
 
 
+# 非工具调用的动作标记
+NON_TOOL_ACTIONS = ("FINISH", "FORCE_STOP", "ERROR")
+
+
 @dataclass
 class TaskMetrics:
     """单次任务执行的完整指标"""
@@ -123,20 +127,43 @@ def _get_termination_type(history: List[Dict]) -> str:
     return "INCOMPLETE"
 
 
+def _parse_tool_action(action: Any) -> Optional[Dict[str, Any]]:
+    """把 history 里的 action 解析成工具调用 dict；不是工具调用则返回 None。
+
+    终止动作既可能是裸字符串 `FINISH`，也可能被模型包成和其他动作一样的
+    JSON 外壳 `{"name": "FINISH", "args": {}}`。后者若不排除，会在
+    tool_call_sequence 里多出一个 "FINISH"，把完全正确的轨迹判成
+    accurate=False。Agent 侧已在解析阶段拦截（见
+    agents/base_agent.py::is_terminal_action），这里再兜一层，
+    以便正确处理历史结果文件和第三方 Agent 的轨迹。
+    """
+    if isinstance(action, str) and action.strip().upper() in NON_TOOL_ACTIONS:
+        return None
+    if isinstance(action, dict):
+        parsed = action
+    else:
+        try:
+            parsed = json.loads(action)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if not isinstance(parsed, dict):
+        return None
+    name = parsed.get("name")
+    if isinstance(name, str) and name.strip().upper() in NON_TOOL_ACTIONS:
+        return None
+    return parsed
+
+
 def _extract_tool_sequence(history: List[Dict]) -> List[str]:
     """从 history 中提取实际调用的工具名序列"""
     tools = []
     for step in history:
-        action = step.get("action", "")
-        if action in ("FINISH", "FORCE_STOP", "ERROR"):
+        parsed = _parse_tool_action(step.get("action", ""))
+        if parsed is None:
             continue
-        try:
-            action_dict = json.loads(action)
-            name = action_dict.get("name", "")
-            if name:
-                tools.append(name)
-        except (json.JSONDecodeError, TypeError):
-            pass
+        name = parsed.get("name", "")
+        if name:
+            tools.append(name)
     return tools
 
 
@@ -167,7 +194,7 @@ def _count_tool_failures(history: List[Dict]) -> int:
     error_markers = ["错误:", "工具执行失败:", "命令失败", "命令执行超时", "命令执行异常"]
     for step in history:
         action = step.get("action", "")
-        if action in ("FINISH", "FORCE_STOP", "ERROR"):
+        if action in NON_TOOL_ACTIONS:
             continue
         obs = step.get("observation", "")
         if any(marker in obs for marker in error_markers):

--- a/AgenticArxiv/benchmark/report.py
+++ b/AgenticArxiv/benchmark/report.py
@@ -40,6 +40,7 @@ class BenchmarkReport:
                 "avg_tokens": _avg(items, "total_tokens"),
                 "completion_rate": _rate(items, "task_completed"),
                 "tool_accuracy": _rate(items, "tool_call_accurate"),
+                "arg_accuracy": _avg(items, "arg_score"),
                 "avg_parse_failures": _avg(items, "parse_failures"),
                 "avg_tool_failures": _avg(items, "tool_exec_failures"),
             }
@@ -78,6 +79,7 @@ class BenchmarkReport:
                 "completed": m.task_completed,
                 "termination": m.termination_type,
                 "tool_accurate": m.tool_call_accurate,
+                "arg_score": m.arg_score,
                 "tools": ",".join(m.tool_call_sequence),
                 "expected": ",".join(m.expected_tools),
                 "parse_fail": m.parse_failures,
@@ -132,6 +134,7 @@ class BenchmarkReport:
         acc_rows = [
             ("任务完成率", "completion_rate"),
             ("工具调用准确率", "tool_accuracy"),
+            ("参数准确率", "arg_accuracy"),
             ("平均解析失败", "avg_parse_failures"),
             ("平均工具失败", "avg_tool_failures"),
         ]

--- a/AgenticArxiv/benchmark/run_benchmark.py
+++ b/AgenticArxiv/benchmark/run_benchmark.py
@@ -61,7 +61,17 @@ def main():
         "--prefix", type=str, default=None,
         help="Session ID 前缀，用于区分不同测试轮次 (默认: bench_r<timestamp>)",
     )
+    parser.add_argument(
+        "--no-thinking", action="store_true",
+        help="关闭 Qwen3 等推理模型的思维链。思维链会让生成 token 数翻倍，"
+             "而 token 用量是本 benchmark 的核心对比指标之一，"
+             "混入后三种范式之间的差异会被淹没。",
+    )
     args = parser.parse_args()
+
+    llm_extra = {}
+    if args.no_thinking:
+        llm_extra["chat_template_kwargs"] = {"enable_thinking": False}
 
     # 筛选任务
     if args.task_ids:
@@ -84,6 +94,7 @@ def main():
         repeat=args.repeat,
         model=model,
         session_prefix=args.prefix,
+        llm_extra=llm_extra,
     )
 
     print("=" * 60)

--- a/AgenticArxiv/benchmark/run_benchmark.py
+++ b/AgenticArxiv/benchmark/run_benchmark.py
@@ -67,6 +67,13 @@ def main():
              "而 token 用量是本 benchmark 的核心对比指标之一，"
              "混入后三种范式之间的差异会被淹没。",
     )
+    parser.add_argument(
+        "--offline", action="store_true",
+        help="用 data/mock_arxiv_snapshot.json 回放工具调用，不请求真实 arXiv。"
+             "结果可复现，且去掉网络耗时后「框架开销」才真正可比；"
+             "代价是不再覆盖真实 API 集成。",
+    )
+    parser.add_argument("--snapshot", default=None, help="指定快照路径（默认 data/mock_arxiv_snapshot.json）")
     args = parser.parse_args()
 
     llm_extra = {}
@@ -95,6 +102,8 @@ def main():
         model=model,
         session_prefix=args.prefix,
         llm_extra=llm_extra,
+        offline=args.offline,
+        snapshot=args.snapshot,
     )
 
     print("=" * 60)
@@ -106,6 +115,7 @@ def main():
     print(f"  重复次数: {args.repeat}")
     print(f"  总运行数: {len(task_list) * len(args.agents) * args.repeat}")
     print(f"  输出目录: {args.output}")
+    print(f"  工具执行: {'离线快照回放' if args.offline else '真实 arXiv API'}")
     print("=" * 60)
 
     results = runner.run_all(task_list)

--- a/AgenticArxiv/benchmark/runner.py
+++ b/AgenticArxiv/benchmark/runner.py
@@ -43,11 +43,16 @@ class BenchmarkRunner:
         model: Optional[str] = None,
         session_prefix: Optional[str] = None,
         llm_extra: Optional[Dict[str, Any]] = None,
+        offline: bool = False,
+        snapshot: Optional[str] = None,
     ):
         self.agent_types = agent_types or self.AGENT_TYPES
         self.repeat = repeat
         self.model = model
         self.llm_extra = dict(llm_extra or {})
+        self.offline = offline
+        self.snapshot = snapshot
+        self._env = None
         if session_prefix is None:
             from datetime import datetime
             session_prefix = f"bench_r{datetime.now().strftime('%Y%m%d_%H%M%S')}"
@@ -82,6 +87,7 @@ class BenchmarkRunner:
                     try:
                         # 确保依赖任务已执行
                         self._ensure_dependencies(task_def, session_id, agent_type)
+                        self._apply_setup(task_def, session_id)
 
                         # 下载/翻译任务：清理上一次试验留下的文件和 DB 记录
                         if task_def.get("category") in ("download", "translate"):
@@ -119,23 +125,50 @@ class BenchmarkRunner:
         return results
 
     def _side_effects(self):
-        """Benchmark 沿用原行为（MySQL 落库 + SSE）；无数据库时自动降级到本地内存。"""
+        """Benchmark 沿用原行为（MySQL 落库 + SSE）；无数据库时自动降级到本地内存。
+
+        离线模式必须用 LocalSideEffectManager：否则翻译任务仍会起线程调 pdf2zh、
+        会话状态仍写 MySQL，"离线"就只离了一半。
+        """
         if self._side_fx is None:
-            from agents.side_effects import default_side_effect_manager
-            self._side_fx = default_side_effect_manager()
+            if self.offline:
+                from agents.side_effects import LocalSideEffectManager
+                self._side_fx = LocalSideEffectManager()
+            else:
+                from agents.side_effects import default_side_effect_manager
+                self._side_fx = default_side_effect_manager()
         return self._side_fx
+
+    def _tool_env(self):
+        """离线模式下用 MockArxivEnv 回放快照，取代真实 arXiv 请求。"""
+        if not self.offline:
+            return None
+        if self._env is None:
+            from pathlib import Path as _Path
+            from rl.env import MockArxivEnv
+            path = _Path(self.snapshot) if self.snapshot else (
+                _Path(PROJECT_ROOT).parent / "data" / "mock_arxiv_snapshot.json")
+            if not path.exists():
+                raise SystemExit(
+                    f"离线模式需要快照，但未找到: {path}\n"
+                    f"请先运行: python -m AgenticArxiv.rl.build_snapshot"
+                )
+            self._env = MockArxivEnv(snapshot_path=path, mode="replay")
+            log.info(f"[Benchmark] 离线模式，回放快照 {path}")
+        return self._env
 
     def _create_agent(self, agent_type: str):
         side_fx = self._side_effects()
+        env = self._tool_env()
         if agent_type == "mcp":
             from mcp_protocol.mcp_agent import MCPAgent
-            return MCPAgent(self.llm_client, side_effect_mgr=side_fx, llm_extra=self.llm_extra)
+            return MCPAgent(self.llm_client, side_effect_mgr=side_fx, env=env, llm_extra=self.llm_extra)
         elif agent_type == "skill_cli":
             from skill_cli.skill_agent import SkillAgent
-            return SkillAgent(self.llm_client, side_effect_mgr=side_fx, llm_extra=self.llm_extra)
+            return SkillAgent(self.llm_client, side_effect_mgr=side_fx, env=env, llm_extra=self.llm_extra)
         else:
             from agents.agent_engine import ReActAgent
-            return ReActAgent(self.llm_client, side_effect_mgr=side_fx, llm_extra=self.llm_extra)
+            return ReActAgent(self.llm_client, side_effect_mgr=side_fx, env=env, llm_extra=self.llm_extra)
 
     @staticmethod
     def _cleanup_paper_artifacts(session_id: str):
@@ -161,6 +194,38 @@ class BenchmarkRunner:
             log_path = os.path.join(app_settings.pdf_translated_log_path, f"{pid}.pdf2zh.log")
             if os.path.exists(log_path):
                 os.remove(log_path)
+
+    def _apply_setup(self, task_def: Dict, session_id: str):
+        """执行任务的 setup 动作，把会话状态铺好。
+
+        与 depends_on 的区别：depends_on 会再跑一遍完整 Agent（含 LLM 调用），
+        setup 直接调用工具铺状态。后者更适合"被测任务本身不该包含这些步骤"的场景 ——
+        例如「下载标题含 X 的那篇」，论文列表应当是既有前提，
+        而不是让被测 Agent 先检索一次（那样 expected_tools 就必须包含检索，
+        ref 参数的正确性反而测不出来了）。
+        """
+        setup = task_def.get("setup")
+        if not setup:
+            return
+
+        from models.schemas import Paper
+        from tools.tool_registry import registry
+
+        env = self._tool_env()
+        side_fx = self._side_effects()
+        for action in setup:
+            args = dict(action.get("args") or {})
+            args["session_id"] = session_id
+            name = action["name"]
+            if name == "translate_arxiv_pdf":
+                side_fx.enqueue_translate(**args)
+                continue
+            result = env.execute_tool(name, args) if env else registry.execute_tool(name, args)
+            if name == "get_recently_submitted_cs_papers" and isinstance(result, list) and result:
+                side_fx.set_last_papers(session_id, [Paper(**p) for p in result])
+            if isinstance(result, dict) and isinstance(result.get("paper_id"), str):
+                side_fx.set_last_active_paper_id(session_id, result["paper_id"])
+        log.info(f"  已铺设会话状态: {[a['name'] for a in setup]}")
 
     def _ensure_dependencies(self, task_def: Dict, session_id: str, agent_type: str):
         """如果任务有依赖，先执行依赖任务确保上下文（论文列表等）存在"""

--- a/AgenticArxiv/benchmark/runner.py
+++ b/AgenticArxiv/benchmark/runner.py
@@ -42,10 +42,12 @@ class BenchmarkRunner:
         repeat: int = 3,
         model: Optional[str] = None,
         session_prefix: Optional[str] = None,
+        llm_extra: Optional[Dict[str, Any]] = None,
     ):
         self.agent_types = agent_types or self.AGENT_TYPES
         self.repeat = repeat
         self.model = model
+        self.llm_extra = dict(llm_extra or {})
         if session_prefix is None:
             from datetime import datetime
             session_prefix = f"bench_r{datetime.now().strftime('%Y%m%d_%H%M%S')}"
@@ -127,13 +129,13 @@ class BenchmarkRunner:
         side_fx = self._side_effects()
         if agent_type == "mcp":
             from mcp_protocol.mcp_agent import MCPAgent
-            return MCPAgent(self.llm_client, side_effect_mgr=side_fx)
+            return MCPAgent(self.llm_client, side_effect_mgr=side_fx, llm_extra=self.llm_extra)
         elif agent_type == "skill_cli":
             from skill_cli.skill_agent import SkillAgent
-            return SkillAgent(self.llm_client, side_effect_mgr=side_fx)
+            return SkillAgent(self.llm_client, side_effect_mgr=side_fx, llm_extra=self.llm_extra)
         else:
             from agents.agent_engine import ReActAgent
-            return ReActAgent(self.llm_client, side_effect_mgr=side_fx)
+            return ReActAgent(self.llm_client, side_effect_mgr=side_fx, llm_extra=self.llm_extra)
 
     @staticmethod
     def _cleanup_paper_artifacts(session_id: str):

--- a/AgenticArxiv/mcp_protocol/mcp_agent.py
+++ b/AgenticArxiv/mcp_protocol/mcp_agent.py
@@ -18,7 +18,7 @@ if PROJECT_ROOT not in sys.path:
 from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
-from agents.base_agent import BaseAgent
+from agents.base_agent import BaseAgent, is_terminal_action
 from agents.prompt_templates import get_react_prompt, format_tool_description
 from utils.llm_client import LLMClient
 from utils.logger import log
@@ -178,7 +178,7 @@ class MCPAgent(BaseAgent):
         )
         action_text = action_match.group(1).strip() if action_match else ""
 
-        if action_text.upper() == "FINISH":
+        if is_terminal_action(action_text):
             return thought, None
 
         try:
@@ -186,6 +186,9 @@ class MCPAgent(BaseAgent):
             if json_match:
                 action_json = json.loads(json_match.group(1))
                 if isinstance(action_json, dict):
+                    # 终止动作也可能被包成 JSON，先拦下来，别当工具调用
+                    if is_terminal_action(action_json.get("name")):
+                        return thought, None
                     if "name" in action_json and "args" in action_json:
                         return thought, {"name": action_json["name"], "args": action_json["args"]}
                     else:

--- a/AgenticArxiv/mcp_protocol/mcp_agent.py
+++ b/AgenticArxiv/mcp_protocol/mcp_agent.py
@@ -31,8 +31,9 @@ class MCPAgent(BaseAgent):
     """通过 MCP 协议调用工具的 Agent"""
     agent_type = "mcp"
 
-    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5):
-        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env, max_iterations=max_iterations)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5, llm_extra=None):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env,
+                         max_iterations=max_iterations, llm_extra=llm_extra)
         self._session: Optional[ClientSession] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._mcp_tools: List[Dict[str, Any]] = []

--- a/AgenticArxiv/rl/reward.py
+++ b/AgenticArxiv/rl/reward.py
@@ -10,7 +10,7 @@ import math
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
-from benchmark.metrics import TaskMetrics, extract_metrics
+from benchmark.metrics import TaskMetrics, argument_match_score, extract_metrics
 
 
 TERMINAL_ACTIONS = {"FINISH", "FORCE_STOP", "ERROR"}
@@ -178,26 +178,10 @@ class RewardCalculator:
         history: Sequence[Dict[str, Any]],
         expected_args: Optional[Sequence[Optional[Mapping[str, Any]]]],
     ) -> Optional[float]:
-        if expected_args is None:
-            return None
-        actual = []
-        for step in history:
-            action = _parse_action(step.get("action", ""))
-            if action:
-                actual.append(action.get("parameters", action.get("args", {})))
-        scores = []
-        for index, expected in enumerate(expected_args):
-            if expected is None:
-                continue
-            predicted = actual[index] if index < len(actual) else {}
-            keys = set(expected)
-            if not keys:
-                scores.append(1.0 if not predicted else 0.0)
-                continue
-            key_recall = len(keys & set(predicted)) / len(keys)
-            value_accuracy = sum(predicted.get(k) == v for k, v in expected.items()) / len(keys)
-            scores.append((key_recall + value_accuracy) / 2)
-        return 2 * (sum(scores) / len(scores) if scores else 1.0) - 1
+        # 比对逻辑已提取到 benchmark/metrics.py，供 benchmark 报告共用；
+        # 这里只做 [0,1] → [-1,1] 的缩放，语义与原实现一致。
+        score = argument_match_score(history, expected_args)
+        return None if score is None else 2 * score - 1
 
     @staticmethod
     def _process_score(history: Sequence[Dict[str, Any]], metrics: TaskMetrics) -> float:

--- a/AgenticArxiv/skill_cli/skill_agent.py
+++ b/AgenticArxiv/skill_cli/skill_agent.py
@@ -38,8 +38,9 @@ class SkillAgent(BaseAgent):
     """通过 Skill 文档 + CLI 子进程执行工具的 Agent"""
     agent_type = "skill_cli"
 
-    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5):
-        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env, max_iterations=max_iterations)
+    def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5, llm_extra=None):
+        super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env,
+                         max_iterations=max_iterations, llm_extra=llm_extra)
         self._skill_doc = self._load_skill_doc()
 
         # 确保底层工具已注册（供 _execute_with_side_effects 使用）

--- a/AgenticArxiv/tests/test_benchmark_offline.py
+++ b/AgenticArxiv/tests/test_benchmark_offline.py
@@ -1,0 +1,125 @@
+"""离线回放、setup 铺状态、参数准确率的单元测试（不需要 LLM / 网络 / 数据库）。"""
+
+import json
+import unittest
+
+from benchmark.metrics import argument_match_score
+from benchmark.runner import BenchmarkRunner
+
+
+def _step(name, args):
+    return {"thought": "t", "action": json.dumps({"name": name, "args": args}), "observation": ""}
+
+
+class _FakeEnv:
+    """记录被调用的工具，并返回可预测的结果。"""
+
+    def __init__(self, results=None):
+        self.calls = []
+        self._results = results or {}
+
+    def execute_tool(self, name, args):
+        self.calls.append((name, dict(args)))
+        return self._results.get(name)
+
+
+class _FakeSideEffects:
+    def __init__(self):
+        self.papers = {}
+        self.active = {}
+        self.translated = []
+
+    def set_last_papers(self, session_id, papers):
+        self.papers[session_id] = papers
+
+    def set_last_active_paper_id(self, session_id, paper_id):
+        self.active[session_id] = paper_id
+
+    def enqueue_translate(self, **kwargs):
+        self.translated.append(kwargs)
+
+
+class ArgumentMatchScoreTest(unittest.TestCase):
+    """语义须与提取前的 rl/reward.py::_argument_score 一致。"""
+
+    def test_returns_none_when_task_declares_no_expected_args(self):
+        self.assertIsNone(argument_match_score([_step("t", {"a": 1})], None))
+
+    def test_exact_match_scores_one(self):
+        history = [_step("download_arxiv_pdf", {"ref": 2})]
+        self.assertEqual(argument_match_score(history, [{"ref": 2}]), 1.0)
+
+    def test_right_key_wrong_value_scores_half(self):
+        history = [_step("download_arxiv_pdf", {"ref": 9})]
+        self.assertEqual(argument_match_score(history, [{"ref": 2}]), 0.5)
+
+    def test_missing_step_scores_zero(self):
+        self.assertEqual(argument_match_score([], [{"ref": 2}]), 0.0)
+
+    def test_none_entries_skip_that_step(self):
+        history = [_step("a", {"x": 1}), _step("b", {"ref": 2})]
+        self.assertEqual(argument_match_score(history, [None, {"ref": 2}]), 1.0)
+
+    def test_extra_session_id_does_not_penalise(self):
+        # session_id 由框架注入，不该算模型的错
+        history = [_step("download_arxiv_pdf", {"ref": 2, "session_id": "s"})]
+        self.assertEqual(argument_match_score(history, [{"ref": 2}]), 1.0)
+
+
+class ApplySetupTest(unittest.TestCase):
+    """setup 直接调工具铺状态，不再走一遍完整 Agent。"""
+
+    def _runner(self, env, side_fx):
+        r = BenchmarkRunner(agent_types=["regex"], repeat=1, offline=True)
+        r._env, r._side_fx = env, side_fx
+        return r
+
+    def test_no_setup_is_a_no_op(self):
+        env, fx = _FakeEnv(), _FakeSideEffects()
+        self._runner(env, fx)._apply_setup({"id": "t"}, "s1")
+        self.assertEqual(env.calls, [])
+
+    def test_search_setup_seeds_the_paper_list(self):
+        papers = [{"id": "2608.1v1", "title": "A"}, {"id": "2608.2v1", "title": "B"}]
+        env = _FakeEnv({"get_recently_submitted_cs_papers": papers})
+        fx = _FakeSideEffects()
+        task = {"id": "t", "setup": [
+            {"name": "get_recently_submitted_cs_papers", "args": {"aspect": "AI", "days": 7}}]}
+        self._runner(env, fx)._apply_setup(task, "s1")
+
+        self.assertEqual(env.calls[0][0], "get_recently_submitted_cs_papers")
+        self.assertEqual(env.calls[0][1]["session_id"], "s1")   # session_id 被注入
+        self.assertEqual([p.id for p in fx.papers["s1"]], ["2608.1v1", "2608.2v1"])
+
+    def test_download_setup_marks_the_active_paper(self):
+        env = _FakeEnv({"download_arxiv_pdf": {"paper_id": "2608.1v1", "status": "READY"}})
+        fx = _FakeSideEffects()
+        task = {"id": "t", "setup": [{"name": "download_arxiv_pdf", "args": {"ref": 1}}]}
+        self._runner(env, fx)._apply_setup(task, "s1")
+        self.assertEqual(fx.active["s1"], "2608.1v1")
+
+    def test_translate_setup_is_enqueued_not_executed(self):
+        env, fx = _FakeEnv(), _FakeSideEffects()
+        task = {"id": "t", "setup": [{"name": "translate_arxiv_pdf", "args": {"ref": 1}}]}
+        self._runner(env, fx)._apply_setup(task, "s1")
+        self.assertEqual(env.calls, [])                          # 不同步执行
+        self.assertEqual(fx.translated[0]["session_id"], "s1")
+
+
+class OfflineWiringTest(unittest.TestCase):
+    def test_online_runner_injects_no_env(self):
+        self.assertIsNone(BenchmarkRunner(offline=False)._tool_env())
+
+    def test_missing_snapshot_fails_loudly(self):
+        r = BenchmarkRunner(offline=True, snapshot="/nonexistent/snap.json")
+        with self.assertRaises(SystemExit):
+            r._tool_env()
+
+    def test_offline_forces_local_side_effects(self):
+        from agents.side_effects import LocalSideEffectManager
+        self.assertIsInstance(BenchmarkRunner(offline=True)._side_effects(),
+                              LocalSideEffectManager)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AgenticArxiv/tests/test_llm_request_params.py
+++ b/AgenticArxiv/tests/test_llm_request_params.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""stop 序列与 llm_extra 透传的测试。
+
+不需要 LLM、网络或 GPU —— 用假的 client 捕获实际发出的请求参数。
+
+运行：
+    cd AgenticArxiv && python tests/test_llm_request_params.py
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+import tools.arxiv_tool  # noqa: F401,E402
+import tools.cache_status_tool  # noqa: F401,E402
+import tools.pdf_download_tool  # noqa: F401,E402
+import tools.pdf_translate_tool  # noqa: F401,E402
+
+from agents.agent_engine import ReActAgent  # noqa: E402
+from agents.side_effects import LocalSideEffectManager  # noqa: E402
+
+
+class CapturingClient:
+    """记录每次请求收到的参数，并立即返回 FINISH 结束循环。"""
+
+    def __init__(self):
+        self.calls = []
+
+    def chat_completions(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"choices": [{"message": {"content": "Thought: done\nAction: FINISH"}}],
+                "usage": {}}
+
+
+def run_once(**agent_kwargs):
+    client = CapturingClient()
+    agent = ReActAgent(client, side_effect_mgr=LocalSideEffectManager(), **agent_kwargs)
+    agent.run("检索最近7天AI论文", session_id="t")
+    return client.calls[0]
+
+
+class TestStopSequences(unittest.TestCase):
+    def test_stop_is_sent_by_default(self):
+        """Observation 必须由工具产生；不设 stop 时模型会自行续写整段交互。"""
+        self.assertEqual(run_once()["extra"]["stop"], ["Observation:"])
+
+    def test_stop_can_be_disabled(self):
+        class NoStop(ReActAgent):
+            stop_sequences = ()
+        client = CapturingClient()
+        NoStop(client, side_effect_mgr=LocalSideEffectManager()).run("x", session_id="t")
+        # 无任何额外参数时 BaseAgent 传 None（保持改动前的行为）
+        extra = client.calls[0]["extra"]
+        self.assertTrue(extra is None or "stop" not in extra, f"意外携带 stop: {extra}")
+
+
+class TestLlmExtra(unittest.TestCase):
+    def test_extra_is_forwarded(self):
+        extra = run_once(llm_extra={"chat_template_kwargs": {"enable_thinking": False}})["extra"]
+        self.assertEqual(extra["chat_template_kwargs"], {"enable_thinking": False})
+        self.assertEqual(extra["stop"], ["Observation:"])   # 与 stop 共存
+
+    def test_llm_extra_can_override_stop(self):
+        extra = run_once(llm_extra={"stop": ["###"]})["extra"]
+        self.assertEqual(extra["stop"], ["###"])
+
+    def test_default_is_empty_dict_not_none(self):
+        agent = ReActAgent(CapturingClient(), side_effect_mgr=LocalSideEffectManager())
+        self.assertEqual(agent.llm_extra, {})
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/AgenticArxiv/tests/test_terminal_action.py
+++ b/AgenticArxiv/tests/test_terminal_action.py
@@ -1,0 +1,109 @@
+"""JSON 外壳包裹的终止动作不应被当成工具调用。
+
+模型有时不写裸 `Action: FINISH`，而是套上和其他动作一样的 JSON 外壳
+`{"name": "FINISH", "args": {}}` —— prompt 里其余动作都是 JSON，这么写很自然。
+修复前它会被当成一次工具调用：白跑一轮迭代（工具执行失败，错误再喂回模型），
+并在 tool_call_sequence 里多出一个 "FINISH"，把本来完全正确的轨迹判成
+accurate=False。
+
+实测（Qwen3.5-9B，43 任务 × 3 范式 × 2 次 = 258 次运行）：命中 5 次
+（regex 3 / mcp 2），5 次全部被误判为 accurate=False，其中至少 2 次实际已
+正确完成任务，例如：
+
+    get_recently_submitted_cs_papers,download_arxiv_pdf,get_paper_cache_status,
+    translate_arxiv_pdf,FINISH        <- 完整正确序列，仅多出末尾的 FINISH
+
+分布并不均匀：在需要条件分支的任务上命中率可达 50%（8/16），足以把该任务的
+成功率整体压到 0。skill_cli 不受影响 —— 它的解析器要求子命令必须是 4 个
+CLI 名之一，"FINISH" 匹配不上就走终止分支；实测 0 次命中，与此一致。
+"""
+
+import json
+import unittest
+
+from agents.base_agent import TERMINAL_ACTIONS, is_terminal_action
+from agents.agent_engine import ReActAgent
+from benchmark.metrics import _check_tool_sequence, _extract_tool_sequence
+
+
+def _step(action, observation=""):
+    return {"thought": "t", "action": action, "observation": observation}
+
+
+class IsTerminalActionTest(unittest.TestCase):
+    def test_accepts_every_terminal_marker(self):
+        for name in TERMINAL_ACTIONS:
+            self.assertTrue(is_terminal_action(name), name)
+
+    def test_is_case_and_whitespace_insensitive(self):
+        for text in ("finish", " FINISH ", "Finish\n"):
+            self.assertTrue(is_terminal_action(text), repr(text))
+
+    def test_rejects_tool_names_and_non_strings(self):
+        for value in ("download_arxiv_pdf", "", None, 123, {"name": "FINISH"}):
+            self.assertFalse(is_terminal_action(value), repr(value))
+
+
+class ReActParseTerminalTest(unittest.TestCase):
+    """_parse_react_text 不使用 self，可用哑实例直接调用。"""
+
+    def _parse(self, response):
+        return ReActAgent._parse_react_text(None, response)
+
+    def test_bare_finish_terminates(self):
+        _, action = self._parse("Thought: 完成了\nAction: FINISH")
+        self.assertIsNone(action)
+
+    def test_json_wrapped_finish_terminates(self):
+        _, action = self._parse(
+            'Thought: 完成了\nAction: {"name": "FINISH", "args": {}}'
+        )
+        self.assertIsNone(action)
+
+    def test_json_wrapped_force_stop_terminates(self):
+        _, action = self._parse(
+            'Thought: 停\nAction: {"name": "FORCE_STOP", "args": {}}'
+        )
+        self.assertIsNone(action)
+
+    def test_real_tool_call_still_parses(self):
+        _, action = self._parse(
+            'Thought: 下载\nAction: {"name": "download_arxiv_pdf", "args": {"ref": 1}}'
+        )
+        self.assertEqual(action, {"name": "download_arxiv_pdf", "args": {"ref": 1}})
+
+
+class MetricsTerminalActionTest(unittest.TestCase):
+    """兜底层：历史结果文件和第三方 Agent 的轨迹仍可能带 JSON 终止动作。"""
+
+    FINISH_JSON = json.dumps({"name": "FINISH", "args": {}})
+
+    def test_json_finish_is_not_counted_as_a_tool(self):
+        history = [
+            _step(json.dumps({"name": "download_arxiv_pdf", "args": {"ref": 1}})),
+            _step(self.FINISH_JSON),
+        ]
+        self.assertEqual(_extract_tool_sequence(history), ["download_arxiv_pdf"])
+
+    def test_bare_terminal_actions_still_excluded(self):
+        history = [
+            _step(json.dumps({"name": "download_arxiv_pdf", "args": {"ref": 1}})),
+            _step("FINISH"),
+        ]
+        self.assertEqual(_extract_tool_sequence(history), ["download_arxiv_pdf"])
+
+    def test_correct_trajectory_is_no_longer_judged_inaccurate(self):
+        # 实测样本 ref_stress_image_restoration/regex：正确完成却被判 False
+        history = [
+            _step(json.dumps({"name": "download_arxiv_pdf", "args": {"ref": 1}})),
+            _step(self.FINISH_JSON),
+        ]
+        self.assertTrue(
+            _check_tool_sequence(
+                _extract_tool_sequence(history), ["download_arxiv_pdf"]
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> Stacks on #<PR8>. Please merge that one first; this branch is rebased on it.

Three changes that make benchmark runs reproducible and make "the agent picked the right tool but the wrong paper" visible.

## 1. `--offline` replays tools from a snapshot

Every run currently hits the real arXiv API, so numbers drift with the network and with whatever arXiv returns that day.

`MockArxivEnv` already replays `data/mock_arxiv_snapshot.json` for RL rollouts. `BenchmarkRunner` now injects it as the tool env, and forces `LocalSideEffectManager` so translation is not really queued and session state is not written to MySQL — otherwise "offline" is only half offline.

Measured side effect: the framework-overhead column becomes meaningful for the first time. Tool time drops from seconds of network to under 3ms, so overhead is no longer hidden inside it.

`--snapshot` points at a different snapshot. Without `--offline` nothing changes.

## 2. `setup`: pre-seed session state without running a second agent

`depends_on` runs another full agent, LLM calls included, to leave papers in the session. That is right when the dependency is itself under test, but wrong for a task like "download the paper whose title contains X": the paper list should be a given. Forcing the agent to search first means `expected_tools` has to include the search, which is exactly the step that dilutes what the task is measuring.

`setup` calls the tools directly instead.

No bundled task uses `setup` yet — it is there so a task can *state* its precondition rather than act it out. Happy to split this out if you would rather land it alongside a task that uses it.

## 3. `arg_score` on `TaskMetrics`

The argument comparison already existed inside the RL reward and was invisible to the benchmark, which only compares tool names. A task like "download the paper titled X" that downloads the wrong paper still produces the sequence `[download_arxiv_pdf]` and was scored accurate.

The comparison moves to `benchmark/metrics.py::argument_match_score`; `rl/reward.py` calls it and keeps its `[-1, 1]` scaling, so reward semantics are unchanged (the existing 13 reward tests still pass). The report gains a 参数准确率 row and a per-run `arg_score` column.

One behaviour change falls out of sharing the parser: a JSON-wrapped terminal action no longer shifts the index alignment between actual and expected args.

## Tests

`tests/test_benchmark_offline.py`, 13 tests, no LLM, network or database.
