### PR TITLE
feat: add GitHub and Gitee repository tools

### DIFF
--- a/AgenticArxiv/agents/agent_engine.py
+++ b/AgenticArxiv/agents/agent_engine.py
@@ -25,6 +25,7 @@ class ReActAgent(BaseAgent):
             import tools.pdf_download_tool  # noqa: F401
             import tools.pdf_translate_tool  # noqa: F401
             import tools.cache_status_tool  # noqa: F401
+            import tools.code_repository_tool  # noqa: F401
             log.info(f"已导入工具模块，注册了 {len(registry.list_tools())} 个工具")
         except ImportError as e:
             log.warning(f"导入工具模块失败: {e}")

--- a/AgenticArxiv/agents/base_agent.py
+++ b/AgenticArxiv/agents/base_agent.py
@@ -267,16 +267,30 @@ class BaseAgent(ABC):
 
     def _enrich_task_with_context(self, task: str, session_id: str) -> str:
         """向任务描述注入当前会话状态，帮助 LLM 避免重复操作"""
+        contexts = []
         try:
             papers = self.side_effects.get_last_papers(session_id)
             if papers:
                 titles = [f"  {i+1}. {p.title}" for i, p in enumerate(papers[:10])]
                 ctx = f"\n\n[会话上下文] 当前会话已有 {len(papers)} 篇论文:\n" + "\n".join(titles)
                 ctx += "\n可直接用 ref 序号引用，无需重新搜索。"
-                return task + ctx
+                contexts.append(ctx)
         except Exception:
             pass
-        return task
+        try:
+            from tools.code_repository_tool import get_repository_results
+            for platform in ("github", "gitee"):
+                repos = get_repository_results(session_id, platform)
+                if repos:
+                    names = [f"  {i+1}. {r.get('full_name', 'unknown')}" for i, r in enumerate(repos[:10])]
+                    contexts.append(
+                        f"\n\n[会话上下文] 最近的 {platform.title()} 仓库搜索结果:\n"
+                        + "\n".join(names)
+                        + "\n下载工具可直接使用 repository 序号引用。"
+                    )
+        except Exception:
+            pass
+        return task + "".join(contexts)
 
     # ---------- 工具执行（可被 env 接管） ----------
 
@@ -365,6 +379,24 @@ class BaseAgent(ABC):
                         return "未获取到任何论文记录，请尝试调整搜索参数（如增加天数范围）"
                 else:
                     return f"工具返回结果格式异常: {type(result)}, 内容: {str(result)[:200]}"
+
+            elif tool_name in ("search_github_repositories", "search_gitee_repositories"):
+                platform = "github" if "github" in tool_name else "gitee"
+                if isinstance(result, dict) and "error" in result:
+                    return f"工具执行失败: {result['error']}"
+                if not isinstance(result, list):
+                    return f"工具返回结果格式异常: {type(result)}, 内容: {str(result)[:200]}"
+                from tools.code_repository_tool import remember_repository_results
+                remember_repository_results(self.session_id, platform, result)
+                if not result:
+                    return f"在 {platform.title()} 未找到匹配仓库，请调整关键词或筛选条件"
+                lines = []
+                for i, repo in enumerate(result[:5], 1):
+                    lines.append(
+                        f"  {i}. {repo.get('full_name', 'unknown')} "
+                        f"(stars={repo.get('stars', 0)}, language={repo.get('language') or 'unknown'})"
+                    )
+                return f"在 {platform.title()} 找到 {len(result)} 个仓库:\n" + "\n".join(lines)
 
             elif tool_name == "format_papers_console":
                 return "FINISH"

--- a/AgenticArxiv/agents/prompt_templates.py
+++ b/AgenticArxiv/agents/prompt_templates.py
@@ -54,6 +54,9 @@ def format_tool_description(tools) -> str:
         if 'parameters' in tool and 'properties' in tool['parameters']:
             params = []
             for param_name, param_spec in tool['parameters']['properties'].items():
+                # Framework-injected values must not become model decisions.
+                if param_spec.get('x-internal'):
+                    continue
                 param_type = param_spec.get('type', 'unknown')
                 param_desc = param_spec.get('description', '')
                 default_val = param_spec.get('default', '无默认值')

--- a/AgenticArxiv/api/app.py
+++ b/AgenticArxiv/api/app.py
@@ -9,6 +9,7 @@ import tools.arxiv_tool  # noqa: F401
 import tools.pdf_download_tool  # noqa: F401
 import tools.pdf_translate_tool  # noqa: F401
 import tools.cache_status_tool  # noqa: F401
+import tools.code_repository_tool  # noqa: F401
 
 from api.endpoints import router as api_router
 from models.db import init_db

--- a/AgenticArxiv/benchmark/tasks.py
+++ b/AgenticArxiv/benchmark/tasks.py
@@ -89,6 +89,87 @@ BENCHMARK_TASKS: List[Dict[str, Any]] = [
         "expected_termination": "FINISH",
         "category": "composite",
     },
