### PR TITLE
standardize README commands

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -36,6 +36,9 @@ git clone https://github.com/Algorineko/AgenticArXiv-RL.git
 cd AgenticArXiv-RL
 ```
 
+All following commands are intended to be run from the repository root
+`AgenticArXiv-RL/`.
+
 ### 2️⃣ Environment Setup
 
 **Create a virtual environment**:
@@ -67,8 +70,7 @@ EOF
 ### 3️⃣ Test Rollout
 
 ```bash
-cd AgenticArxiv
-python -m rl.rollout search_01 ../traces/train/
+python -m AgenticArxiv.rl.rollout search_01 traces/train/
 ```
 
 **Expected output**:
@@ -130,7 +132,7 @@ python -m rl.rollout search_01 ../traces/train/
    ```
 2. Train:
    ```bash
-   python -m rl.train_sft
+   python -m AgenticArxiv.rl.train_sft
    ```
 3. Output: `./outputs/sft/final` model
 
@@ -165,7 +167,7 @@ reproducibility; otherwise generation falls back to the live tools. Only
 different first actions whose reward gap exceeds `--min_reward_gap` are paired.
 2. Train:
    ```bash
-   python -m rl.train_dpo
+   python -m AgenticArxiv.rl.train_dpo
    ```
 3. Output: `./outputs/dpo/final` model
 
@@ -186,7 +188,7 @@ different first actions whose reward gap exceeds `--min_reward_gap` are paired.
 
 **Steps**:
 ```bash
-python -m rl.train_grpo
+python -m AgenticArxiv.rl.train_grpo
 ```
 
 **Output**: `./outputs/grpo/final` model
@@ -277,13 +279,11 @@ AgenticArXiv-RL/
 ### 1. Rollout (Collect Trajectories)
 
 ```bash
-cd AgenticArxiv
-
 # Single task
-python -m rl.rollout search_01 ../traces/train/
+python -m AgenticArxiv.rl.rollout search_01 traces/train/
 
 # Batch rollout
-python -m rl.rollout --all ../traces/train/
+python -m AgenticArxiv.rl.rollout --all --output_dir traces/train/
 ```
 
 ### 2. Training Pipeline (SFT → DPO → GRPO)
@@ -293,16 +293,16 @@ python -m rl.rollout --all ../traces/train/
 python scripts/generate_sft_data.py
 
 # Step 2: SFT training
-python -m rl.train_sft
+python -m AgenticArxiv.rl.train_sft
 
 # Step 3: Generate DPO data (requires SFT model)
 python scripts/generate_dpo_data.py
 
 # Step 4: DPO training
-python -m rl.train_dpo
+python -m AgenticArxiv.rl.train_dpo
 
 # Step 5: GRPO training
-python -m rl.train_grpo
+python -m AgenticArxiv.rl.train_grpo
 ```
 
 ### 3. Reward Computation Test

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -38,6 +38,9 @@ git clone https://github.com/Algorineko/AgenticArXiv-RL.git
 cd AgenticArXiv-RL
 ```
 
+Todos los comandos siguientes deben ejecutarse desde la raíz del repositorio
+`AgenticArXiv-RL/`.
+
 ### 2️⃣ Configuración del Entorno
 
 **Crear entorno virtual**:
@@ -69,8 +72,7 @@ EOF
 ### 3️⃣ Prueba de Rollout
 
 ```bash
-cd AgenticArxiv
-python -m rl.rollout search_01 ../traces/train/
+python -m AgenticArxiv.rl.rollout search_01 traces/train/
 ```
 
 **Salida esperada**:
@@ -132,7 +134,7 @@ python -m rl.rollout search_01 ../traces/train/
    ```
 2. Entrenar:
    ```bash
-   python -m rl.train_sft
+   python -m AgenticArxiv.rl.train_sft
    ```
 3. Salida: Modelo en `./outputs/sft/final`
 
@@ -160,7 +162,7 @@ python -m rl.rollout search_01 ../traces/train/
    ```
 2. Entrenar:
    ```bash
-   python -m rl.train_dpo
+   python -m AgenticArxiv.rl.train_dpo
    ```
 3. Salida: Modelo en `./outputs/dpo/final`
 
@@ -181,7 +183,7 @@ python -m rl.rollout search_01 ../traces/train/
 
 **Pasos**:
 ```bash
-python -m rl.train_grpo
+python -m AgenticArxiv.rl.train_grpo
 ```
 
 **Salida**: Modelo en `./outputs/grpo/final`
@@ -272,13 +274,11 @@ AgenticArXiv-RL/
 ### 1. Rollout (recopilar trajectory)
 
 ```bash
-cd AgenticArxiv
-
 # Tarea individual
-python -m rl.rollout search_01 ../traces/train/
+python -m AgenticArxiv.rl.rollout search_01 traces/train/
 
 # Rollout por lotes
-python -m rl.rollout --all ../traces/train/
+python -m AgenticArxiv.rl.rollout --all --output_dir traces/train/
 ```
 
 ### 2. Flujo de Entrenamiento (SFT → DPO → GRPO)
@@ -288,16 +288,16 @@ python -m rl.rollout --all ../traces/train/
 python scripts/generate_sft_data.py
 
 # Paso 2: Entrenamiento SFT
-python -m rl.train_sft
+python -m AgenticArxiv.rl.train_sft
 
 # Paso 3: Generar datos DPO (requiere modelo SFT)
 python scripts/generate_dpo_data.py
 
 # Paso 4: Entrenamiento DPO
-python -m rl.train_dpo
+python -m AgenticArxiv.rl.train_dpo
 
 # Paso 5: Entrenamiento GRPO
-python -m rl.train_grpo
+python -m AgenticArxiv.rl.train_grpo
 ```
 
 ### 3. Prueba de cálculo de Reward

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ git clone https://github.com/Algorineko/AgenticArXiv-RL.git
 cd AgenticArXiv-RL
 ```
 
+后续命令默认均在仓库根目录 `AgenticArXiv-RL/` 下执行。
+
 ### 2️⃣ 环境配置
 
 **创建虚拟环境**：


### PR DESCRIPTION
## Summary
- Clarify that README commands should be run from the repository root
- Standardize English and Spanish README examples to use `python -m AgenticArxiv.rl...`
- Remove subdirectory-based `cd AgenticArxiv` / `../traces` examples

## Verification
- Searched README files for stale `cd AgenticArxiv`, `python -m rl.`, and `../traces` examples
- Ran `python3 -m py_compile` on the documented RL entry scripts