### PR TITLE
fix(rl): make three silent training failures loud

### DIFF
--- a/AgenticArxiv/rl/precision.py
+++ b/AgenticArxiv/rl/precision.py
@@ -1,0 +1,22 @@
+"""混合精度开关的唯一来源。
+
+原本 train_sft / train_dpo / train_grpo 各自带一份 `_precision_flags`，
+其中两份写成「只要有 CUDA 就开 fp16」。这在 bf16 权重的模型上是硬崩：
+
+    NotImplementedError: "_amp_foreach_non_finite_check_and_unscale_cuda"
+                         not implemented for 'BFloat16'
+
+fp16 的 GradScaler 不接受 bf16 梯度。现代基座模型（Qwen2.5 等）默认就是
+bf16 权重，所以这条路在任何 bf16 显卡上都走不通。
+"""
+
+
+def precision_flags() -> dict:
+    """训练器的精度参数：CUDA 上优先 bf16，退回 fp16；CPU / Apple MPS 不开混合精度。"""
+    import torch
+
+    if not torch.cuda.is_available():
+        return {}
+    if torch.cuda.is_bf16_supported():
+        return {"bf16": True}
+    return {"fp16": True}

--- a/AgenticArxiv/rl/train_dpo.py
+++ b/AgenticArxiv/rl/train_dpo.py
@@ -24,9 +24,9 @@ from datasets import load_dataset
 
 
 def _precision_flags():
-    """只有 CUDA 才开 fp16；CPU / Apple MPS 上开 fp16 会训练失败。"""
-    import torch
-    return {"fp16": True} if torch.cuda.is_available() else {}
+    """见 rl/precision.py：CUDA 上优先 bf16，退回 fp16；CPU / MPS 不开混合精度。"""
+    from rl.precision import precision_flags
+    return precision_flags()
 
 
 def main():

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -31,7 +31,7 @@ os.environ.setdefault("STORE_BACKEND", "memory")
 os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
 from datasets import Dataset
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer, TrainerCallback
 from trl import GRPOConfig, GRPOTrainer
 
 import tools.arxiv_tool  # noqa: F401  触发工具注册
@@ -51,11 +51,9 @@ DEFAULT_SNAPSHOT = REPO_ROOT / "data" / "mock_arxiv_snapshot.json"
 
 
 def _precision_flags():
-    """只有 CUDA 才开 bf16/fp16；CPU / Apple MPS 上开混合精度会训练失败。"""
-    import torch
-    if torch.cuda.is_available():
-        return {"bf16": torch.cuda.is_bf16_supported(), "fp16": not torch.cuda.is_bf16_supported()}
-    return {}
+    """见 rl/precision.py：CUDA 上优先 bf16，退回 fp16；CPU / MPS 不开混合精度。"""
+    from rl.precision import precision_flags
+    return precision_flags()
 
 
 def _gold_completion_tokens(tokenizer, tasks) -> int:
@@ -74,6 +72,58 @@ def _gold_completion_tokens(tokenizer, tasks) -> int:
     return max(lengths)
 
 