+
+    # === 类型 6: 开源代码仓库检索与下载 ===
+    {
+        "id": "github_search_01",
+        "task": "在 GitHub 搜索 Python 实现的 RAG 项目，按 stars 降序返回前5个",
+        "expected_tools": ["search_github_repositories"],
+        "expected_tool_args": [{"query": "RAG", "language": "Python", "sort": "stars", "order": "desc", "max_results": 5}],
+        "expected_termination": "FINISH", "category": "code_search",
+    },
+    {
+        "id": "github_search_02",
+        "task": "去 GitHub 找最近更新的 TypeScript MCP server 项目，最多3个",
+        "expected_tools": ["search_github_repositories"],
+        "expected_tool_args": [{"query": "MCP server", "language": "TypeScript", "sort": "updated", "order": "desc", "max_results": 3}],
+        "expected_termination": "FINISH", "category": "code_search",
+    },
+    {
+        "id": "gitee_search_01",
+        "task": "在 Gitee 搜索 Java 微服务项目，按 stars 降序返回前5个",
+        "expected_tools": ["search_gitee_repositories"],
+        "expected_tool_args": [{"query": "微服务", "language": "Java", "sort": "stars", "order": "desc", "max_results": 5}],
+        "expected_termination": "FINISH", "category": "code_search",
+    },
+    {
+        "id": "gitee_search_02",
+        "task": "去 Gitee 找 Python 大模型应用项目，按最近更新排序，最多3个",
+        "expected_tools": ["search_gitee_repositories"],
+        "expected_tool_args": [{"query": "大模型应用", "language": "Python", "sort": "updated", "order": "desc", "max_results": 3}],
+        "expected_termination": "FINISH", "category": "code_search",
+    },
+    {
+        "id": "github_download_direct_01",
+        "task": "下载 GitHub 仓库 langchain-ai/langchain 的 main 分支源码",
+        "expected_tools": ["download_github_repository"],
+        "expected_tool_args": [{"repository": "langchain-ai/langchain", "ref": "main"}],
+        "expected_termination": "FINISH", "category": "code_download",
+    },
+    {
+        "id": "gitee_download_direct_01",
+        "task": "下载 Gitee 仓库 dromara/hutool 的 v5-master 分支源码",
+        "expected_tools": ["download_gitee_repository"],
+        "expected_tool_args": [{"repository": "dromara/hutool", "ref": "v5-master"}],
+        "expected_termination": "FINISH", "category": "code_download",
+    },
+    {
+        "id": "github_search_download_01",
+        "task": "在 GitHub 搜索 Python Agent 框架，按 stars 排序取前3个，然后下载第1个仓库",
+        "expected_tools": ["search_github_repositories", "download_github_repository"],
+        "expected_tool_args": [
+            {"query": "AI agent framework", "language": "Python", "sort": "stars", "order": "desc", "max_results": 3},
+            {"repository": 1},
+        ],
+        "expected_termination": "FINISH", "category": "code_composite",
+    },
+    {
+        "id": "gitee_search_download_01",
+        "task": "在 Gitee 搜索 Java 工作流引擎，返回前3个，然后下载第2个仓库",
+        "expected_tools": ["search_gitee_repositories", "download_gitee_repository"],
+        "expected_tool_args": [
+            {"query": "工作流引擎", "language": "Java", "sort": "stars", "order": "desc", "max_results": 3},
+            {"repository": 2},
+        ],
+        "expected_termination": "FINISH", "category": "code_composite",
+    },
+    {
+        "id": "cross_platform_search_01",
+        "task": "分别在 GitHub 和 Gitee 搜索向量数据库项目，各返回3个，不要下载",
+        "expected_tools": ["search_github_repositories", "search_gitee_repositories"],
+        "expected_tool_args": [
+            {"query": "vector database", "max_results": 3},
+            {"query": "向量数据库", "max_results": 3},
+        ],
+        "expected_termination": "FINISH", "category": "code_composite",
+    },
+    {
+        "id": "github_tag_download_01",
+        "task": "从 GitHub 下载 psf/requests 仓库的 v2.32.3 标签源码，不需要先搜索",
+        "expected_tools": ["download_github_repository"],
+        "expected_tool_args": [{"repository": "psf/requests", "ref": "v2.32.3"}],
+        "expected_termination": "FINISH", "category": "code_download",
+    },
 ]
 
 

--- a/AgenticArxiv/config.py
+++ b/AgenticArxiv/config.py
@@ -48,6 +48,14 @@ class Settings:
         "TRANSLATE_CACHE_PATH", os.path.join(DEFAULT_OUTPUT_DIR, "translate_cache.json")
     )
 
+    # --- source repository search/download ---
+    repository_download_path: str = os.getenv(
+        "REPOSITORY_DOWNLOAD_PATH", os.path.join(DEFAULT_OUTPUT_DIR, "repositories")
+    )
+    repository_max_download_mb: int = int(
+        os.getenv("REPOSITORY_MAX_DOWNLOAD_MB", "100")
+    )
+
     # --- pdf2zh CLI ---
     pdf2zh_bin: str = os.getenv("PDF2ZH_BIN", "pdf2zh")
     pdf2zh_service: str = os.getenv("PDF2ZH_SERVICE", "bing")

--- a/AgenticArxiv/main.py
+++ b/AgenticArxiv/main.py
@@ -9,6 +9,7 @@ import tools.arxiv_tool  # noqa: F401
 import tools.pdf_download_tool  # noqa: F401
 import tools.pdf_translate_tool  # noqa: F401
 import tools.cache_status_tool  # noqa: F401
+import tools.code_repository_tool  # noqa: F401
 
 from utils.llm_client import get_env_llm_client
 from agents.agent_engine import ReActAgent

--- a/AgenticArxiv/mcp_protocol/mcp_agent.py
+++ b/AgenticArxiv/mcp_protocol/mcp_agent.py
@@ -44,6 +44,7 @@ class MCPAgent(BaseAgent):
             import tools.pdf_download_tool  # noqa: F401
             import tools.pdf_translate_tool  # noqa: F401
             import tools.cache_status_tool  # noqa: F401
+            import tools.code_repository_tool  # noqa: F401
         except ImportError as e:
             log.warning(f"导入工具模块失败: {e}")
 

--- a/AgenticArxiv/mcp_protocol/server.py
+++ b/AgenticArxiv/mcp_protocol/server.py
@@ -28,6 +28,7 @@ import tools.arxiv_tool  # noqa: F401
 import tools.pdf_download_tool  # noqa: F401
 import tools.pdf_translate_tool  # noqa: F401
 import tools.cache_status_tool  # noqa: F401
+import tools.code_repository_tool  # noqa: F401
 
 from tools.tool_registry import registry
 

--- a/AgenticArxiv/rl/build_snapshot.py
+++ b/AgenticArxiv/rl/build_snapshot.py
@@ -24,10 +24,21 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 os.environ.setdefault("STORE_BACKEND", "memory")
 
 import tools.arxiv_tool  # noqa: F401  触发工具注册
+import tools.code_repository_tool  # noqa: F401
 from rl.env import MockArxivEnv
 
 # 覆盖 benchmark/rl 任务集里出现过的所有方向
 DEFAULT_ASPECTS = ["*", "AI", "LG", "CL", "CV", "RO", "CR"]
