### PR TITLE
feat(rl): generate DPO data from local SFT model

### DIFF
--- a/AgenticArxiv/tests/test_dpo_pairs.py
+++ b/AgenticArxiv/tests/test_dpo_pairs.py
@@ -68,6 +68,16 @@ class TestBuildPreferencePair(unittest.TestCase):
         self.assertEqual(pair["chosen"], SEARCH)
         self.assertEqual(pair["rejected"], DOWNLOAD)
 
+    def test_finds_distinct_middle_action_when_extremes_match(self):
+        rollouts = [rollout(2.0, SEARCH), rollout(1.0, DOWNLOAD), rollout(0.0, SEARCH)]
+        pair = build_preference_pair(rollouts, TASK)
+        self.assertEqual(pair["chosen"], SEARCH)
+        self.assertEqual(pair["rejected"], DOWNLOAD)
+
+    def test_respects_minimum_reward_gap(self):
+        rollouts = [rollout(1.01, SEARCH), rollout(1.0, DOWNLOAD)]
+        self.assertIsNone(build_preference_pair(rollouts, TASK, min_reward_gap=0.05))
+
     def test_none_when_actions_identical(self):
         rollouts = [rollout(1.5, SEARCH, "FINISH"), rollout(0.5, SEARCH, "FINISH")]
         self.assertIsNone(build_preference_pair(rollouts, TASK))

--- a/AgenticArxiv/tests/test_llm_request_params.py
+++ b/AgenticArxiv/tests/test_llm_request_params.py
@@ -22,6 +22,7 @@ import tools.pdf_translate_tool  # noqa: F401,E402
 
 from agents.agent_engine import ReActAgent  # noqa: E402
 from agents.side_effects import LocalSideEffectManager  # noqa: E402
+from utils.llm_client import TransformersLLMClient  # noqa: E402
 
 
 class CapturingClient:
@@ -71,6 +72,47 @@ class TestLlmExtra(unittest.TestCase):
     def test_default_is_empty_dict_not_none(self):
         agent = ReActAgent(CapturingClient(), side_effect_mgr=LocalSideEffectManager())
         self.assertEqual(agent.llm_extra, {})
+
+
+class TestTransformersClientResponse(unittest.TestCase):
+    def test_adapts_local_generation_to_openai_response(self):
+        import torch
+
+        class Tokenizer:
+            pad_token_id = 0
+
+            def apply_chat_template(self, messages, **kwargs):
+                return "prompt"
+
+            def __call__(self, prompt, return_tensors=None):
+                return {"input_ids": torch.tensor([[1, 2]])}
+
+            def decode(self, ids, skip_special_tokens=True):
+                return "Thought: x\nAction: FINISH\nObservation: invented"
+
+        class Model:
+            def parameters(self):
+                return iter([torch.nn.Parameter(torch.zeros(1))])
+
+            def generate(self, **kwargs):
+                return torch.tensor([[1, 2, 3, 4, 5]])
+
+        client = TransformersLLMClient.__new__(TransformersLLMClient)
+        client.tokenizer = Tokenizer()
+        client.model = Model()
+        client.seed = 7
+        client._calls = 0
+        response = client.chat_completions(
+            model="local",
+            messages=[{"role": "user", "content": "x"}],
+            extra={"stop": ["Observation:"]},
+        )
+        self.assertEqual(
+            response["choices"][0]["message"]["content"],
+            "Thought: x\nAction: FINISH\n",
+        )
+        self.assertEqual(response["usage"]["prompt_tokens"], 2)
+        self.assertEqual(response["usage"]["completion_tokens"], 3)
 
 
 if __name__ == "__main__":

--- a/AgenticArxiv/utils/llm_client.py
+++ b/AgenticArxiv/utils/llm_client.py
@@ -48,6 +48,107 @@ class LLMClient:
         return resp.json()
 
 