+class RewardVarianceGuard(TrainerCallback):
+    """组内奖励方差为 0 时中止训练。
+
+    GRPO 的梯度来自同一 prompt 采样出的若干条轨迹之间的奖励差异。
+    若一组内所有样本拿到同一个奖励，优势归零，这一步不产生任何梯度。
+    最常见的成因是基座模型还吐不出可解析的动作 —— 每条采样都落到解析
+    失败的地板分，方差恒为 0。
+
+    这种失败是静默的：训练照常跑完、loss 看着像在收敛（其实只是 KL 项）、
+    checkpoint 照常保存，唯一的迹象是日志里 frac_reward_zero_std 恒为 1，
+    而这一栏很容易被忽略。这里把它变成一次响亮的失败。
+    """
+
+    def __init__(self, patience: int = 5):
+        self.patience = patience
+        self.streak = 0
+        self.tripped = False
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        if not logs:
+            return
+        frac = logs.get("frac_reward_zero_std")
+        std = logs.get("reward_std")
+        if frac is None and std is None:
+            return
+        dead = (frac is not None and float(frac) >= 1.0) or (
+            frac is None and std is not None and float(std) == 0.0
+        )
+        if not dead:
+            self.streak = 0
+            return
+
+        self.streak += 1
+        if self.streak < self.patience:
+            return
+
+        self.tripped = True
+        control.should_training_stop = True
+        mean = logs.get("reward")
+        print(
+            f"\n❌ 连续 {self.streak} 步组内奖励方差为 0"
+            + (f"（奖励恒为 {float(mean):.4f}）" if mean is not None else "")
+            + "，优势全零，训练不产生任何梯度。\n"
+            "   最常见原因：基座模型还产不出可解析的 ReAct 动作，每条采样都落到解析失败的地板分。\n"
+            "   处理办法：\n"
+            "     1) 先跑 SFT 让模型学会输出格式，再用 --model outputs/sft/final 起 GRPO\n"
+            "     2) 换更强的基座模型\n"
+            "     3) 若确认是任务全在难度谱两端（全对或全错），换一批成功率居中的任务\n"
+            "   确实想继续跑，用 --allow_zero_variance 跳过本检查。"
+        )
+
+
 def main(
     model: str = "outputs/dpo/final",
     output_dir: str = "outputs/grpo",
@@ -86,6 +136,7 @@ def main(
     max_completion_length: int = 256,
     temperature: float = 1.0,
     snapshot: str = None,
+    allow_zero_variance: bool = False,
 ):
     model_path = REPO_ROOT / model
     if model_path.exists():
@@ -165,7 +216,14 @@ def main(
         train_dataset=train_dataset,
         processing_class=tokenizer,
     )
+    guard = None
+    if not allow_zero_variance:
+        guard = RewardVarianceGuard()
+        trainer.add_callback(guard)
     trainer.train()
+
+    if guard is not None and guard.tripped:
+        raise SystemExit(1)
 
     final_dir = REPO_ROOT / output_dir / "final"
     trainer.save_model(str(final_dir))
@@ -183,6 +241,11 @@ if __name__ == "__main__":
     p.add_argument("--lr", type=float, default=1e-5)
     p.add_argument("--beta", type=float, default=0.04)
     p.add_argument("--num_generations", type=int, default=4)
+    p.add_argument(
+        "--allow_zero_variance", action="store_true",
+        help="跳过「组内奖励方差为 0」检查。默认开启该检查：方差为 0 时"
+             "GRPO 不产生任何梯度，训练会静默空转",
+    )
     p.add_argument("--max_completion_length", type=int, default=256)
     p.add_argument("--temperature", type=float, default=1.0)
     p.add_argument("--snapshot", default=None)

--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -7,8 +7,10 @@ SFT（Supervised Fine-Tuning）：
 
 使用方式：
     python -m AgenticArxiv.rl.train_sft
+    python -m AgenticArxiv.rl.train_sft --model HuggingFaceTB/SmolLM2-135M-Instruct --max_length 3072
 """
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -24,62 +26,124 @@ from datasets import load_dataset
 
 
 def _precision_flags():
-    """只有 CUDA 才开 fp16；CPU / Apple MPS 上开 fp16 会训练失败。"""
-    import torch
-    return {"fp16": True} if torch.cuda.is_available() else {}
+    """见 rl/precision.py：CUDA 上优先 bf16，退回 fp16；CPU / MPS 不开混合精度。"""
+    from rl.precision import precision_flags
+    return precision_flags()
 
 
-def main():
-    """SFT 训练主函数"""
+def _messages_of(row):
+    """兼容两种数据格式：{"messages": [...]} 与 {"prompt": [...], "completion": [...]}。"""
+    if "messages" in row:
+        return list(row["messages"])
+    return list(row.get("prompt") or []) + list(row.get("completion") or [])
 
-    # 1. 配置
-    model_name = "Qwen/Qwen2.5-1.5B-Instruct"  # 基座模型
-    train_data_path = REPO_ROOT / "data" / "sft" / "sft_train.jsonl"
-    output_dir = REPO_ROOT / "outputs" / "sft"
 
-    print(f"📦 加载模型: {model_name}")
-    tokenizer = AutoTokenizer.from_pretrained(model_name)
-    model = AutoModelForCausalLM.from_pretrained(model_name)
+def _token_length(tokenizer, messages) -> int:
+    # 先渲染成字符串再计数：apply_chat_template(tokenize=True) 在 transformers 5.x
+    # 返回 BatchEncoding，len() 数到的是字段数而不是 token 数。
+    text = tokenizer.apply_chat_template(messages, tokenize=False)
+    return len(tokenizer(text)["input_ids"])
 
-    # 2. 加载 SFT 数据集
+
+def _check_lengths(tokenizer, dataset, max_length: int):
+    """样本超过 max_length 就会被从右截断，而右边正是唯一带监督信号的 assistant 部分。
+
+    截断是静默的：训练照常跑完、loss 照常下降、checkpoint 照常保存，
+    只是模型没学到任何东西。这里在训练前把它变成一次响亮的失败。
+    """
+    lengths = sorted(_token_length(tokenizer, _messages_of(row)) for row in dataset)
+    total = len(lengths)
+    if not total:
+        raise SystemExit("❌ 数据集为空")
+
+    over = sum(1 for n in lengths if n > max_length)
+    longest = lengths[-1]
+    print(
+        f"   token 长度: 中位 {lengths[total // 2]} / p90 {lengths[int(total * 0.9)]} / max {longest}"
+    )
+
+    if over > total * 0.01:
+        raise SystemExit(
+            f"❌ {over}/{total} ({over / total:.0%}) 的样本超过 max_length={max_length}，"
+            f"会被截断掉 assistant 部分，训练将无监督信号。\n"
+            f"   请改用 --max_length {longest + 64}（或缩短 prompt 中的工具描述）"
+        )
+    if over:
+        print(f"   ⚠️  {over}/{total} 个样本超过 max_length={max_length}，这部分会被截断")
+
+
+def main(
+    model: str = "Qwen/Qwen2.5-1.5B-Instruct",
+    data: str = None,
+    output_dir: str = "outputs/sft",
+    epochs: int = 3,
+    batch_size: int = 4,
+    grad_accum: int = 4,
+    lr: float = 2e-5,
+    max_length: int = 3072,
+):
+    train_data_path = Path(data) if data else REPO_ROOT / "data" / "sft" / "sft_train.jsonl"
+    out_path = REPO_ROOT / output_dir if not Path(output_dir).is_absolute() else Path(output_dir)
+
+    print(f"📦 加载模型: {model}")
+    tokenizer = AutoTokenizer.from_pretrained(model)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+    policy = AutoModelForCausalLM.from_pretrained(model)
+
     print(f"📚 加载 SFT 数据集: {train_data_path}")
-    if not Path(train_data_path).exists():
-        print(f"❌ 数据集不存在: {train_data_path}")
-        print(f"请先运行: python scripts/generate_sft_data.py")
-        return
+    if not train_data_path.exists():
+        raise SystemExit(
+            f"❌ 数据集不存在: {train_data_path}\n"
+            f"   请先运行: python scripts/generate_sft_data.py"
+        )
 
     train_dataset = load_dataset("json", data_files=str(train_data_path), split="train")
     print(f"   样本数: {len(train_dataset)}")
 
-    # 3. 配置 SFT
+    # --- 长度守卫 ---
+    _check_lengths(tokenizer, train_dataset, max_length)
+
     config = SFTConfig(
-        output_dir=str(output_dir),
-        num_train_epochs=3,
-        per_device_train_batch_size=4,
-        gradient_accumulation_steps=4,
-        learning_rate=2e-5,
-        max_length=1024,          # TRL>=0.20 用 max_length（旧名 max_seq_length 已移除）
+        output_dir=str(out_path),
+        num_train_epochs=epochs,
+        per_device_train_batch_size=batch_size,
+        gradient_accumulation_steps=grad_accum,
+        learning_rate=lr,
+        max_length=max_length,    # TRL>=0.20 用 max_length（旧名 max_seq_length 已移除）
         logging_steps=10,
         save_steps=100,
         save_total_limit=3,
         **_precision_flags(),     # 只有 CUDA 才开 fp16
     )
 
-    # 4. 训练
     print(f"🚀 开始 SFT 训练...")
     trainer = SFTTrainer(
-        model=model,
+        model=policy,
         args=config,
         train_dataset=train_dataset,
         processing_class=tokenizer,   # TRL>=0.13 用 processing_class（旧名 tokenizer 已移除）
     )
     trainer.train()
 
-    # 5. 保存
-    final_output_dir = output_dir / "final"
+    final_output_dir = out_path / "final"
     trainer.save_model(str(final_output_dir))
+    tokenizer.save_pretrained(str(final_output_dir))
     print(f"✅ SFT 训练完成，模型已保存: {final_output_dir}")
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="SFT 训练")
+    parser.add_argument("--model", default="Qwen/Qwen2.5-1.5B-Instruct")
+    parser.add_argument("--data", default=None)
+    parser.add_argument("--output_dir", default="outputs/sft")
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--batch_size", type=int, default=4)
+    parser.add_argument("--grad_accum", type=int, default=4)
+    parser.add_argument("--lr", type=float, default=2e-5)
+    parser.add_argument(
+        "--max_length", type=int, default=3072,
+        help="超过此长度的样本会被从右截断，而右边正是 assistant 目标；"
+             "训练前会做长度体检，不匹配直接报错",
+    )
+    main(**vars(parser.parse_args()))

--- a/AgenticArxiv/tests/test_training_guards.py
+++ b/AgenticArxiv/tests/test_training_guards.py
@@ -1,0 +1,142 @@
+"""训练脚本的两个「把静默失败变成响亮失败」的守卫。
+
+两个失败模式都不会让训练崩：跑完、保存 checkpoint、日志看着正常，
+只是模型什么都没学到。
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from rl.precision import precision_flags
+from rl.train_grpo import RewardVarianceGuard
+from rl.train_sft import _check_lengths, _messages_of
+
+
+class _FakeTokenizer:
+    """按字符数近似 token 数，够用来测长度守卫的分支。"""
+
+    def apply_chat_template(self, messages, tokenize=False):
+        return "".join(m.get("content", "") for m in messages)
+
+    def __call__(self, text):
+        return {"input_ids": list(range(len(text)))}
+
+
+def _row(n_prompt, n_completion):
+    return {
+        "prompt": [{"role": "user", "content": "p" * n_prompt}],
+        "completion": [{"role": "assistant", "content": "c" * n_completion}],
+    }
+
+
+class MessagesOfTest(unittest.TestCase):
+    def test_prompt_completion_format(self):
+        self.assertEqual(len(_messages_of(_row(3, 2))), 2)
+
+    def test_messages_format(self):
+        row = {"messages": [{"role": "user", "content": "x"}]}
+        self.assertEqual(_messages_of(row), row["messages"])
+
+
+class CheckLengthsTest(unittest.TestCase):
+    def test_passes_when_everything_fits(self):
+        _check_lengths(_FakeTokenizer(), [_row(10, 5)] * 4, max_length=100)
+
+    def test_aborts_when_most_samples_overflow(self):
+        # 这是实测到的真实情形：207/207 超过 max_length=1024
+        with self.assertRaises(SystemExit) as ctx:
+            _check_lengths(_FakeTokenizer(), [_row(900, 80)] * 10, max_length=100)
+        self.assertIn("max_length", str(ctx.exception))
+
+    def test_suggests_a_length_that_actually_fits(self):
+        with self.assertRaises(SystemExit) as ctx:
+            _check_lengths(_FakeTokenizer(), [_row(200, 50)] * 10, max_length=100)
+        self.assertIn("314", str(ctx.exception))     # max 250 + 64
+
+    def test_tolerates_a_single_outlier(self):
+        rows = [_row(10, 5)] * 200 + [_row(900, 80)]
+        _check_lengths(_FakeTokenizer(), rows, max_length=100)   # <=1% 只告警
+
+    def test_empty_dataset_aborts(self):
+        with self.assertRaises(SystemExit):
+            _check_lengths(_FakeTokenizer(), [], max_length=100)
+
+
+class RewardVarianceGuardTest(unittest.TestCase):
+    def _fire(self, guard, n, **logs):
+        control = SimpleNamespace(should_training_stop=False)
+        for _ in range(n):
+            guard.on_log(Mock(), Mock(), control, logs=dict(logs))
+        return control
+
+    def test_healthy_variance_never_stops(self):
+        guard = RewardVarianceGuard(patience=3)
+        control = self._fire(guard, 10, frac_reward_zero_std=0.0, reward_std=0.4)
+        self.assertFalse(control.should_training_stop)
+        self.assertFalse(guard.tripped)
+
+    def test_stops_after_patience_consecutive_dead_steps(self):
+        guard = RewardVarianceGuard(patience=3)
+        control = self._fire(guard, 3, frac_reward_zero_std=1.0, reward=-0.8393)
+        self.assertTrue(control.should_training_stop)
+        self.assertTrue(guard.tripped)
+
+    def test_does_not_stop_before_patience(self):
+        guard = RewardVarianceGuard(patience=3)
+        control = self._fire(guard, 2, frac_reward_zero_std=1.0)
+        self.assertFalse(control.should_training_stop)
+
+    def test_streak_resets_on_a_healthy_step(self):
+        guard = RewardVarianceGuard(patience=3)
+        self._fire(guard, 2, frac_reward_zero_std=1.0)
+        self._fire(guard, 1, frac_reward_zero_std=0.0)
+        control = self._fire(guard, 2, frac_reward_zero_std=1.0)
+        self.assertFalse(control.should_training_stop)
+
+    def test_falls_back_to_reward_std_when_frac_absent(self):
+        guard = RewardVarianceGuard(patience=2)
+        control = self._fire(guard, 2, reward_std=0.0)
+        self.assertTrue(control.should_training_stop)
+
+    def test_ignores_logs_without_reward_fields(self):
+        guard = RewardVarianceGuard(patience=1)
+        control = self._fire(guard, 5, loss=0.1, epoch=1.0)
+        self.assertFalse(control.should_training_stop)
+
+
+class PrecisionFlagsTest(unittest.TestCase):
+    """fp16 的 GradScaler 不接受 bf16 梯度；在 bf16 权重的模型上会硬崩：
+    NotImplementedError: _amp_foreach_non_finite_check_and_unscale_cuda ... for 'BFloat16'
+    """
+
+    def _flags(self, cuda, bf16):
+        import torch
+        from unittest.mock import patch
+        with patch.object(torch.cuda, "is_available", return_value=cuda), \
+             patch.object(torch.cuda, "is_bf16_supported", return_value=bf16):
+            return precision_flags()
+
+    def test_no_mixed_precision_off_cuda(self):
+        self.assertEqual(self._flags(cuda=False, bf16=False), {})
+
+    def test_prefers_bf16_when_supported(self):
+        self.assertEqual(self._flags(cuda=True, bf16=True), {"bf16": True})
+
+    def test_never_sets_fp16_alongside_bf16(self):
+        # 同时置位会让 GradScaler 介入 bf16 梯度，正是崩溃的来源
+        self.assertNotIn("fp16", self._flags(cuda=True, bf16=True))
+
+    def test_falls_back_to_fp16_without_bf16(self):
+        self.assertEqual(self._flags(cuda=True, bf16=False), {"fp16": True})
+
+    def test_all_three_trainers_agree(self):
+        from rl.train_dpo import _precision_flags as dpo
+        from rl.train_grpo import _precision_flags as grpo
+        from rl.train_sft import _precision_flags as sft
+        self.assertEqual(sft(), dpo())
+        self.assertEqual(dpo(), grpo())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Three defects in the training scripts. None of them fails in a way that points at the cause: two run to completion, print a decreasing loss and save a checkpoint while learning nothing, and the third dies inside the AMP scaler.

### 1. SFT truncates away the only supervised tokens

`train_sft.py` sets `max_length=1024`. Measured on the bundled `data/sft/sft_train.jsonl` with the script's own default base model (`Qwen/Qwen2.5-1.5B-Instruct`):

```
samples 207
token length:  median 1311   p90 1506   max 1770
over max_length=1024:  207/207 = 100%
completion median: 57 tokens
```

Every sample overflows. The prompt is dominated by the tool descriptions and the completion is only ~57 tokens. Truncation happens from the right, so the assistant target — the only part carrying a learning signal — is cut off, and `outputs/sft/final` is written anyway.

On TRL 1.x the examples end up fully masked and are dropped instead ("Dropping fully masked examples from train dataset"), which is louder but still leaves you guessing why the dataset shrank.

### 2. GRPO trains on zero advantage

GRPO's gradient comes from reward differences *within* a group sampled from the same prompt. When every sample in a group gets the same reward, advantages are zero and the step contributes nothing.

This happens at **both ends** of the difficulty range, which is what makes it easy to misread as "the model is bad". Both were measured here:

**Policy cannot yet emit a parseable action** (SmolLM2-135M):
```
reward               -0.8393  constant
reward_std            0
frac_reward_zero_std  1
grad_norm             0.014 - 0.05
clipped_ratio         1
mean_terminated_length 0
```

**Policy has memorised the SFT targets** (Qwen2.5-1.5B, 3 epochs, `mean_token_accuracy` 1.0, `entropy` 3.7e-4):
```
reward                1.0000  constant
reward_std            0
frac_reward_zero_std  1
grad_norm             5e-09
clipped_ratio         0
```

`-0.8393` is exactly the parse-failure reward, confirmed against `RewardCalculator`:

```
parse failure   -0.8393
bare FINISH     +0.1250
correct call    +1.0000
```

For contrast, a healthy run on the same tasks sits at `reward_std` 0.017–0.63 with `grad_norm` 4–20.5, so the two are easy to separate.

### 3. fp16 is forced on bf16 weights

`_precision_flags()` in `train_sft.py` and `train_dpo.py` returns `{"fp16": True}` whenever CUDA is available. Modern bases ship bf16 weights, and fp16's `GradScaler` cannot unscale bf16 gradients:

```
NotImplementedError: "_amp_foreach_non_finite_check_and_unscale_cuda"
                     not implemented for 'BFloat16'
```

This aborts on any bf16-capable GPU. `train_grpo.py` already had the correct version — which is the point: the helper was copy-pasted into three files and two copies never got the fix.

## Change

The first two follow the pattern already established by the `max_completion_length` guard in `train_grpo.py`: turn a silent no-op into a loud failure that names the next step.

**`rl/precision.py`** (new)
- One `precision_flags()`: bf16 on CUDA when supported, else fp16, nothing off CUDA. All three trainers call it, so the next fix cannot land in only one copy.

**`rl/train_sft.py`**
- `_check_lengths()` runs before training. Aborts if more than 1% of samples overflow and names a length that would fit; warns if a smaller fraction does.
- Default `max_length` raised 1024 → 3072.
- `argparse` added, so base model, data path, epochs and length are no longer hard-coded.
- Tokenizer saved alongside the model, so the checkpoint is loadable on its own.

One subtlety: `apply_chat_template(tokenize=True)` returns a `BatchEncoding` on transformers 5.x, so `len()` counts fields rather than tokens. The length check renders with `tokenize=False` first and then tokenizes the string.

**`rl/train_grpo.py`**
- `RewardVarianceGuard`, a `TrainerCallback` that stops training after 5 consecutive steps with zero within-group reward variance and exits non-zero. The message lists the likely causes and what to do about each.
- `--allow_zero_variance` opts out, for when you deliberately want the run to proceed.

## Verification

End to end on one A40 with `Qwen2.5-1.5B-Instruct`, tools replayed from the offline snapshot:

- SFT completes in 314s, `train_loss` 0.025, no samples dropped
- GRPO on the resulting checkpoint trips the variance guard at `reward` 1.0000 / `grad_norm` 5e-09 — the memorisation case above

## Tests

`tests/test_training_guards.py`, 18 tests, no model download, GPU or network:

- **length check** — passes when everything fits, aborts on mass overflow, suggests a length that actually fits, tolerates a single outlier, rejects an empty dataset
- **both dataset schemas** — `messages` and `prompt`/`completion`
- **variance guard** — healthy variance never stops, stops at patience, does not stop before patience, streak resets on a healthy step, falls back to `reward_std` when `frac_reward_zero_std` is absent, ignores logs with no reward fields
- **precision** — no mixed precision off CUDA, prefers bf16, never sets fp16 alongside bf16, falls back to fp16 without bf16, all three trainers agree