+DEFAULT_REPOSITORY_QUERIES = [
+    ("search_github_repositories", "RAG", "Python"),
+    ("search_github_repositories", "MCP server", "TypeScript"),
+    ("search_github_repositories", "AI agent framework", "Python"),
+    ("search_github_repositories", "vector database", None),
+    ("search_gitee_repositories", "微服务", "Java"),
+    ("search_gitee_repositories", "大模型应用", "Python"),
+    ("search_gitee_repositories", "工作流引擎", "Java"),
+    ("search_gitee_repositories", "向量数据库", None),
+]
 
 
 def build(
@@ -59,6 +70,19 @@ def build(
             ok += 1
         except Exception as e:
             print(f"  [FAIL] aspect={aspect:<3} → {e}")
+            fail += 1
+
+    print("  repository search pools:")
+    for tool_name, query, language in DEFAULT_REPOSITORY_QUERIES:
+        try:
+            call_args = {"query": query, "max_results": min(max_results, 20)}
+            if language:
+                call_args["language"] = language
+            repos = env.execute_tool(tool_name, call_args)
+            print(f"  [OK]   {tool_name} query={query!r} → {len(repos)} 个")
+            ok += 1
+        except Exception as e:
+            print(f"  [FAIL] {tool_name} query={query!r} → {e}")
             fail += 1
 
     env.save_snapshot()

--- a/AgenticArxiv/rl/env.py
+++ b/AgenticArxiv/rl/env.py
@@ -24,6 +24,8 @@
 
 import json
 import os
+import hashlib
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
@@ -34,7 +36,11 @@ from utils.logger import log
 _VOLATILE_ARG_KEYS = {"session_id", "output_path", "save_to_file"}
 
 # 需要走快照回放的"网络型"工具
-DEFAULT_SNAPSHOT_TOOLS: Set[str] = {"get_recently_submitted_cs_papers"}
+DEFAULT_SNAPSHOT_TOOLS: Set[str] = {
+    "get_recently_submitted_cs_papers",
+    "search_github_repositories",
+    "search_gitee_repositories",
+}
 
 
 class MockArxivEnv:
@@ -95,6 +101,10 @@ class MockArxivEnv:
         if tool_name == "download_arxiv_pdf" and self.offline_download:
             self.stats["offline_stubs"] += 1
             return self._offline_download(args)
+        if tool_name in ("download_github_repository", "download_gitee_repository") and self.offline_download:
+            self.stats["offline_stubs"] += 1
+            platform = "github" if "github" in tool_name else "gitee"
+            return self._offline_repository_download(platform, args)
 
         # 2) 非快照工具（纯本地，如缓存查询）→ 直接真实执行
         if tool_name not in self.snapshot_tools:
@@ -122,6 +132,11 @@ class MockArxivEnv:
         #     否则策略稍微改个参数就变成 KeyError，奖励信号会被污染成"全是工具失败"。
         if tool_name == "get_recently_submitted_cs_papers":
             derived = self._derive_search_result(args, tool_data)
+            if derived is not None:
+                self.stats["hit"] += 1
+                return derived
+        if tool_name in ("search_github_repositories", "search_gitee_repositories"):
+            derived = self._derive_repository_search_result(args, tool_data)
             if derived is not None:
                 self.stats["hit"] += 1
                 return derived
@@ -179,6 +194,39 @@ class MockArxivEnv:
             max_results = 50
         max_results = max(1, min(max_results, len(pool)))
         return pool[:max_results]
+
+    @staticmethod
+    def _derive_repository_search_result(args: Dict[str, Any], tool_data: Dict[str, Any]):
+        """Reuse a recorded query pool while preserving limit and sort semantics."""
+        query = str(args.get("query", "")).strip().casefold()
+        language = str(args.get("language", "")).strip().casefold()
+        pool = None
+        for entry in tool_data.values():
+            recorded = entry.get("args", {})
+            if str(recorded.get("query", "")).strip().casefold() != query:
+                continue
+            recorded_language = str(recorded.get("language", "")).strip().casefold()
+            if language and recorded_language and recorded_language != language:
+                continue
+            candidate = entry.get("result")
+            if isinstance(candidate, list):
+                pool = list(candidate)
+                break
+        if pool is None:
+            return None
+        sort_key = {"stars": "stars", "forks": "forks", "updated": "updated_at"}.get(
+            str(args.get("sort", "stars"))
+        )
+        if sort_key:
+            pool.sort(
+                key=lambda item: item.get(sort_key) or ("" if sort_key == "updated_at" else 0),
+                reverse=str(args.get("order", "desc")) != "asc",
+            )
+        try:
+            limit = max(1, min(int(args.get("max_results", 5)), 20))
+        except (TypeError, ValueError):
+            limit = 5
+        return pool[:limit]
 
     # ---------- 离线下载桩 ----------
 
@@ -250,6 +298,31 @@ class MockArxivEnv:
         }
 
     # ---------- 快照读写 ----------
+
+    @staticmethod
+    def _offline_repository_download(platform: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a harmless deterministic ZIP in place of a network archive."""
+        from config import settings
+        from tools.code_repository_tool import _resolve_repository, _split_full_name
+
+        session_id = args.get("session_id", "default")
+        item = _resolve_repository(platform, session_id, args.get("repository"))
+        owner, name = _split_full_name(item["full_name"], platform)
+        ref = str(args.get("ref") or item.get("default_branch") or "main")
+        safe_ref = "".join(ch if ch.isalnum() or ch in "_.-" else "_" for ch in ref)
+        output_dir = Path(settings.repository_download_path).resolve()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        path = output_dir / f"{platform}__{owner}__{name}__{safe_ref}.zip"
+        existed = path.exists() and path.stat().st_size > 0
+        if not existed or args.get("force"):
+            with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+                archive.writestr(f"{name}-{safe_ref}/README.md", "offline repository fixture\n")
+        digest = hashlib.sha256(path.read_bytes()).hexdigest()
+        return {
+            "platform": platform, "repository": f"{owner}/{name}", "ref": ref,
+            "local_path": str(path), "status": "READY", "existed": existed,
+            "size_bytes": path.stat().st_size, "sha256": digest, "extracted": False,
+        }
 
     @staticmethod
     def _make_key(args: Dict[str, Any]) -> str:

--- a/AgenticArxiv/rl/stage_verifier.py
+++ b/AgenticArxiv/rl/stage_verifier.py
@@ -29,6 +29,7 @@ from rl.reward import RewardCalculator
 # 工具导入（触发注册）
 import tools.arxiv_tool  # noqa: F401
 import tools.cache_status_tool  # noqa: F401
+import tools.code_repository_tool  # noqa: F401
 import tools.pdf_download_tool  # noqa: F401
 import tools.pdf_translate_tool  # noqa: F401
 

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -42,6 +42,7 @@ import tools.arxiv_tool  # noqa: F401  触发工具注册
 import tools.cache_status_tool  # noqa: F401
 import tools.pdf_download_tool  # noqa: F401
 import tools.pdf_translate_tool  # noqa: F401
+import tools.code_repository_tool  # noqa: F401
 
 from benchmark.tasks import get_all_tasks
 from rl.canary import CanaryEvaluator, CanaryCallback

--- a/AgenticArxiv/skill_cli/skill_agent.py
+++ b/AgenticArxiv/skill_cli/skill_agent.py
@@ -49,6 +49,7 @@ class SkillAgent(BaseAgent):
             import tools.pdf_download_tool  # noqa: F401
             import tools.pdf_translate_tool  # noqa: F401
             import tools.cache_status_tool  # noqa: F401
+            import tools.code_repository_tool  # noqa: F401
         except ImportError as e:
             log.warning(f"导入工具模块失败: {e}")
 

--- a/AgenticArxiv/tests/test_code_repository_tool.py
+++ b/AgenticArxiv/tests/test_code_repository_tool.py
@@ -1,0 +1,89 @@
+"""Offline unit tests for repository search/download tools."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+import tools.code_repository_tool as repo_tool  # noqa: E402
+from agents.agent_engine import ReActAgent  # noqa: E402
+from agents.side_effects import LocalSideEffectManager  # noqa: E402
+from rl.env import MockArxivEnv  # noqa: E402
+
+
+class RepositoryToolTests(unittest.TestCase):
+    def setUp(self):
+        repo_tool.clear_repository_memory()
+
+    @staticmethod
+    def _response(payload):
+        response = Mock()
+        response.status_code = 200
+        response.json.return_value = payload
+        response.raise_for_status.return_value = None
+        return response
+
+    @patch("tools.code_repository_tool.requests.get")
+    def test_github_search_normalises_and_remembers(self, get):
+        get.return_value = self._response({"items": [{
+            "id": 7, "full_name": "acme/rag", "name": "rag",
+            "owner": {"login": "acme"}, "stargazers_count": 9,
+            "forks_count": 2, "default_branch": "main", "language": "Python",
+        }]})
+        result = repo_tool.search_github_repositories("rag", language="Python", session_id="s")
+        self.assertEqual(result[0]["full_name"], "acme/rag")
+        self.assertEqual(repo_tool.get_repository_results("s", "github")[0]["stars"], 9)
+        self.assertIn("language:Python", get.call_args.kwargs["params"]["q"])
+
+    @patch("tools.code_repository_tool.requests.get")
+    def test_gitee_search_supports_list_response(self, get):
+        get.return_value = self._response([{
+            "id": 8, "full_name": "acme/workflow", "name": "workflow",
+            "owner": {"login": "acme"}, "stars_count": 5,
+            "forks_count": 1, "default_branch": "master", "language": "Java",
+        }])
+        result = repo_tool.search_gitee_repositories("工作流", session_id="s")
+        self.assertEqual(result[0]["platform"], "gitee")
+        self.assertEqual(result[0]["stars"], 5)
+
+    def test_offline_search_to_download_by_index(self):
+        repos = [{"platform": "github", "full_name": "acme/demo", "default_branch": "main"}]
+        repo_tool.remember_repository_results("s", "github", repos)
+        with tempfile.TemporaryDirectory() as directory:
+            fake_settings = SimpleNamespace(repository_download_path=directory)
+            with patch("config.settings", fake_settings):
+                env = MockArxivEnv(mode="replay")
+                result = env.execute_tool(
+                    "download_github_repository", {"session_id": "s", "repository": 1}
+                )
+            self.assertEqual(result["status"], "READY")
+            self.assertFalse(result["extracted"])
+            self.assertTrue(Path(result["local_path"]).is_file())
+
+    def test_agent_formats_and_remembers_mock_search_results(self):
+        class FakeEnv:
+            def execute_tool(self, name, args):
+                return [{"platform": "gitee", "full_name": "acme/demo", "stars": 3, "language": "Python"}]
+
+        agent = ReActAgent(None, side_effect_mgr=LocalSideEffectManager(), env=FakeEnv())
+        agent.session_id = "agent-session"
+        observation = agent._execute_with_side_effects({
+            "name": "search_gitee_repositories", "args": {"query": "demo"}
+        })
+        self.assertIn("acme/demo", observation)
+        self.assertEqual(repo_tool.get_repository_results("agent-session", "gitee")[0]["full_name"], "acme/demo")
+
+    def test_rejects_wrong_host_and_path_like_repository(self):
+        for value in ("https://evil.example/acme/demo", "../demo", "a/b/c"):
+            with self.assertRaises(ValueError):
+                repo_tool._split_full_name(value, "github")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AgenticArxiv/tools/code_repository_tool.py
+++ b/AgenticArxiv/tools/code_repository_tool.py
@@ -1,0 +1,366 @@
+"""GitHub/Gitee repository search and safe source archive download tools.
+
+Downloads are ZIP archives only.  They are never executed or automatically
+extracted, which keeps both interactive use and RL rollouts predictable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import quote, urlparse
+
+import requests
+
+from config import settings
+from tools.tool_registry import registry
+
+_GITHUB_API = "https://api.github.com"
+_GITEE_API = "https://gitee.com/api/v5"
+_SAFE_PART = re.compile(r"^[A-Za-z0-9_.-]+$")
+_SEARCH_MEMORY: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
+_MEMORY_LOCK = threading.RLock()
+
+
+def remember_repository_results(
+    session_id: str, platform: str, repositories: List[Dict[str, Any]]
+) -> None:
+    """Remember search results so a later download can use a 1-based ref."""
+    with _MEMORY_LOCK:
+        _SEARCH_MEMORY.setdefault(session_id or "default", {})[platform] = list(repositories)
+
+
+def clear_repository_memory(session_id: Optional[str] = None) -> None:
+    """Test/helper API; clear one session or all repository search memory."""
+    with _MEMORY_LOCK:
+        if session_id is None:
+            _SEARCH_MEMORY.clear()
+        else:
+            _SEARCH_MEMORY.pop(session_id, None)
+
+
+def get_repository_results(session_id: str, platform: str) -> List[Dict[str, Any]]:
+    with _MEMORY_LOCK:
+        return list(_SEARCH_MEMORY.get(session_id or "default", {}).get(platform, []))
+
+
+def _checked_limit(max_results: int) -> int:
+    value = int(max_results)
+    if not 1 <= value <= 20:
+        raise ValueError("max_results must be between 1 and 20")
+    return value
+
+
+def _raise_for_api(response: requests.Response, platform: str) -> None:
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        detail = ""
+        try:
+            payload = response.json()
+            detail = payload.get("message") or payload.get("error") or ""
+        except Exception:
+            detail = response.text[:200]
+        hint = "；可配置访问令牌以提高限额或访问私有资源" if response.status_code in (401, 403, 429) else ""
+        raise RuntimeError(f"{platform} API 请求失败 ({response.status_code}): {detail}{hint}") from exc
+
+
+def _github_headers() -> Dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "AgenticArxiv-RL",
+    }
+    token = os.getenv("GITHUB_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _gitee_params(params: Dict[str, Any]) -> Dict[str, Any]:
+    token = os.getenv("GITEE_TOKEN", "").strip()
+    if token:
+        params["access_token"] = token
+    return params
+
+
+def _normalise_github(item: Dict[str, Any]) -> Dict[str, Any]:
+    owner = item.get("owner") or {}
+    return {
+        "platform": "github",
+        "id": item.get("id"),
+        "full_name": item.get("full_name"),
+        "name": item.get("name"),
+        "owner": owner.get("login"),
+        "description": item.get("description") or "",
+        "html_url": item.get("html_url"),
+        "clone_url": item.get("clone_url"),
+        "default_branch": item.get("default_branch"),
+        "language": item.get("language"),
+        "stars": item.get("stargazers_count", 0),
+        "forks": item.get("forks_count", 0),
+        "updated_at": item.get("updated_at"),
+        "archived": bool(item.get("archived", False)),
+    }
+
+
+def _normalise_gitee(item: Dict[str, Any]) -> Dict[str, Any]:
+    owner = item.get("owner") or {}
+    full_name = item.get("full_name") or item.get("path_with_namespace")
+    return {
+        "platform": "gitee",
+        "id": item.get("id"),
+        "full_name": full_name,
+        "name": item.get("name") or item.get("path"),
+        "owner": owner.get("login") or owner.get("username") or (full_name or "/").split("/")[0],
+        "description": item.get("description") or "",
+        "html_url": item.get("html_url") or item.get("url"),
+        "clone_url": item.get("clone_url") or item.get("http_url_to_repo"),
+        "default_branch": item.get("default_branch"),
+        "language": item.get("language"),
+        "stars": item.get("stargazers_count", item.get("stars_count", 0)),
+        "forks": item.get("forks_count", 0),
+        "updated_at": item.get("updated_at") or item.get("last_push_at"),
+        "archived": bool(item.get("archived", False)),
+    }
+
+
+def search_github_repositories(
+    query: str,
+    language: Optional[str] = None,
+    sort: str = "stars",
+    order: str = "desc",
+    max_results: int = 5,
+    session_id: str = "default",
+) -> List[Dict[str, Any]]:
+    query = str(query).strip()
+    if not query:
+        raise ValueError("query cannot be empty")
+    if sort not in ("stars", "forks", "updated") or order not in ("asc", "desc"):
+        raise ValueError("invalid sort or order")
+    if language:
+        query = f"{query} language:{language.strip()}"
+    response = requests.get(
+        f"{_GITHUB_API}/search/repositories",
+        params={"q": query, "sort": sort, "order": order, "per_page": _checked_limit(max_results), "page": 1},
+        headers=_github_headers(),
+        timeout=(5, 20),
+    )
+    _raise_for_api(response, "GitHub")
+    results = [_normalise_github(item) for item in response.json().get("items", [])]
+    remember_repository_results(session_id, "github", results)
+    return results
+
+
+def search_gitee_repositories(
+    query: str,
+    language: Optional[str] = None,
+    sort: str = "stars",
+    order: str = "desc",
+    max_results: int = 5,
+    session_id: str = "default",
+) -> List[Dict[str, Any]]:
+    query = str(query).strip()
+    if not query:
+        raise ValueError("query cannot be empty")
+    if sort not in ("stars", "forks", "updated") or order not in ("asc", "desc"):
+        raise ValueError("invalid sort or order")
+    sort_map = {"stars": "stars_count", "forks": "forks_count", "updated": "last_push_at"}
+    params: Dict[str, Any] = {
+        "q": query,
+        "sort": sort_map.get(sort, sort),
+        "order": order,
+        "per_page": _checked_limit(max_results),
+        "page": 1,
+    }
+    if language:
+        params["language"] = language.strip()
+    response = requests.get(
+        f"{_GITEE_API}/search/repositories",
+        params=_gitee_params(params),
+        headers={"Accept": "application/json", "User-Agent": "AgenticArxiv-RL"},
+        timeout=(5, 20),
+    )
+    _raise_for_api(response, "Gitee")
+    payload = response.json()
+    items = payload.get("items", []) if isinstance(payload, dict) else payload
+    results = [_normalise_gitee(item) for item in items]
+    remember_repository_results(session_id, "gitee", results)
+    return results
+
+
+def _split_full_name(value: str, platform: str) -> tuple[str, str]:
+    value = value.strip()
+    if value.startswith("http://") or value.startswith("https://"):
+        parsed = urlparse(value)
+        expected = "github.com" if platform == "github" else "gitee.com"
+        if parsed.hostname not in (expected, f"www.{expected}"):
+            raise ValueError(f"repository URL must belong to {expected}")
+        value = parsed.path.strip("/")
+    if value.endswith(".git"):
+        value = value[:-4]
+    parts = value.split("/")
+    if (
+        len(parts) != 2
+        or any(part in (".", "..") for part in parts)
+        or not all(_SAFE_PART.fullmatch(part) for part in parts)
+    ):
+        raise ValueError("repository must be owner/name, a repository URL, or a search-result index")
+    return parts[0], parts[1]
+
+
+def _resolve_repository(
+    platform: str, session_id: str, repository: Union[int, str, None]
+) -> Dict[str, Any]:
+    results = get_repository_results(session_id, platform)
+    if repository is None:
+        if not results:
+            raise ValueError(f"no previous {platform} search results; search first or provide owner/name")
+        return results[0]
+    if isinstance(repository, int) and not isinstance(repository, bool):
+        if repository < 1 or repository > len(results):
+            raise ValueError(f"repository index out of range: 1..{len(results)}")
+        return results[repository - 1]
+    owner, name = _split_full_name(str(repository), platform)
+    return {"platform": platform, "full_name": f"{owner}/{name}", "owner": owner, "name": name}
+
+
+def _default_branch(platform: str, owner: str, name: str) -> str:
+    if platform == "github":
+        response = requests.get(
+            f"{_GITHUB_API}/repos/{quote(owner)}/{quote(name)}",
+            headers=_github_headers(), timeout=(5, 20),
+        )
+    else:
+        response = requests.get(
+            f"{_GITEE_API}/repos/{quote(owner)}/{quote(name)}",
+            params=_gitee_params({}),
+            headers={"Accept": "application/json", "User-Agent": "AgenticArxiv-RL"}, timeout=(5, 20),
+        )
+    _raise_for_api(response, platform.title())
+    branch = response.json().get("default_branch")
+    if not branch:
+        raise RuntimeError(f"{platform} repository metadata has no default_branch")
+    return str(branch)
+
+
+def _archive_url(platform: str, owner: str, name: str, ref: str) -> str:
+    if platform == "github":
+        return f"{_GITHUB_API}/repos/{quote(owner)}/{quote(name)}/zipball/{quote(ref, safe='')}"
+    return f"{_GITEE_API}/repos/{quote(owner)}/{quote(name)}/zipball"
+
+
+def _download_repository(
+    platform: str,
+    repository: Union[int, str, None] = None,
+    ref: Optional[str] = None,
+    force: bool = False,
+    session_id: str = "default",
+) -> Dict[str, Any]:
+    item = _resolve_repository(platform, session_id, repository)
+    owner, name = _split_full_name(item["full_name"], platform)
+    branch = (ref or item.get("default_branch") or "").strip()
+    if not branch:
+        branch = _default_branch(platform, owner, name)
+    if len(branch) > 200 or any(ch in branch for ch in ("\0", "\r", "\n")):
+        raise ValueError("invalid ref")
+
+    output_dir = Path(settings.repository_download_path).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    safe_ref = re.sub(r"[^A-Za-z0-9_.-]+", "_", branch).strip("._") or "default"
+    target = (output_dir / f"{platform}__{owner}__{name}__{safe_ref}.zip").resolve()
+    if output_dir not in target.parents:
+        raise ValueError("unsafe output path")
+    if target.exists() and target.stat().st_size > 0 and not force:
+        return _archive_result(platform, owner, name, branch, target, True)
+
+    headers = _github_headers() if platform == "github" else {"Accept": "application/zip", "User-Agent": "AgenticArxiv-RL"}
+    response = requests.get(
+        _archive_url(platform, owner, name, branch),
+        headers=headers,
+        params=_gitee_params({"ref": branch}) if platform == "gitee" else None,
+        stream=True, allow_redirects=True, timeout=(5, 60),
+    )
+    _raise_for_api(response, platform.title())
+    max_bytes = max(1, int(settings.repository_max_download_mb)) * 1024 * 1024
+    declared = int(response.headers.get("Content-Length") or 0)
+    if declared > max_bytes:
+        response.close()
+        raise ValueError(f"archive exceeds {settings.repository_max_download_mb} MB limit")
+    partial = target.with_suffix(target.suffix + ".part")
+    total = 0
+    try:
+        with open(partial, "wb") as file_obj:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if not chunk:
+                    continue
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ValueError(f"archive exceeds {settings.repository_max_download_mb} MB limit")
+                file_obj.write(chunk)
+        os.replace(partial, target)
+    finally:
+        response.close()
+        if partial.exists():
+            partial.unlink()
+    return _archive_result(platform, owner, name, branch, target, False)
+
+
+def _archive_result(platform: str, owner: str, name: str, ref: str, path: Path, existed: bool) -> Dict[str, Any]:
+    digest = hashlib.sha256()
+    with open(path, "rb") as file_obj:
+        for chunk in iter(lambda: file_obj.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return {
+        "platform": platform,
+        "repository": f"{owner}/{name}",
+        "ref": ref,
+        "local_path": str(path),
+        "status": "READY",
+        "existed": existed,
+        "size_bytes": path.stat().st_size,
+        "sha256": digest.hexdigest(),
+        "extracted": False,
+    }
+
+
+def download_github_repository(repository=None, ref=None, force=False, session_id="default"):
+    return _download_repository("github", repository, ref, force, session_id)
+
+
+def download_gitee_repository(repository=None, ref=None, force=False, session_id="default"):
+    return _download_repository("gitee", repository, ref, force, session_id)
+
+
+SEARCH_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string", "description": "仓库关键词或主题", "minLength": 1},
+        "language": {"type": "string", "description": "可选编程语言筛选"},
+        "sort": {"type": "string", "description": "排序字段", "enum": ["stars", "forks", "updated"], "default": "stars"},
+        "order": {"type": "string", "description": "排序方向", "enum": ["desc", "asc"], "default": "desc"},
+        "max_results": {"type": "integer", "description": "最大结果数", "minimum": 1, "maximum": 20, "default": 5},
+        "session_id": {"type": "string", "description": "内部会话标识", "default": "default", "x-internal": True},
+    },
+    "required": ["query"],
+}
+
+DOWNLOAD_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "repository": {"description": "搜索结果序号（从1开始）、owner/name 或仓库URL", "anyOf": [{"type": "integer", "minimum": 1}, {"type": "string"}]},
+        "ref": {"type": "string", "description": "可选分支、Tag或提交；默认使用仓库默认分支"},
+        "force": {"type": "boolean", "description": "是否覆盖已下载归档", "default": False},
+        "session_id": {"type": "string", "description": "内部会话标识", "default": "default", "x-internal": True},
+    },
+    "required": [],
+}
+
+registry.register_tool("search_github_repositories", "在 GitHub 搜索代码仓库；结果可供下载工具按序号引用", SEARCH_SCHEMA, search_github_repositories)
+registry.register_tool("search_gitee_repositories", "在 Gitee 搜索代码仓库；结果可供下载工具按序号引用", SEARCH_SCHEMA, search_gitee_repositories)
+registry.register_tool("download_github_repository", "下载 GitHub 仓库源码 ZIP；不执行、不自动解压", DOWNLOAD_SCHEMA, download_github_repository)
+registry.register_tool("download_gitee_repository", "下载 Gitee 仓库源码 ZIP；不执行、不自动解压", DOWNLOAD_SCHEMA, download_gitee_repository)

--- a/README.en.md
+++ b/README.en.md
@@ -9,6 +9,28 @@
 
 ---
 
+## Source repository tools
+
+The agent can search and download source code from GitHub and Gitee:
+
+- `search_github_repositories` / `search_gitee_repositories` normalize metadata and remember results in the session.
+- `download_github_repository` / `download_gitee_repository` accept a 1-based search-result index, `owner/name`, or a repository URL.
+- Downloads are size-limited ZIP archives; they are never executed or automatically extracted.
+
+Public repositories work without credentials where the platform permits it. Set
+`GITHUB_TOKEN` or `GITEE_TOKEN` to raise API limits or access resources permitted
+by that token. Optional settings are `REPOSITORY_DOWNLOAD_PATH` and
+`REPOSITORY_MAX_DOWNLOAD_MB` (default: 100).
+
+After changing repository tasks, regenerate the offline training snapshot:
+
+```bash
+cd AgenticArxiv
+python -m rl.build_snapshot
+```
+
+---
+
 ## 🎯 Project Overview
 
 This project transforms arXiv paper retrieval/download/translation tasks into a **trainable reinforcement learning environment**, with a focus on:
@@ -231,7 +253,7 @@ AgenticArXiv-RL/
 │  │  └─ cache_status_tool.py      # Cache query
 │  ├─ benchmark/                     # ⭐ Verifiable Reward source
 │  │  ├─ metrics.py               # TaskMetrics, strict tool-sequence & argument matching
-│  │  ├─ tasks.py                 # BENCHMARK_TASKS (8 task seeds)
+│  │  ├─ tasks.py                 # BENCHMARK_TASKS (paper and repository seeds)
 │  │  ├─ runner.py                 # Benchmark executor
 │  │  ├─ run_benchmark.py          # CLI benchmark entry
 │  │  └─ report.py                 # Metrics report
@@ -332,7 +354,7 @@ print(f'Reward: {reward:.2f}')  # Expected: ~1.5
 
 ## 🧪 Test Task Set
 
-From `benchmark/tasks.py`, containing 8 tasks:
+From `benchmark/tasks.py`, containing 18 tasks: 8 paper tasks and 10 source-repository tasks.
 
 | ID | Task | Type | Expected Tool |
 |----|------|------|---------------|
@@ -344,6 +366,11 @@ From `benchmark/tasks.py`, containing 8 tasks:
 | `translate_01` | Translate the 1st paper | Translation | `translate_arxiv_pdf` |
 | `cache_01` | Check cache status of the 1st paper | Cache | `get_paper_cache_status` |
 | `composite_01` | Search + Download | Composite | `get_recently_submitted_cs_papers`, `download_arxiv_pdf` |
+| `github_search_*` | Search GitHub repositories | Code search | `search_github_repositories` |
+| `gitee_search_*` | Search Gitee repositories | Code search | `search_gitee_repositories` |
+| `*_download_*` | Download a repository/tag | Code download | Platform download tool |
+| `*_search_download_*` | Search then download by index | Code composite | Platform search + download |
+| `cross_platform_search_01` | Search both platforms | Code composite | Both search tools |
 
 ---
 
@@ -479,7 +506,7 @@ Ordered by priority. Contributions welcome (see 🤝 Contributing).
 
 ### P1 — Mid term (data & evaluation)
 
-- [ ] **Expand the task set**: `benchmark/tasks.py` has only 8 tasks; grow it to 50+ and auto-derive `expected_tools` / `expected_tool_args`.
+- [ ] **Continue expanding the task set**: `benchmark/tasks.py` now has 18 tasks; grow it to 50+ and auto-derive `expected_tools` / `expected_tool_args`.
 - [ ] **eval/ badcase replay**: the `eval/` directory listed in the tree does not exist yet; implement `eval_cases.jsonl` + `badcase_replay.py` to close the bad-case replay loop.
 - [ ] **Reward-hacking triage**: build on `RewardVarianceGuard` / `CanaryCallback` with a reward-hacking case library and curriculum weight tuning.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@
 
 ---
 
+## 开源代码仓库工具
+
+Agent 现在可以完成 GitHub/Gitee 的“检索 → 选择 → 下载源码”流程：
+
+- `search_github_repositories` / `search_gitee_repositories`：统一仓库元数据，并在会话中保存搜索结果；
+- `download_github_repository` / `download_gitee_repository`：支持搜索结果序号、`owner/name` 和仓库 URL；
+- 下载结果为带大小上限的 ZIP，不执行代码，也不自动解压。
+
+公开仓库通常无需令牌；也可配置 `GITHUB_TOKEN`、`GITEE_TOKEN`。下载目录和上限可通过
+`REPOSITORY_DOWNLOAD_PATH`、`REPOSITORY_MAX_DOWNLOAD_MB`（默认 100）设置。
+新增或修改仓库任务后，运行 `cd AgenticArxiv && python -m rl.build_snapshot`
+生成供离线训练使用的快照。
+
+---
+
 ## 🎯 项目定位
 
 将 arXiv 论文检索/下载/翻译任务改造为**可训练的强化学习环境**，专注于：
@@ -238,7 +253,7 @@ AgenticArXiv-RL/
 │  │  └─ cache_status_tool.py      # 缓存查询
 │  ├─ benchmark/                     # ⭐ Verifiable Reward 来源
 │  │  ├─ metrics.py               # TaskMetrics、工具序列严格匹配、参数匹配
-│  │  ├─ tasks.py                 # BENCHMARK_TASKS（7 个任务种子）
+│  │  ├─ tasks.py                 # BENCHMARK_TASKS（论文与代码仓库任务种子）
 │  │  ├─ runner.py                 # 基准执行器
 │  │  ├─ run_benchmark.py          # 命令行基准入口
 │  │  └─ report.py                 # 指标统计报告
@@ -339,7 +354,7 @@ print(f'Reward: {reward:.2f}')  # 期望: ~1.5
 
 ## 🧪 测试任务集
 
-来自 `benchmark/tasks.py`，包含 7 个任务：
+来自 `benchmark/tasks.py`，包含 18 个任务：8 个论文任务和 10 个代码仓库任务。
 
 | ID | 任务 | 类型 | 预期工具 |
 |----|------|------|---------|
@@ -350,6 +365,11 @@ print(f'Reward: {reward:.2f}')  # 期望: ~1.5
 | `translate_01` | 翻译第1篇论文 | 翻译 | `translate_arxiv_pdf` |
 | `cache_01` | 查看第1篇论文缓存状态 | 缓存 | `get_paper_cache_status` |
 | `composite_01` | 搜索+下载 | 复合 | `get_recently_submitted_cs_papers`, `download_arxiv_pdf` |
+| `github_search_*` | GitHub 仓库检索 | 代码检索 | `search_github_repositories` |
+| `gitee_search_*` | Gitee 仓库检索 | 代码检索 | `search_gitee_repositories` |
+| `*_download_*` | 指定仓库/Tag 下载 | 代码下载 | 对应平台下载工具 |
+| `*_search_download_*` | 搜索后按序号下载 | 代码复合 | 对应平台搜索、下载工具 |
+| `cross_platform_search_01` | 双平台检索 | 代码复合 | 两个平台搜索工具 |
 
 ---
 
@@ -484,7 +504,7 @@ PPO 更适合生产级大模型训练（7B+），本项目作为学习 demo 不�
 
 ### P1 — 中期（数据与评测）
 
-- [ ] **任务集扩充**：`benchmark/tasks.py` 仅 7 个任务，扩充到 50+，并支持自动派生 `expected_tools` / `expected_tool_args`，奖励才有区分度。
+- [ ] **任务集继续扩充**：`benchmark/tasks.py` 当前 18 个任务，继续扩充到 50+，并支持自动派生 `expected_tools` / `expected_tool_args`。
 - [ ] **eval/ badcase replay**：目录树中的 `eval/`（`eval_cases.jsonl`、`badcase_replay.py`）实际尚不存在，需实现坏例回放闭环。
 - [ ] **Reward hacking 排查**：在现有 `RewardVarianceGuard` / `CanaryCallback` 基础上补 reward-hacking 案例库与多粒度权重课程调优。
 

--- a/scripts/generate_sft_data.py
+++ b/scripts/generate_sft_data.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(PACKAGE_ROOT))
 os.environ.setdefault("STORE_BACKEND", "memory")
 
 from benchmark.tasks import get_all_tasks
+from benchmark.metrics import extract_metrics
 from agents.agent_engine import ReActAgent
 from agents.side_effects import LocalSideEffectManager
 from utils.llm_client import get_env_llm_client
@@ -46,8 +47,17 @@ def generate_sft_dataset():
         try:
             result = agent.run(task_def["task"], session_id=f"sft_gen_{task_def['id']}")
 
-            # 只保留成功的 trajectories
-            if result.get("iteration_count", 0) > 0 and result.get("history"):
+            # 只保留经过静态 oracle 验证的 expert trajectories，避免老师模型
+            # 选错平台/工具/参数或工具执行失败后仍污染 SFT 数据。
+            metrics = extract_metrics(task_def, result, "react", trial=1)
+            is_verified = (
+                metrics.task_completed
+                and metrics.tool_call_accurate
+                and metrics.arg_score >= 0.999
+                and metrics.tool_exec_failures == 0
+                and metrics.parse_failures == 0
+            )
+            if is_verified and result.get("history"):
                 print(f"   ✅ 成功，共 {len(result['history'])} 步")
 
                 # 转为 SFT 格式（每一步作为一条训练样本）
@@ -60,7 +70,7 @@ def generate_sft_dataset():
                         "messages": [
                             {
                                 "role": "system",
-                                "content": "你是一个 arXiv 论文检索 Agent，可以调用工具完成任务。"
+                                "content": "你是一个科研与开源代码资源 Agent，可以调用工具完成论文检索、仓库检索和安全下载任务。"
                             },
                             {
                                 "role": "user",
@@ -73,7 +83,12 @@ def generate_sft_dataset():
                         ]
                     })
             else:
-                print(f"   ⚠️  执行失败或无有效步骤")
+                print(
+                    "   ⚠️  未通过轨迹校验，已丢弃 "
+                    f"(completed={metrics.task_completed}, "
+                    f"tools={metrics.tool_call_accurate}, args={metrics.arg_score:.2f}, "
+                    f"exec_failures={metrics.tool_exec_failures})"
+                )
 
         except Exception as e:
             print(f"   ❌ 执行出错: {e}")


### PR DESCRIPTION
## Summary

This PR extends the agent's tool-use scenarios from paper operations to source-code repository discovery and download.

- Add GitHub repository search and ZIP download tools
- Add Gitee repository search and ZIP download tools
- Support repository references by search-result index, `owner/name`, or URL
- Preserve search results in session context for multi-step search-to-download workflows
- Add offline Mock environment support for deterministic RL rollouts
- Add 10 repository-related benchmark seed tasks
- Validate SFT trajectories before adding them to the training dataset
- Update Chinese and English documentation

## Safety

Repository downloads:

- are limited to ZIP archives
- are not executed
- are not automatically extracted
- have a configurable size limit
- use tokens only through environment variables

## Testing

- `python -m compileall -q AgenticArxiv scripts`
- 47 relevant unit and regression tests passed
- Added tests for GitHub/Gitee result normalization, session memory, offline downloads, and unsafe repository reference rejection