+class TransformersLLMClient:
+    """Expose a local Hugging Face causal LM through the small client contract.
+
+    Imports are intentionally lazy so benchmark and data-processing utilities do
+    not need to import the training stack unless local inference is requested.
+    The returned object mirrors the subset of OpenAI's chat-completions response
+    consumed by :class:`BaseAgent`.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        device: str = "auto",
+        dtype: str = "auto",
+        seed: Optional[int] = None,
+    ) -> None:
+        import torch
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+
+        self.model_name = model
+        self.seed = seed
+        self._calls = 0
+        self.tokenizer = AutoTokenizer.from_pretrained(model)
+        if self.tokenizer.pad_token_id is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+
+        dtype_map = {
+            "auto": "auto",
+            "float16": torch.float16,
+            "bfloat16": torch.bfloat16,
+            "float32": torch.float32,
+        }
+        if dtype not in dtype_map:
+            raise ValueError(f"Unsupported dtype {dtype!r}; choose from {sorted(dtype_map)}")
+        load_kwargs: Dict[str, Any] = {"torch_dtype": dtype_map[dtype]}
+        self.device = device
+        if device == "auto":
+            load_kwargs["device_map"] = "auto"
+        self.model = AutoModelForCausalLM.from_pretrained(model, **load_kwargs)
+        if device != "auto":
+            self.model.to(device)
+        self.model.eval()
+
+    def chat_completions(
+        self,
+        model: str,
+        messages: List[Dict[str, str]],
+        temperature: float = 0.3,
+        max_tokens: int = 1000,
+        stream: bool = False,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        import torch
+
+        if stream:
+            raise ValueError("TransformersLLMClient does not support streaming")
+        extra = dict(extra or {})
+        stop = extra.pop("stop", []) or []
+        template_kwargs = extra.pop("chat_template_kwargs", {}) or {}
+        prompt = self.tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            **template_kwargs,
+        )
+        inputs = self.tokenizer(prompt, return_tensors="pt")
+        target = next(self.model.parameters()).device
+        inputs = {key: value.to(target) for key, value in inputs.items()}
+        do_sample = temperature is not None and temperature > 0
+        generation_kwargs: Dict[str, Any] = {
+            "max_new_tokens": max_tokens,
+            "do_sample": do_sample,
+            "pad_token_id": self.tokenizer.pad_token_id,
+            **extra,
+        }
+        if do_sample:
+            generation_kwargs["temperature"] = temperature
+        if self.seed is not None:
+            # A different, reproducible stream per call gives DPO rollouts
+            # diversity without making repeated dataset builds irreproducible.
+            torch.manual_seed(self.seed + self._calls)
+        self._calls += 1
+        with torch.inference_mode():
+            output = self.model.generate(**inputs, **generation_kwargs)
+        prompt_tokens = inputs["input_ids"].shape[-1]
+        completion_ids = output[0, prompt_tokens:]
+        content = self.tokenizer.decode(completion_ids, skip_special_tokens=True)
+        for marker in stop:
+            if marker in content:
+                content = content.split(marker, 1)[0]
+        completion_tokens = int(completion_ids.shape[-1])
+        return {
+            "choices": [{"message": {"role": "assistant", "content": content}}],
+            "usage": {
+                "prompt_tokens": int(prompt_tokens),
+                "completion_tokens": completion_tokens,
+                "total_tokens": int(prompt_tokens) + completion_tokens,
+            },
+        }
+
+
 def get_env_llm_client() -> LLMClient:
     """
     从环境变量读取：

--- a/README.en.md
+++ b/README.en.md
@@ -153,6 +153,13 @@ python -m rl.rollout search_01 ../traces/train/
    ```bash
    python scripts/generate_dpo_data.py
    ```
