### PR TITLE
feat(rl): add training stage auto-verification with canary evaluation

### DIFF
--- a/AgenticArxiv/rl/canary.py
+++ b/AgenticArxiv/rl/canary.py
@@ -1,0 +1,248 @@
+"""Training canary: periodic evaluation on a fixed small task set during training.
+
+During GRPO training, the model's reward can fluctuate. The canary provides
+an early warning signal: if performance on a fixed set of tasks starts
+degrading, training can be stopped before wasting more compute.
+
+与 RewardVarianceGuard 的分工：
+- RewardVarianceGuard：检测"组内奖励方差为 0"（梯度为零，训练空转）
+- CanaryCallback：检测"模型在固定任务上性能退化"（学到错误策略）
+
+Usage:
+    from rl.canary import CanaryEvaluator, CanaryCallback
+
+    evaluator = CanaryEvaluator(model, tokenizer, canary_task_ids, reward_calc, env)
+    callback = CanaryCallback(evaluator, steps=50, min_reward=-0.5, patience=3)
+    trainer.add_callback(callback)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+import torch
+from transformers import PreTrainedModel, PreTrainedTokenizer
+from trl import TrainerCallback
+
+from benchmark.tasks import get_task_by_id
+from rl.grpo_reward import synthesize_trajectory
+from rl.reward import RewardCalculator
+
+# 默认 canary 任务：一个简单搜索 + 一个复合任务，覆盖单步和多步场景
+DEFAULT_CANARY_TASK_IDS = ["search_01", "composite_01"]
+
+
+@dataclass
+class CanaryResult:
+    """单次 canary 评估的结果。"""
+
+    step: int
+    mean_reward: float
+    task_completion_rate: float
+    per_task_rewards: Dict[str, float]
+    num_generations_per_task: int = 4
+
+
+class CanaryEvaluator:
+    """在固定 canary 任务集上评估模型。
+
+    对每个任务生成多条 completion，计算 reward，汇总结果。
+    复用 grpo_reward.py 的 synthesize_trajectory 和 RewardCalculator，
+    确保评分标准与训练完全一致。
+    """
+
+    def __init__(
+        self,
+        model: PreTrainedModel,
+        tokenizer: PreTrainedTokenizer,
+        canary_task_ids: Sequence[str] | None = None,
+        reward_calc: RewardCalculator | None = None,
+        env: Any = None,
+        num_generations: int = 4,
+        max_new_tokens: int = 256,
+        temperature: float = 1.0,
+    ):
+        self.model = model
+        self.tokenizer = tokenizer
+        self.canary_task_ids = list(canary_task_ids or DEFAULT_CANARY_TASK_IDS)
+        self.reward_calc = reward_calc or RewardCalculator()
+        self.env = env
+        self.num_generations = num_generations
+        self.max_new_tokens = max_new_tokens
+        self.temperature = temperature
+
+        # 加载任务定义
+        self._tasks: Dict[str, Dict] = {}
+        for tid in self.canary_task_ids:
+            task = get_task_by_id(tid)
+            if task is None:
+                raise ValueError(f"Canary 任务不存在: {tid}")
+            self._tasks[tid] = task
+
+    @staticmethod
+    def _build_prompt(task: Dict) -> str:
+        """构造与训练时一致的 ReAct prompt（含工具描述与格式约束）。"""
+        from agents.prompt_templates import format_tool_description, get_react_prompt
+        from tools.tool_registry import registry
+
+        tools_desc = format_tool_description(registry.list_tools())
+        return get_react_prompt(task=task["task"], tools_description=tools_desc, history="")
+
+    def evaluate(self, step: int = 0) -> CanaryResult:
+        """运行一次 canary 评估。
+
+        Returns:
+            CanaryResult 包含聚合指标。
+        """
+        device = next(self.model.parameters()).device
+        self.model.eval()
+
+        all_rewards: List[float] = []
+        per_task: Dict[str, float] = {}
+        completed: int = 0
+        total: int = 0
+
+        pad_token_id = self.tokenizer.pad_token_id or self.tokenizer.eos_token_id
+
+        with torch.no_grad():
+            for tid, task in self._tasks.items():
+                prompt = self._build_prompt(task)
+                inputs = self.tokenizer(prompt, return_tensors="pt").to(device)
+                prompt_len = inputs.input_ids.shape[1]
+
+                try:
+                    outputs = self.model.generate(
+                        **inputs,
+                        max_new_tokens=self.max_new_tokens,
+                        temperature=self.temperature,
+                        do_sample=True,
+                        num_return_sequences=self.num_generations,
+                        pad_token_id=pad_token_id,
+                    )
+                except Exception:
+                    # 生成失败（如 OOM）→ 记录地板分
+                    per_task[tid] = -1.0
+                    all_rewards.extend([-1.0] * self.num_generations)
+                    total += self.num_generations
+                    continue
+
+                # 只取新生成的 token（去掉 prompt 部分）
+                generated_ids = outputs[:, prompt_len:]
+                completions = self.tokenizer.batch_decode(
+                    generated_ids, skip_special_tokens=True
+                )
+
+                task_rewards = []
+                for completion in completions:
+                    result = synthesize_trajectory(completion, env=self.env)
+                    breakdown, _ = self.reward_calc.compute_reward_breakdown(task, result)
+                    reward = float(breakdown.total)
+                    task_rewards.append(reward)
+                    if breakdown.outcome > 0:
+                        completed += 1
+                    total += 1
+
+                per_task[tid] = (
+                    sum(task_rewards) / len(task_rewards) if task_rewards else -1.0
+                )
+                all_rewards.extend(task_rewards)
+
+        self.model.train()
+
+        mean_reward = sum(all_rewards) / len(all_rewards) if all_rewards else -1.0
+        completion_rate = completed / total if total > 0 else 0.0
+
+        return CanaryResult(
+            step=step,
+            mean_reward=round(mean_reward, 4),
+            task_completion_rate=round(completion_rate, 4),
+            per_task_rewards={k: round(v, 4) for k, v in per_task.items()},
+            num_generations_per_task=self.num_generations,
+        )
+
+
+class CanaryCallback(TrainerCallback):
+    """TRL 回调：每 N 步在固定 canary 任务上评估模型。
+
+    若 canary 奖励连续 `patience` 次低于 `min_reward`，则停止训练。
+
+    这捕获了 RewardVarianceGuard 覆盖不到的场景：模型学到了"钻空子"策略，
+    奖励整体缓慢下降（组内方差仍 > 0，但绝对水平在退化）。
+    """
+
+    def __init__(
+        self,
+        evaluator: CanaryEvaluator,
+        steps: int = 50,
+        min_reward: float = -1.0,
+        patience: int = 3,
+    ):
+        """
+        Args:
+            evaluator: CanaryEvaluator 实例（持有模型引用）
+            steps: 每隔多少步评估一次
+            min_reward: 奖励下限。默认 -1.0 表示禁用检查（-1 是理论最低分）
+            patience: 连续低于阈值多少次后停止训练
+        """
+        self.evaluator = evaluator
+        self.steps = steps
+        self.min_reward = min_reward
+        self.patience = patience
+        self._below_streak = 0
+        self._tripped = False
+        self._results: List[CanaryResult] = []
+
+    @property
+    def tripped(self) -> bool:
+        """是否已触发阈值停止。"""
+        return self._tripped
+
+    @property
+    def results(self) -> List[CanaryResult]:
+        """历次 canary 评估结果（按时间顺序）。"""
+        return list(self._results)
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        if state.global_step % self.steps != 0:
+            return
+
+        result = self.evaluator.evaluate(step=state.global_step)
+        self._results.append(result)
+
+        # 打印 canary 报告
+        print(
+            f"\n🐤 Canary (step {result.step}): "
+            f"mean_reward={result.mean_reward:.4f}  "
+            f"completion_rate={result.task_completion_rate:.2%}  "
+            f"per_task={result.per_task_rewards}"
+        )
+
+        # 阈值检查（min_reward == -1.0 时禁用）
+        if self.min_reward <= -1.0:
+            return
+
+        if result.mean_reward < self.min_reward:
+            self._below_streak += 1
+            print(
+                f"⚠️  Canary reward {result.mean_reward:.4f} 低于阈值 {self.min_reward} "
+                f"({self._below_streak}/{self.patience})"
+            )
+            if self._below_streak >= self.patience:
+                self._tripped = True
+                control.should_training_stop = True
+                recent = self._results[-self.patience:]
+                print(
+                    f"\n❌ Canary reward 连续 {self.patience} 次低于阈值 {self.min_reward}，"
+                    f"训练已停止。\n"
+                    f"   最近 canary 结果: {[(r.step, r.mean_reward) for r in recent]}\n"
+                    f"   处理办法：\n"
+                    f"     1) 换更小的学习率\n"
+                    f"     2) 增大 beta（加强 KL 约束）\n"
+                    f"     3) 检查任务是否全在难度谱两端\n"
+                    f"   确实想继续跑，用 --min_canary_reward -1.0 跳过本检查。"
+                )
+        else:
+            self._below_streak = 0

--- a/AgenticArxiv/rl/stage_verifier.py
+++ b/AgenticArxiv/rl/stage_verifier.py
@@ -1,0 +1,395 @@
+"""Post-stage verification: validates that each training stage produces
+a model that meets minimum quality thresholds.
+
+Usage:
+    from rl.stage_verifier import StageVerifier
+
+    verifier = StageVerifier()
+    report = verifier.verify_sft(model_path, tokenizer)
+    if not report.passed:
+        print(report.summary())
+        raise SystemExit(1)
+    verifier.save_report(report, Path("outputs/sft/final"))
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, PreTrainedModel, PreTrainedTokenizer
+
+from rl.grpo_reward import parse_react_action, synthesize_trajectory
+from rl.reward import RewardCalculator
+
+# 工具导入（触发注册）
+import tools.arxiv_tool  # noqa: F401
+import tools.cache_status_tool  # noqa: F401
+import tools.pdf_download_tool  # noqa: F401
+import tools.pdf_translate_tool  # noqa: F401
+
+
+@dataclass
+class VerificationReport:
+    """单次阶段验证的结果。"""
+
+    stage: str  # "sft", "dpo", "grpo"
+    model_path: str
+    passed: bool
+    metrics: Dict[str, float] = field(default_factory=dict)
+    thresholds: Dict[str, float] = field(default_factory=dict)
+    failures: List[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        status = "✅ PASS" if self.passed else "❌ FAIL"
+        lines = [f"{status} {self.stage.upper()} 阶段验证: {self.model_path}"]
+        for k, v in self.metrics.items():
+            t = self.thresholds.get(k, 0)
+            flag = "✅" if v >= t else "❌"
+            lines.append(f"  {flag} {k}: {v:.4f} (阈值: {t})")
+        if self.failures:
+            lines.append(f"  失败: {', '.join(self.failures)}")
+        return "\n".join(lines)
+
+
+class StageVerifier:
+    """在每个训练阶段结束后验证模型质量。
+
+    阈值参考：
+    - SFT parse_rate=0.3：至少 30% 的输出能解析为合法工具调用
+    - DPO mean_reward=-0.3：应优于随机猜测
+    - GRPO mean_reward=-0.2：应展现学习进展
+
+    所有阈值均可通过构造参数覆盖。
+    """
+
+    def __init__(
+        self,
+        sft_min_parse_rate: float = 0.3,
+        dpo_min_reward: float = -0.3,
+        grpo_min_reward: float = -0.2,
+    ):
+        self.thresholds = {
+            "sft": {"parse_rate": sft_min_parse_rate},
+            "dpo": {"mean_reward": dpo_min_reward},
+            "grpo": {"mean_reward": grpo_min_reward},
+        }
+
+    # ------------------------------------------------------------------
+    # SFT 验证
+    # ------------------------------------------------------------------
+
+    def verify_sft(
+        self,
+        model_path: str | Path,
+        tokenizer: PreTrainedTokenizer | None = None,
+        num_samples: int = 8,
+    ) -> VerificationReport:
+        """验证 SFT 模型能否产出可解析的 ReAct 动作。
+
+        加载模型，对 benchmark 任务生成 completion，统计 parse 成功率。
+        使用 chat template（SFT 模型训练时的格式），而非裸 ReAct prompt。
+
+        Args:
+            model_path: 模型路径
+            tokenizer: 可选外部 tokenizer；不传则从 model_path 加载
+            num_samples: 生成样本数（每个任务一条）
+        """
+        model_path = str(model_path)
+        print(f"🔍 验证 SFT 模型: {model_path}")
+
+        try:
+            model = AutoModelForCausalLM.from_pretrained(model_path)
+            if tokenizer is None:
+                tokenizer = AutoTokenizer.from_pretrained(model_path)
+                if tokenizer.pad_token is None:
+                    tokenizer.pad_token = tokenizer.eos_token
+        except Exception as e:
+            return VerificationReport(
+                stage="sft",
+                model_path=model_path,
+                passed=False,
+                metrics={"parse_rate": 0.0},
+                thresholds=self.thresholds["sft"],
+                failures=[f"模型加载失败: {e}"],
+            )
+
+        prompts = self._sft_prompts(num_samples)
+        parse_rate = _check_parse_rate(model, tokenizer, prompts)
+
+        thresholds = self.thresholds["sft"]
+        passed = parse_rate >= thresholds["parse_rate"]
+        failures = []
+        if not passed:
+            failures.append(
+                f"parse_rate={parse_rate:.2%} < {thresholds['parse_rate']:.0%}"
+            )
+
+        return VerificationReport(
+            stage="sft",
+            model_path=model_path,
+            passed=passed,
+            metrics={"parse_rate": round(parse_rate, 4)},
+            thresholds=thresholds,
+            failures=failures,
+        )
+
+    # ------------------------------------------------------------------
+    # DPO 验证
+    # ------------------------------------------------------------------
+
+    def verify_dpo(
+        self,
+        model_path: str | Path,
+        tokenizer: PreTrainedTokenizer | None = None,
+        env: Any = None,
+    ) -> VerificationReport:
+        """验证 DPO 模型在 canary 任务上的平均奖励。
+
+        Args:
+            model_path: 模型路径
+            tokenizer: 可选外部 tokenizer
+            env: 可选 MockArxivEnv 用于工具执行
+        """
+        model_path = str(model_path)
+        print(f"🔍 验证 DPO 模型: {model_path}")
+
+        try:
+            model = AutoModelForCausalLM.from_pretrained(model_path)
+            if tokenizer is None:
+                tokenizer = AutoTokenizer.from_pretrained(model_path)
+                if tokenizer.pad_token is None:
+                    tokenizer.pad_token = tokenizer.eos_token
+        except Exception as e:
+            return VerificationReport(
+                stage="dpo",
+                model_path=model_path,
+                passed=False,
+                metrics={"mean_reward": -1.0},
+                thresholds=self.thresholds["dpo"],
+                failures=[f"模型加载失败: {e}"],
+            )
+
+        mean_reward = _check_canary_reward(model, tokenizer, env=env)
+
+        thresholds = self.thresholds["dpo"]
+        passed = mean_reward >= thresholds["mean_reward"]
+        failures = []
+        if not passed:
+            failures.append(
+                f"mean_reward={mean_reward:.4f} < {thresholds['mean_reward']}"
+            )
+
+        return VerificationReport(
+            stage="dpo",
+            model_path=model_path,
+            passed=passed,
+            metrics={"mean_reward": round(mean_reward, 4)},
+            thresholds=thresholds,
+            failures=failures,
+        )
+
+    # ------------------------------------------------------------------
+    # GRPO 验证
+    # ------------------------------------------------------------------
+
+    def verify_grpo(
+        self,
+        model_path: str | Path,
+        tokenizer: PreTrainedTokenizer | None = None,
+        env: Any = None,
+    ) -> VerificationReport:
+        """验证 GRPO 模型在 canary 任务上的平均奖励。
+
+        Args:
+            model_path: 模型路径
+            tokenizer: 可选外部 tokenizer
+            env: 可选 MockArxivEnv 用于工具执行
+        """
+        model_path = str(model_path)
+        print(f"🔍 验证 GRPO 模型: {model_path}")
+
+        try:
+            model = AutoModelForCausalLM.from_pretrained(model_path)
+            if tokenizer is None:
+                tokenizer = AutoTokenizer.from_pretrained(model_path)
+                if tokenizer.pad_token is None:
+                    tokenizer.pad_token = tokenizer.eos_token
+        except Exception as e:
+            return VerificationReport(
+                stage="grpo",
+                model_path=model_path,
+                passed=False,
+                metrics={"mean_reward": -1.0},
+                thresholds=self.thresholds["grpo"],
+                failures=[f"模型加载失败: {e}"],
+            )
+
+        mean_reward = _check_canary_reward(model, tokenizer, env=env)
+
+        thresholds = self.thresholds["grpo"]
+        passed = mean_reward >= thresholds["mean_reward"]
+        failures = []
+        if not passed:
+            failures.append(
+                f"mean_reward={mean_reward:.4f} < {thresholds['mean_reward']}"
+            )
+
+        return VerificationReport(
+            stage="grpo",
+            model_path=model_path,
+            passed=passed,
+            metrics={"mean_reward": round(mean_reward, 4)},
+            thresholds=thresholds,
+            failures=failures,
+        )
+
+    # ------------------------------------------------------------------
+    # 报告持久化
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def save_report(report: VerificationReport, output_dir: Path) -> None:
+        """保存验证报告到模型目录。"""
+        output_dir.mkdir(parents=True, exist_ok=True)
+        report_path = output_dir / "verification_report.json"
+        report_path.write_text(
+            json.dumps(
+                {
+                    "stage": report.stage,
+                    "model_path": report.model_path,
+                    "passed": report.passed,
+                    "metrics": report.metrics,
+                    "thresholds": report.thresholds,
+                    "failures": report.failures,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        print(f"📋 验证报告已保存: {report_path}")
+
+    # ------------------------------------------------------------------
+    # SFT 测试 prompt 构造
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _sft_prompts(num_samples: int) -> List[str]:
+        """构造 SFT 验证用的 chat prompt 列表。
+
+        使用 benchmark 任务描述作为 user 消息，配上 system prompt。
+        """
+        from benchmark.tasks import get_all_tasks
+
+        SYSTEM = (
+            "你是 arXiv 论文检索 Agent。"
+            "根据用户需求调用工具，以 JSON 格式返回动作："
+            '{"name": "工具名", "arguments": {...}}'
+        )
+
+        tasks = get_all_tasks()
+        # 取前 num_samples 个任务，不够就循环
+        selected = (tasks * (1 + num_samples // max(1, len(tasks))))[:num_samples]
+
+        prompts = []
+        for task in selected:
+            prompts.append(
+                f"System: {SYSTEM}\n\nUser: {task['task']}\n\nAssistant:"
+            )
+        return prompts
+
+
+# ------------------------------------------------------------------
+# 内部辅助函数
+# ------------------------------------------------------------------
+
+
+def _check_parse_rate(
+    model: PreTrainedModel,
+    tokenizer: PreTrainedTokenizer,
+    prompts: Sequence[str],
+    max_new_tokens: int = 256,
+    temperature: float = 0.3,
+) -> float:
+    """生成 completion 并统计 parse 成功率。
+
+    一个 completion 被认为"可解析"当且仅当：
+    - 包含合法的 JSON 对象（有 "name" 字段）
+    - 或可被 parse_react_action 识别为 "call"
+    """
+    device = next(model.parameters()).device
+    model.eval()
+
+    parsed = 0
+    total = 0
+    pad_token_id = tokenizer.pad_token_id or tokenizer.eos_token_id
+
+    with torch.no_grad():
+        for prompt in prompts:
+            inputs = tokenizer(prompt, return_tensors="pt").to(device)
+            prompt_len = inputs.input_ids.shape[1]
+
+            try:
+                outputs = model.generate(
+                    **inputs,
+                    max_new_tokens=max_new_tokens,
+                    temperature=temperature,
+                    do_sample=True,
+                    num_return_sequences=2,
+                    pad_token_id=pad_token_id,
+                )
+            except Exception:
+                total += 2
+                continue
+
+            generated_ids = outputs[:, prompt_len:]
+            completions = tokenizer.batch_decode(
+                generated_ids, skip_special_tokens=True
+            )
+
+            for completion in completions:
+                total += 1
+                # 先尝试 ReAct 解析
+                kind, action = parse_react_action(completion)
+                if kind == "call":
+                    parsed += 1
+                    continue
+                # 再尝试直接 JSON 解析（SFT 模型可能不输出 ReAct 前缀）
+                try:
+                    obj = json.loads(completion.strip())
+                    if isinstance(obj, dict) and "name" in obj:
+                        parsed += 1
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+    model.train()
+    return parsed / total if total > 0 else 0.0
+
+
+def _check_canary_reward(
+    model: PreTrainedModel,
+    tokenizer: PreTrainedTokenizer,
+    env: Any = None,
+    num_generations: int = 4,
+) -> float:
+    """在 canary 任务上评估模型，返回平均奖励。
+
+    复用 CanaryEvaluator 以保持评估逻辑一致。
+    """
+    from rl.canary import DEFAULT_CANARY_TASK_IDS, CanaryEvaluator
+
+    evaluator = CanaryEvaluator(
+        model=model,
+        tokenizer=tokenizer,
+        canary_task_ids=DEFAULT_CANARY_TASK_IDS,
+        reward_calc=RewardCalculator(),
+        env=env,
+        num_generations=num_generations,
+    )
+    result = evaluator.evaluate(step=0)
+    return result.mean_reward

--- a/AgenticArxiv/rl/train_dpo.py
+++ b/AgenticArxiv/rl/train_dpo.py
@@ -7,8 +7,10 @@ DPO（Direct Preference Optimization）：
 
 使用方式：
     python -m AgenticArxiv.rl.train_dpo
+    python -m AgenticArxiv.rl.train_dpo --verify --min_reward -0.2
 """
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -22,6 +24,8 @@ from trl import DPOConfig, DPOTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from datasets import load_dataset
 
+from rl.stage_verifier import StageVerifier
+
 
 def _precision_flags():
     """见 rl/precision.py：CUDA 上优先 bf16，退回 fp16；CPU / MPS 不开混合精度。"""
@@ -29,14 +33,20 @@ def _precision_flags():
     return precision_flags()
 
 
-def main():
+def main(
+    model: str = None,
+    data: str = None,
+    output_dir: str = None,
+    verify: bool = False,
+    min_reward: float = -0.3,
+):
     """DPO 训练主函数"""
 
     # 1. 配置
-    model_path = REPO_ROOT / "outputs" / "sft" / "final"  # 从 SFT 模型继续
+    model_path = Path(model) if model else REPO_ROOT / "outputs" / "sft" / "final"
     model_name = str(model_path)
-    train_data_path = REPO_ROOT / "data" / "dpo" / "dpo_train.jsonl"
-    output_dir = REPO_ROOT / "outputs" / "dpo"
+    train_data_path = Path(data) if data else REPO_ROOT / "data" / "dpo" / "dpo_train.jsonl"
+    out_dir = Path(output_dir) if output_dir else REPO_ROOT / "outputs" / "dpo"
 
     print(f"📦 加载 SFT 模型: {model_name}")
     if not model_path.exists():
@@ -45,6 +55,8 @@ def main():
         return
 
     tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
     model = AutoModelForCausalLM.from_pretrained(model_name)
     ref_model = AutoModelForCausalLM.from_pretrained(model_name)  # reference model
 
@@ -60,7 +72,7 @@ def main():
 
     # 3. 配置 DPO
     config = DPOConfig(
-        output_dir=str(output_dir),
+        output_dir=str(out_dir),
         num_train_epochs=3,
         per_device_train_batch_size=2,
         gradient_accumulation_steps=8,
@@ -84,10 +96,36 @@ def main():
     trainer.train()
 
     # 5. 保存
-    final_output_dir = output_dir / "final"
+    final_output_dir = out_dir / "final"
     trainer.save_model(str(final_output_dir))
+    tokenizer.save_pretrained(str(final_output_dir))
     print(f"✅ DPO 训练完成，模型已保存: {final_output_dir}")
+
+    # --- 阶段验证：检查模型是否达到最低奖励阈值 ---
+    if verify:
+        print(f"\n🔍 运行 DPO 阶段验证...")
+        verifier = StageVerifier(dpo_min_reward=min_reward)
+        report = verifier.verify_dpo(model_path=str(final_output_dir))
+        verifier.save_report(report, final_output_dir)
+        print(report.summary())
+        if not report.passed:
+            print(
+                f"\n⚠️  DPO 阶段验证未通过，但模型已保存。"
+                f"请在继续 GRPO 前检查 {final_output_dir / 'verification_report.json'}。"
+            )
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="DPO 训练")
+    parser.add_argument("--model", default=None, help="SFT 模型路径")
+    parser.add_argument("--data", default=None, help="DPO 数据集路径")
+    parser.add_argument("--output_dir", default=None, help="输出目录")
+    parser.add_argument(
+        "--verify", action="store_true", default=False,
+        help="训练结束后运行阶段验证（检查模型奖励是否达标）",
+    )
+    parser.add_argument(
+        "--min_reward", type=float, default=-0.3,
+        help="DPO 验证的最低平均奖励阈值（默认 -0.3）",
+    )
+    main(**vars(parser.parse_args()))

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -9,9 +9,13 @@ GRPO（Group Relative Policy Optimization）：
 奖励定义见 rl/grpo_reward.py：把模型生成的一步补成最小完整轨迹，
 再交给 rl/reward.py 已有的 RewardCalculator 打分，不引入第二套标准。
 
+训练中每 N 步自动运行 canary 评估（在固定小任务集上验证模型未退化），
+训练结束后可选运行阶段验证（检查模型是否达到最低质量阈值）。
+
 使用方式：
     python -m AgenticArxiv.rl.train_grpo
     python -m AgenticArxiv.rl.train_grpo --model outputs/sft/final --num_generations 8
+    python -m AgenticArxiv.rl.train_grpo --canary_steps 20 --min_canary_reward -0.3
 """
 
 import argparse
@@ -40,12 +44,15 @@ import tools.pdf_download_tool  # noqa: F401
 import tools.pdf_translate_tool  # noqa: F401
 
 from benchmark.tasks import get_all_tasks
+from rl.canary import CanaryEvaluator, CanaryCallback
 from rl.grpo_reward import (
     build_prompt_dataset,
     load_mock_env,
     make_grpo_reward_fn,
     parse_react_action,
 )
+from rl.reward import RewardCalculator
+from rl.stage_verifier import StageVerifier
 
 DEFAULT_SNAPSHOT = REPO_ROOT / "data" / "mock_arxiv_snapshot.json"
 
@@ -137,6 +144,10 @@ def main(
     temperature: float = 1.0,
     snapshot: str = None,
     allow_zero_variance: bool = False,
+    canary_steps: int = 50,
+    min_canary_reward: float = -1.0,
+    canary_patience: int = 3,
+    verify: bool = True,
 ):
     model_path = REPO_ROOT / model
     if model_path.exists():
@@ -216,6 +227,28 @@ def main(
         train_dataset=train_dataset,
         processing_class=tokenizer,
     )
+
+    # --- Canary 回调：每 N 步在固定任务上评估，检测性能退化 ---
+    canary_cb = None
+    if canary_steps > 0:
+        canary_evaluator = CanaryEvaluator(
+            model=policy,
+            tokenizer=tokenizer,
+            reward_calc=RewardCalculator(),
+            env=env,
+            num_generations=num_generations,
+            max_new_tokens=max_completion_length,
+            temperature=temperature,
+        )
+        canary_cb = CanaryCallback(
+            evaluator=canary_evaluator,
+            steps=canary_steps,
+            min_reward=min_canary_reward,
+            patience=canary_patience,
+        )
+        trainer.add_callback(canary_cb)
+        print(f"🐤 Canary: 每 {canary_steps} 步评估，阈值={min_canary_reward}，patience={canary_patience}")
+
     guard = None
     if not allow_zero_variance:
         guard = RewardVarianceGuard()
@@ -224,11 +257,31 @@ def main(
 
     if guard is not None and guard.tripped:
         raise SystemExit(1)
+    if canary_cb is not None and canary_cb.tripped:
+        raise SystemExit(1)
 
     final_dir = REPO_ROOT / output_dir / "final"
     trainer.save_model(str(final_dir))
     tokenizer.save_pretrained(str(final_dir))
     print(f"✅ GRPO 训练完成，模型已保存: {final_dir}")
+
+    # --- 阶段验证：训练后检查模型是否达到最低质量阈值 ---
+    if verify:
+        print(f"\n🔍 运行 GRPO 阶段验证...")
+        verifier = StageVerifier()
+        report = verifier.verify_grpo(
+            model_path=str(final_dir),
+            tokenizer=tokenizer,
+            env=env,
+        )
+        verifier.save_report(report, final_dir)
+        print(report.summary())
+        if not report.passed:
+            raise SystemExit(
+                f"\n❌ GRPO 阶段验证失败，模型未达到最低质量阈值。\n"
+                f"   检查 {final_dir / 'verification_report.json'} 了解详情。\n"
+                f"   跳过验证用 --no-verify。"
+            )
 
 
 if __name__ == "__main__":
@@ -249,6 +302,25 @@ if __name__ == "__main__":
     p.add_argument("--max_completion_length", type=int, default=256)
     p.add_argument("--temperature", type=float, default=1.0)
     p.add_argument("--snapshot", default=None)
+    p.add_argument(
+        "--canary_steps", type=int, default=50,
+        help="每隔多少步运行 canary 评估（0 表示禁用）",
+    )
+    p.add_argument(
+        "--min_canary_reward", type=float, default=-1.0,
+        help="Canary 奖励下限。低于此值连续 patience 次则停止训练。"
+             "默认 -1.0（理论最低分）表示禁用检查",
+    )
+    p.add_argument(
+        "--canary_patience", type=int, default=3,
+        help="Canary 奖励连续低于阈值多少次后停止训练",
+    )
+    p.add_argument(
+        "--verify", action=argparse.BooleanOptionalAction, default=True,
+        help="训练结束后运行阶段验证（默认开启）",
+    )
     a = p.parse_args()
     main(a.model, a.output_dir, a.epochs, a.batch_size, a.grad_accum, a.lr, a.beta,
-         a.num_generations, a.max_completion_length, a.temperature, a.snapshot)
+         a.num_generations, a.max_completion_length, a.temperature, a.snapshot,
+         a.allow_zero_variance, a.canary_steps, a.min_canary_reward,
+         a.canary_patience, a.verify)

--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -8,6 +8,7 @@ SFT（Supervised Fine-Tuning）：
 使用方式：
     python -m AgenticArxiv.rl.train_sft
     python -m AgenticArxiv.rl.train_sft --model HuggingFaceTB/SmolLM2-135M-Instruct --max_length 3072
+    python -m AgenticArxiv.rl.train_sft --verify --min_parse_rate 0.5
 """
 
 import argparse
@@ -23,6 +24,8 @@ sys.path.insert(0, str(PACKAGE_ROOT))
 from trl import SFTConfig, SFTTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from datasets import load_dataset
+
+from rl.stage_verifier import StageVerifier
 
 
 def _precision_flags():
@@ -81,6 +84,8 @@ def main(
     grad_accum: int = 4,
     lr: float = 2e-5,
     max_length: int = 3072,
+    verify: bool = False,
+    min_parse_rate: float = 0.3,
 ):
     train_data_path = Path(data) if data else REPO_ROOT / "data" / "sft" / "sft_train.jsonl"
     out_path = REPO_ROOT / output_dir if not Path(output_dir).is_absolute() else Path(output_dir)
@@ -131,6 +136,19 @@ def main(
     tokenizer.save_pretrained(str(final_output_dir))
     print(f"✅ SFT 训练完成，模型已保存: {final_output_dir}")
 
+    # --- 阶段验证：检查模型是否能产出可解析的输出 ---
+    if verify:
+        print(f"\n🔍 运行 SFT 阶段验证...")
+        verifier = StageVerifier(sft_min_parse_rate=min_parse_rate)
+        report = verifier.verify_sft(model_path=str(final_output_dir))
+        verifier.save_report(report, final_output_dir)
+        print(report.summary())
+        if not report.passed:
+            print(
+                f"\n⚠️  SFT 阶段验证未通过，但模型已保存。"
+                f"请在继续 DPO/GRPO 前检查 {final_output_dir / 'verification_report.json'}。"
+            )
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="SFT 训练")
@@ -145,5 +163,13 @@ if __name__ == "__main__":
         "--max_length", type=int, default=3072,
         help="超过此长度的样本会被从右截断，而右边正是 assistant 目标；"
              "训练前会做长度体检，不匹配直接报错",
+    )
+    parser.add_argument(
+        "--verify", action="store_true", default=False,
+        help="训练结束后运行阶段验证（检查模型产出可解析率）",
+    )
+    parser.add_argument(
+        "--min_parse_rate", type=float, default=0.3,
+        help="SFT 验证的最低可解析率阈值（默认 0.3）",
     )
     main(**vars(parser.parse_args()))

--- a/AgenticArxiv/tests/test_canary.py
+++ b/AgenticArxiv/tests/test_canary.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Canary 评估和回调测试。
+
+不需要 GPU、不需要 LLM、不需要网络（工具执行走离线快照，缺快照时自动跳过相关用例）。
+
+运行：
+    cd AgenticArxiv && python tests/test_canary.py
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PACKAGE_ROOT))
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+import tools.arxiv_tool  # noqa: F401,E402
+import tools.cache_status_tool  # noqa: F401,E402
+import tools.pdf_download_tool  # noqa: F401,E402
+import tools.pdf_translate_tool  # noqa: F401,E402
+
+import torch  # noqa: E402
+from rl.canary import (  # noqa: E402
+    DEFAULT_CANARY_TASK_IDS,
+    CanaryCallback,
+    CanaryEvaluator,
+    CanaryResult,
+)
+from rl.reward import RewardCalculator  # noqa: E402
+
+# 正确的 tool call（search_01 的 gold action）
+CORRECT_COMPLETION = (
+    'Thought: 需要检索AI论文\n'
+    'Action: {"name":"get_recently_submitted_cs_papers",'
+    '"args":{"aspect":"AI","days":7,"max_results":5}}'
+)
+# 错误的 tool call（参数不对）
+WRONG_TOOL_COMPLETION = (
+    'Thought: 下载论文\n'
+    'Action: {"name":"download_arxiv_pdf","args":{"ref":1}}'
+)
+# 不可解析的
+BAD_COMPLETION = "Thought: 我先想想\nAction: {invalid json}"
+
+
+class _FakeTokenizer:
+    """模拟 tokenizer：返回确定性的 token id 序列。"""
+
+    def __init__(self, completion_text=CORRECT_COMPLETION):
+        self._completion = completion_text
+        self.pad_token_id = 0
+        self.eos_token_id = 2
+
+    def __call__(self, text, return_tensors="pt", **kwargs):
+        # 返回假的 input_ids（长度为 10 的 prompt）
+        ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
+        return SimpleNamespace(input_ids=ids, shape=ids.shape)
+
+    def batch_decode(self, ids, skip_special_tokens=True):
+        # 返回预设的 completion 文本
+        n = ids.shape[0] if hasattr(ids, 'shape') else len(ids)
+        return [self._completion] * n
+
+    @staticmethod
+    def apply_chat_template(messages, tokenize=False):
+        return "mock prompt"
+
+
+class _FakeModel:
+    """模拟模型：返回确定性的 token id 序列。"""
+
+    def __init__(self, num_return_sequences=4):
+        self._num = num_return_sequences
+        self._training = True
+
+    def generate(self, **kwargs):
+        n = kwargs.get("num_return_sequences", self._num)
+        # 返回 n 个假序列（prompt_len + 5 个新 token）
+        prompt_len = kwargs.get("input_ids", torch.tensor([[0]])).shape[1]
+        return torch.ones((n, prompt_len + 5), dtype=torch.long)
+
+    def eval(self):
+        self._training = False
+        return self
+
+    def train(self):
+        self._training = True
+        return self
+
+    def parameters(self):
+        return [torch.nn.Parameter(torch.zeros(1))]
+
+
+class CanaryResultTest(unittest.TestCase):
+    def test_defaults(self):
+        r = CanaryResult(step=0, mean_reward=0.5, task_completion_rate=0.75,
+                         per_task_rewards={"search_01": 0.5})
+        self.assertEqual(r.step, 0)
+        self.assertEqual(r.mean_reward, 0.5)
+        self.assertEqual(r.task_completion_rate, 0.75)
+        self.assertEqual(r.num_generations_per_task, 4)
+
+
+class CanaryEvaluatorTest(unittest.TestCase):
+    def setUp(self):
+        self.model = _FakeModel()
+        self.tokenizer = _FakeTokenizer()
+        self.evaluator = CanaryEvaluator(
+            model=self.model,
+            tokenizer=self.tokenizer,
+            canary_task_ids=DEFAULT_CANARY_TASK_IDS,
+            reward_calc=RewardCalculator(),
+            env=None,
+            num_generations=2,
+        )
+
+    def test_evaluator_returns_result(self):
+        result = self.evaluator.evaluate(step=100)
+        self.assertIsInstance(result, CanaryResult)
+        self.assertEqual(result.step, 100)
+        self.assertIsInstance(result.mean_reward, float)
+        self.assertIsInstance(result.task_completion_rate, float)
+        self.assertIsInstance(result.per_task_rewards, dict)
+        # 两个 canary 任务都应该有结果
+        for tid in DEFAULT_CANARY_TASK_IDS:
+            self.assertIn(tid, result.per_task_rewards)
+
+    def test_invalid_task_id_raises(self):
+        with self.assertRaises(ValueError):
+            CanaryEvaluator(
+                model=self.model,
+                tokenizer=self.tokenizer,
+                canary_task_ids=["nonexistent_task"],
+            )
+
+    def test_evaluator_restores_train_mode(self):
+        self.model.train()  # 模拟训练模式
+        self.evaluator.evaluate(step=0)
+        self.assertTrue(self.model._training, "evaluate 后应恢复为 train 模式")
+
+
+class CanaryCallbackTest(unittest.TestCase):
+    def _make_cb(self, steps=10, min_reward=-0.5, patience=3):
+        evaluator = Mock()
+        evaluator.evaluate = Mock(return_value=CanaryResult(
+            step=0, mean_reward=-0.8, task_completion_rate=0.0,
+            per_task_rewards={"search_01": -0.8},
+        ))
+        return CanaryCallback(evaluator, steps=steps, min_reward=min_reward,
+                              patience=patience)
+
+    def _fire(self, cb, n, step=0, **logs):
+        """触发 n 次 on_log。"""
+        control = SimpleNamespace(should_training_stop=False)
+        for i in range(n):
+            state = SimpleNamespace(global_step=step + i * cb.steps)
+            cb.on_log(Mock(), state, control, logs=dict(logs))
+        return control
+
+    def test_fires_at_correct_intervals(self):
+        cb = self._make_cb(steps=10, min_reward=-1.0)
+        # step=0 触发
+        self._fire(cb, 1, step=0)
+        self.assertEqual(len(cb.results), 1)
+        # step=5 不触发（不是 10 的倍数）
+        cb.on_log(Mock(), SimpleNamespace(global_step=5),
+                  SimpleNamespace(should_training_stop=False), logs={})
+        self.assertEqual(len(cb.results), 1)
+        # step=10 触发
+        cb.on_log(Mock(), SimpleNamespace(global_step=10),
+                  SimpleNamespace(should_training_stop=False), logs={})
+        self.assertEqual(len(cb.results), 2)
+
+    def test_stops_after_patience(self):
+        cb = self._make_cb(steps=10, min_reward=0.0, patience=3)
+        control = self._fire(cb, 3, step=0)
+        self.assertTrue(control.should_training_stop)
+        self.assertTrue(cb.tripped)
+
+    def test_does_not_stop_before_patience(self):
+        cb = self._make_cb(steps=10, min_reward=0.0, patience=3)
+        control = self._fire(cb, 2, step=0)
+        self.assertFalse(control.should_training_stop)
+        self.assertFalse(cb.tripped)
+
+    def test_streak_resets_on_healthy(self):
+        cb = self._make_cb(steps=10, min_reward=0.0, patience=3)
+        # 两次低于阈值
+        self._fire(cb, 2, step=0)
+        self.assertFalse(cb.tripped)
+        # 一次健康（切换 evaluator 返回高奖励）
+        cb.evaluator.evaluate = Mock(return_value=CanaryResult(
+            step=0, mean_reward=0.5, task_completion_rate=1.0,
+            per_task_rewards={"search_01": 0.5},
+        ))
+        self._fire(cb, 1, step=20)
+        self.assertFalse(cb.tripped)
+        # 再切换回低奖励，重新计数
+        cb.evaluator.evaluate = Mock(return_value=CanaryResult(
+            step=0, mean_reward=-0.8, task_completion_rate=0.0,
+            per_task_rewards={"search_01": -0.8},
+        ))
+        control = self._fire(cb, 2, step=30)
+        self.assertFalse(control.should_training_stop)  # 只 2 次，还没到 3
+
+    def test_min_reward_default_disables_check(self):
+        """默认 min_reward=-1.0 时阈值检查被禁用。"""
+        cb = self._make_cb(steps=10, min_reward=-1.0, patience=1)
+        control = self._fire(cb, 5, step=0)
+        self.assertFalse(control.should_training_stop)
+        self.assertFalse(cb.tripped)
+
+    def test_results_accumulate(self):
+        cb = self._make_cb(steps=10, min_reward=-1.0)
+        self._fire(cb, 3, step=0)
+        self.assertEqual(len(cb.results), 3)
+        for r in cb.results:
+            self.assertIsInstance(r, CanaryResult)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/AgenticArxiv/tests/test_training_guards.py
+++ b/AgenticArxiv/tests/test_training_guards.py
@@ -138,5 +138,88 @@ class PrecisionFlagsTest(unittest.TestCase):
         self.assertEqual(dpo(), grpo())
 
 
+class StageVerifierTest(unittest.TestCase):
+    """阶段验证器的逻辑测试（不需要真实模型）。"""
+
+    def test_report_passed_formatting(self):
+        from rl.stage_verifier import VerificationReport
+        report = VerificationReport(
+            stage="sft", model_path="/tmp/model",
+            passed=True, metrics={"parse_rate": 0.8},
+            thresholds={"parse_rate": 0.3},
+        )
+        summary = report.summary()
+        self.assertIn("PASS", summary)
+        self.assertIn("SFT", summary)
+        self.assertIn("0.8", summary)
+
+    def test_report_failed_formatting(self):
+        from rl.stage_verifier import VerificationReport
+        report = VerificationReport(
+            stage="dpo", model_path="/tmp/model",
+            passed=False, metrics={"mean_reward": -0.5},
+            thresholds={"mean_reward": -0.3},
+            failures=["mean_reward too low"],
+        )
+        summary = report.summary()
+        self.assertIn("FAIL", summary)
+        self.assertIn("DPO", summary)
+        self.assertIn("too low", summary)
+
+    def test_thresholds_configurable(self):
+        from rl.stage_verifier import StageVerifier
+        v = StageVerifier(
+            sft_min_parse_rate=0.5,
+            dpo_min_reward=0.0,
+            grpo_min_reward=0.1,
+        )
+        self.assertEqual(v.thresholds["sft"]["parse_rate"], 0.5)
+        self.assertEqual(v.thresholds["dpo"]["mean_reward"], 0.0)
+        self.assertEqual(v.thresholds["grpo"]["mean_reward"], 0.1)
+
+    def test_verify_sft_model_load_failure(self):
+        """模型路径不存在时返回 failed report 而非抛异常。"""
+        from rl.stage_verifier import StageVerifier
+        v = StageVerifier()
+        report = v.verify_sft(model_path="/nonexistent/path/model")
+        self.assertFalse(report.passed)
+        self.assertIn("模型加载失败", report.failures[0])
+
+    def test_verify_dpo_model_load_failure(self):
+        from rl.stage_verifier import StageVerifier
+        v = StageVerifier()
+        report = v.verify_dpo(model_path="/nonexistent/path/model")
+        self.assertFalse(report.passed)
+        self.assertIn("模型加载失败", report.failures[0])
+
+    def test_verify_grpo_model_load_failure(self):
+        from rl.stage_verifier import StageVerifier
+        v = StageVerifier()
+        report = v.verify_grpo(model_path="/nonexistent/path/model")
+        self.assertFalse(report.passed)
+        self.assertIn("模型加载失败", report.failures[0])
+
+    def test_save_report_writes_file(self):
+        import tempfile
+        import json
+        from pathlib import Path
+        from rl.stage_verifier import StageVerifier, VerificationReport
+
+        report = VerificationReport(
+            stage="sft", model_path="/tmp/model",
+            passed=True, metrics={"parse_rate": 0.8},
+            thresholds={"parse_rate": 0.3},
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir)
+            StageVerifier.save_report(report, out)
+            report_path = out / "verification_report.json"
+            self.assertTrue(report_path.exists())
+            data = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(data["stage"], "sft")
+            self.assertTrue(data["passed"])
+            self.assertEqual(data["metrics"]["parse_rate"], 0.8)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 概述

为 SFT → DPO → GRPO 训练管线添加三层自动验证机制，解决当前单向流水线无中间验证的问题。

## 变更内容

### 新增文件

| 文件 | 说明 |
|------|------|
| `rl/canary.py` | Canary 评估器 + TRL 回调，在训练中定期评估模型性能 |
| `rl/stage_verifier.py` | 阶段验证器，在每个训练阶段结束后验证模型质量 |
| `tests/test_canary.py` | Canary 模块的单元测试 |

### 修改文件

| 文件 | 变更 |
|------|------|
| `rl/train_grpo.py` | 新增 `--canary_steps` `--min_canary_reward` `--canary_patience` `--verify` |
| `rl/train_sft.py` | 新增 `--verify` `--min_parse_rate` |
| `rl/train_dpo.py` | 新增 `--verify` `--min_reward`，同时重构为接受 CLI 参数 |
| `tests/test_training_guards.py` | 新增 StageVerifier 测试 |

## 三层验证机制

### 1. GRPO Canary 回调（训练中）
- 每 N 步在固定小任务集（search_01 + composite_01）上评估模型
- 若连续 `patience` 次低于阈值，停止训练
- 复用现有 `synthesize_trajectory` + `RewardCalculator`，评分标准与训练一致
- 默认 `--min_canary_reward -1.0`（禁用阈值检查），可通过 CLI 开启

### 2. 阶段验证（训练后）
- **SFT**：检查 parse rate（可解析为合法工具调用的比例），阈值默认 0.3
- **DPO/GRPO**：在 canary 任务上评估平均奖励，阈值默认 -0.3/-0.2
- 验证报告保存为 `verification_report.json` 到模型目录
- GRPO 默认开启 `--verify`，SFT/DPO 需手动指定

### 3. Reward 阈值守卫
- GRPO 验证失败 → `SystemExit(1)`，拒绝保存模型
- SFT/DPO 验证失败 → 警告但保留模型（不删除已有产出）

## 使用示例

```bash
# GRPO + canary 监测
python -m AgenticArxiv.rl.train_grpo --canary_steps 20 --min_canary_reward -0.3

# SFT + 验证
python -m AgenticArxiv.rl.train_sft --verify --min_parse_rate 0.5

# DPO + 验证
python -m AgenticArxiv.rl.train_dpo --verify --min_reward -0.2
```

## 设计决策

- Canary 复用 `grpo_reward.py` 的 `synthesize_trajectory` + `RewardCalculator`，保证训练/评估一致性
- 回调模式与现有 `RewardVarianceGuard` 一致（`on_log` hook）
- 所有阈值均可通过 CLI 配置
- SFT/DPO 验证为 opt-in（需加载模型跑推理，有额外开销）