+
+This command samples the local Hugging Face model at `outputs/sft/final` and
+does not require `LLM_API_KEY`. Use `--model`, `--num_rollouts_per_task`,
+`--temperature`, and `--seed` to customize generation. When
+`data/mock_arxiv_snapshot.json` exists, tool calls are replayed offline for
+reproducibility; otherwise generation falls back to the live tools. Only
+different first actions whose reward gap exceeds `--min_reward_gap` are paired.
 2. Train:
    ```bash
    python -m rl.train_dpo

--- a/README.md
+++ b/README.md
@@ -152,6 +152,21 @@ python -m AgenticArxiv.rl.rollout search_01 traces/train/
    ```bash
    python scripts/generate_dpo_data.py
    ```
+
+该命令直接加载 `outputs/sft/final` 的本地 Hugging Face 模型进行多次采样，
+不需要 `LLM_API_KEY`。常用可选参数：
+
+```bash
+python scripts/generate_dpo_data.py \
+  --model outputs/sft/final \
+  --num_rollouts_per_task 8 \
+  --temperature 0.8 \
+  --seed 42
+```
+
+若已生成 `data/mock_arxiv_snapshot.json`，工具调用会自动使用离线回放，
+保证数据生成可复现；否则会回退到实时网络。只有奖励差超过
+`--min_reward_gap`（默认 0.05）且首个工具动作不同的轨迹才会组成偏好对。
 2. 训练：
    ```bash
    python -m AgenticArxiv.rl.train_dpo

--- a/scripts/generate_dpo_data.py
+++ b/scripts/generate_dpo_data.py
@@ -26,6 +26,7 @@ DPO 数据格式：
 import os
 import sys
 import json
+import argparse
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -40,8 +41,9 @@ os.environ.setdefault("STORE_BACKEND", "memory")
 from benchmark.tasks import get_all_tasks
 from agents.agent_engine import ReActAgent
 from agents.side_effects import LocalSideEffectManager
-from utils.llm_client import get_env_llm_client
+from utils.llm_client import TransformersLLMClient
 from rl.reward import RewardCalculator
+from rl.env import MockArxivEnv
 
 
 # 终止标记，不是真实的工具调用
@@ -60,21 +62,27 @@ def first_tool_action(result: dict) -> str:
     return ""
 
 
-def build_preference_pair(rollouts: list, task_def: dict):
+def build_preference_pair(rollouts: list, task_def: dict, min_reward_gap: float = 0.0):
     """从同一任务的多条 rollout 构造一条偏好样本，无法构造时返回 None。"""
     if len(rollouts) < 2:
         return None
 
-    ordered = sorted(rollouts, key=lambda x: x["reward"], reverse=True)
-    best, worst = ordered[0], ordered[-1]
-
-    chosen = first_tool_action(best["result"])
-    rejected = first_tool_action(worst["result"])
-
-    if not chosen or not rejected or chosen == rejected:
+    # Extremes can have the same first action even when a useful, different
+    # action exists in the middle. Search every valid pair and keep the largest
+    # reward gap instead of silently throwing that preference signal away.
+    candidates = []
+    for chosen_rollout in rollouts:
+        chosen = first_tool_action(chosen_rollout["result"])
+        if not chosen:
+            continue
+        for rejected_rollout in rollouts:
+            rejected = first_tool_action(rejected_rollout["result"])
+            gap = chosen_rollout["reward"] - rejected_rollout["reward"]
+            if rejected and chosen != rejected and gap > min_reward_gap:
+                candidates.append((gap, chosen, rejected))
+    if not candidates:
         return None
-    if best["reward"] <= worst["reward"]:
-        return None      # 奖励无差异，没有偏好信息
+    _, chosen, rejected = max(candidates, key=lambda item: item[0])
 
     return {
         "prompt": task_def["task"],
@@ -83,7 +91,17 @@ def build_preference_pair(rollouts: list, task_def: dict):
     }
 
 
-def generate_dpo_dataset(num_rollouts_per_task: int = 5):
+def generate_dpo_dataset(
+    num_rollouts_per_task: int = 5,
+    model: str = None,
+    output: str = None,
+    snapshot: str = None,
+    device: str = "auto",
+    dtype: str = "auto",
+    temperature: float = 0.8,
+    seed: int = 42,
+    min_reward_gap: float = 0.05,
+):
     """
     从 SFT 模型 rollout 生成 DPO 数据集
 
@@ -91,16 +109,32 @@ def generate_dpo_dataset(num_rollouts_per_task: int = 5):
         num_rollouts_per_task: 每个任务 rollout 次数
     """
 
-    sft_model_path = REPO_ROOT / "outputs" / "sft" / "final"
+    sft_model_path = Path(model) if model else REPO_ROOT / "outputs" / "sft" / "final"
     if not sft_model_path.exists():
         print(f"❌ SFT 模型不存在: {sft_model_path}")
         print(f"请先运行: python -m AgenticArxiv.rl.train_sft")
         return
 
-    # TODO: 加载 SFT 模型（需要修改 llm_client 支持本地模型）
-    # 目前占位：使用原始 LLM
-    llm_client = get_env_llm_client()
-    agent = ReActAgent(llm_client, side_effect_mgr=LocalSideEffectManager())
+    print(f"📦 加载本地 SFT 模型: {sft_model_path}")
+    llm_client = TransformersLLMClient(
+        str(sft_model_path), device=device, dtype=dtype, seed=seed
+    )
+    snapshot_path = Path(snapshot) if snapshot else REPO_ROOT / "data" / "mock_arxiv_snapshot.json"
+    env = None
+    if snapshot_path.exists():
+        env = MockArxivEnv(snapshot_path=snapshot_path, mode="replay")
+        print(f"🗂 使用离线快照: {snapshot_path}")
+    else:
+        print(
+            f"⚠️ 未找到离线快照 {snapshot_path}，工具将使用实时网络。"
+            "如需可复现生成，请先运行 python -m AgenticArxiv.rl.build_snapshot"
+        )
+    agent = ReActAgent(
+        llm_client,
+        side_effect_mgr=LocalSideEffectManager(),
+        env=env,
+        llm_extra={"temperature": temperature},
+    )
 
     reward_calc = RewardCalculator()
     dpo_data = []
@@ -134,7 +168,7 @@ def generate_dpo_dataset(num_rollouts_per_task: int = 5):
             print(f"   ⚠️  rollout 数量不足，跳过")
             continue
 
-        pair = build_preference_pair(rollouts, task_def)
+        pair = build_preference_pair(rollouts, task_def, min_reward_gap=min_reward_gap)
         if pair is None:
             print(f"   ⚠️  chosen/rejected 无效（无工具调用、动作相同或奖励无差异），跳过")
             continue
@@ -145,7 +179,7 @@ def generate_dpo_dataset(num_rollouts_per_task: int = 5):
         print(f"   ✅ chosen_reward={max(rewards):.2f}, rejected_reward={min(rewards):.2f}")
 
     # 保存到 JSONL
-    output_path = REPO_ROOT / "data" / "dpo" / "dpo_train.jsonl"
+    output_path = Path(output) if output else REPO_ROOT / "data" / "dpo" / "dpo_train.jsonl"
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "w", encoding="utf-8") as f:
@@ -156,4 +190,14 @@ def generate_dpo_dataset(num_rollouts_per_task: int = 5):
 
 
 if __name__ == "__main__":
-    generate_dpo_dataset()
+    parser = argparse.ArgumentParser(description="从本地 SFT 模型生成 DPO 偏好数据")
+    parser.add_argument("--model", default=None, help="本地 SFT 模型路径")
+    parser.add_argument("--output", default=None, help="输出 JSONL 路径")
+    parser.add_argument("--snapshot", default=None, help="离线 arXiv 快照路径")
+    parser.add_argument("--num_rollouts_per_task", type=int, default=5)
+    parser.add_argument("--device", default="auto", help="auto/cpu/cuda/cuda:0")
+    parser.add_argument("--dtype", choices=["auto", "float16", "bfloat16", "float32"], default="auto")
+    parser.add_argument("--temperature", type=float, default=0.8)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--min_reward_gap", type=float, default=0.05)
+    generate_dpo_dataset(**vars(parser.parse_args()))


### PR DESCRIPTION
## Summary

- Generate DPO data from the local SFT checkpoint rather than the external API placeholder.
- Add reproducible sampling, device/dtype controls, offline snapshot replay, and robust preference pairing.
- Add regression coverage and update Chinese/English docs.

## Testing

- 30 passed, 7 subtests passed