### PR TITLE
feat(rl): add multi-turn GRPO rollouts

### DIFF
--- a/AgenticArxiv/rl/canary.py
+++ b/AgenticArxiv/rl/canary.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional, Sequence
 
 import torch
 from transformers import PreTrainedModel, PreTrainedTokenizer
-from trl import TrainerCallback
+from transformers import TrainerCallback
 
 from benchmark.tasks import get_task_by_id
 from rl.grpo_reward import synthesize_trajectory
@@ -97,7 +97,7 @@ class CanaryEvaluator:
         Returns:
             CanaryResult 包含聚合指标。
         """
-        device = next(self.model.parameters()).device
+        device = next(iter(self.model.parameters())).device
         self.model.eval()
 
         all_rewards: List[float] = []

--- a/AgenticArxiv/rl/grpo_reward.py
+++ b/AgenticArxiv/rl/grpo_reward.py
@@ -3,7 +3,8 @@
 TRL 的 GRPOTrainer 是「对同一 prompt 采样 N 条输出 → 逐条打分 → 组内相对优势」
 的结构，它只负责生成**一步**，不会替你跑完整的 ReAct 循环。
 
-这里把模型生成的一步补成一条**最小完整轨迹**，再交给项目已有的
+兼容两条路径：旧的单步 completion 会补成最小轨迹；TRL 原生工具循环
+产生的多轮 structured messages 会直接还原为完整 history，再交给项目已有的
 `RewardCalculator.compute_reward_breakdown()` 打分，从而复用现成的奖励定义：
 
     模型输出  →  解析 Thought/Action
@@ -140,6 +141,62 @@ def _completion_text(completion: Any) -> str:
     return str(completion or "")
 
 
+def messages_to_trajectory(completion: Any) -> Dict[str, Any]:
+    """Convert TRL native multi-turn messages into the project's history schema.
+
+    Assistant tool-call messages become action steps and consume the following
+    tool message as their observation.  The final assistant answer becomes a
+    FINISH step.  This preserves the real Action -> Observation -> Action chain
+    produced by GRPOTrainer's tool loop.
+    """
+    if not isinstance(completion, list):
+        return synthesize_trajectory(_completion_text(completion))
+
+    history: List[Dict[str, Any]] = []
+    pending: List[int] = []
+    for message in completion:
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        if role == "assistant":
+            calls = message.get("tool_calls") or []
+            if calls:
+                for call in calls:
+                    function = call.get("function", call) if isinstance(call, dict) else {}
+                    name = function.get("name")
+                    args = function.get("arguments", {})
+                    if isinstance(args, str):
+                        try:
+                            args = json.loads(args)
+                        except json.JSONDecodeError:
+                            args = {}
+                    action = {"name": name, "args": args or {}}
+                    history.append({
+                        "thought": str(message.get("content") or ""),
+                        "action": json.dumps(action, ensure_ascii=False),
+                        "observation": "",
+                    })
+                    pending.append(len(history) - 1)
+            elif str(message.get("content") or "").strip():
+                history.append({
+                    "thought": str(message.get("content") or ""),
+                    "action": "FINISH",
+                    "observation": "任务完成",
+                })
+        elif role == "tool" and pending:
+            index = pending.pop(0)
+            history[index]["observation"] = str(message.get("content") or "")
+
+    if not history:
+        return synthesize_trajectory(_completion_text(completion))
+    return {
+        "history": history,
+        "timing": {},
+        "token_usage": {},
+        "iteration_count": len(history),
+    }
+
+
 def make_grpo_reward_fn(
     tasks_by_id: Dict[str, Dict[str, Any]],
     env: Any = None,
@@ -153,6 +210,7 @@ def make_grpo_reward_fn(
     calc = reward_calc or RewardCalculator()
 
     def grpo_reward_fn(completions=None, task_id=None, trainer_state=None,
+                       trajectory_results=None,
                        **kwargs) -> List[float]:
         completions = completions or []
         ids = task_id or [None] * len(completions)
@@ -163,12 +221,17 @@ def make_grpo_reward_fn(
         step = int(getattr(trainer_state, "global_step", 0) or 0)
 
         rewards: List[float] = []
-        for completion, tid in zip(completions, ids):
+        trajectories = trajectory_results or [None] * len(completions)
+        for completion, tid, rollout_result in zip(completions, ids, trajectories):
             task_def = tasks_by_id.get(tid)
             if task_def is None:
                 rewards.append(0.0)
                 continue
-            result = synthesize_trajectory(_completion_text(completion), env=env)
+            result = rollout_result or (
+                messages_to_trajectory(completion)
+                if isinstance(completion, list)
+                else synthesize_trajectory(_completion_text(completion), env=env)
+            )
             breakdown, _ = calc.compute_reward_breakdown(
                 task_def, result, training_step=step
             )
@@ -177,6 +240,124 @@ def make_grpo_reward_fn(
 
     grpo_reward_fn.__name__ = "grpo_reward_fn"
     return grpo_reward_fn
+
+
+def make_multiturn_rollout_func(environment_factory, max_turns: int = 4):
+    """Create a TRL custom rollout function for textual ReAct models.
+
+    Every assistant turn is sampled from the current policy. Tool observations
+    are appended to the completion token stream with ``env_mask=0``; generated
+    policy tokens use ``env_mask=1`` and therefore participate in GRPO loss.
+    The full history is forwarded to the reward function as an extra field.
+    """
+    max_turns = max(1, int(max_turns))
+
+    def rollout_func(prompts, trainer):
+        import copy
+
+        tokenizer = trainer.processing_class
+        generations = trainer.num_generations if trainer.model.training else trainer.num_generations_eval
+        expanded_prompts = [copy.deepcopy(p) for p in prompts for _ in range(generations)]
+        prompt_ids = []
+        for prompt in expanded_prompts:
+            ids = tokenizer.apply_chat_template(
+                prompt, tokenize=True, add_generation_prompt=True,
+            ) if isinstance(prompt, list) else tokenizer(prompt)["input_ids"]
+            prompt_ids.append(list(ids))
+
+        environments = [environment_factory() for _ in expanded_prompts]
+        trajectory_results = []
+        completion_ids = [[] for _ in expanded_prompts]
+        env_masks = [[] for _ in expanded_prompts]
+        histories = [[] for _ in expanded_prompts]
+        active = list(range(len(expanded_prompts)))
+        full_ids = [list(ids) for ids in prompt_ids]
+
+        # Dataset rows are expanded prompt-major, matching TRL's reward columns.
+        for i, environment in enumerate(environments):
+            environment.reset()
+
+        for _turn in range(max_turns):
+            if not active:
+                break
+            remaining = [trainer.max_completion_length - len(completion_ids[i]) for i in active]
+            keep = [(i, r) for i, r in zip(active, remaining) if r > 0]
+            if not keep:
+                break
+            active = [i for i, _ in keep]
+
+            turn_ids, _, _ = trainer._generate_single_turn(
+                [full_ids[i] for i in active], None, {}
+            )
+            next_active = []
+            for batch_index, index in enumerate(active):
+                budget = trainer.max_completion_length - len(completion_ids[index])
+                generated = list(turn_ids[batch_index])[:budget]
+                text = tokenizer.decode(generated, skip_special_tokens=True)
+                completion_ids[index].extend(generated)
+                env_masks[index].extend([1] * len(generated))
+
+                kind, action = parse_react_action(text)
+                thought = _thought_of(text)
+                if kind == "finish":
+                    histories[index].append({
+                        "thought": thought, "action": "FINISH", "observation": "任务完成"
+                    })
+                    continue
+                if kind == "parse_error":
+                    histories[index].append({
+                        "thought": thought, "action": "PARSE_ERROR",
+                        "observation": "无法解析 Action", "parse_failed": True,
+                    })
+                    continue
+
+                args = dict(action.get("args") or {})
+                try:
+                    if action["name"] == "get_recently_submitted_cs_papers":
+                        result = environments[index].get_recently_submitted_cs_papers(**args)
+                    elif action["name"] == "download_arxiv_pdf":
+                        result = environments[index].download_arxiv_pdf(**args)
+                    elif action["name"] == "translate_arxiv_pdf":
+                        result = environments[index].translate_arxiv_pdf(**args)
+                    elif action["name"] == "get_paper_cache_status":
+                        result = environments[index].get_paper_cache_status(**args)
+                    else:
+                        raise ValueError(f"未知工具: {action['name']}")
+                    observation = str(result)[:1000]
+                except Exception as exc:  # noqa: BLE001
+                    observation = f"工具执行失败: {exc}"
+
+                histories[index].append({
+                    "thought": thought,
+                    "action": json.dumps(action, ensure_ascii=False),
+                    "observation": observation,
+                })
+                suffix = f"\nObservation: {observation}\nThought:"
+                suffix_ids = tokenizer(suffix, add_special_tokens=False)["input_ids"]
+                suffix_ids = list(suffix_ids)[: max(0, trainer.max_completion_length - len(completion_ids[index]))]
+                completion_ids[index].extend(suffix_ids)
+                env_masks[index].extend([0] * len(suffix_ids))
+                full_ids[index] = prompt_ids[index] + completion_ids[index]
+                if len(completion_ids[index]) < trainer.max_completion_length:
+                    next_active.append(index)
+            active = next_active
+
+        for history in histories:
+            trajectory_results.append({
+                "history": history,
+                "timing": {},
+                "token_usage": {},
+                "iteration_count": len(history),
+            })
+        return {
+            "prompt_ids": prompt_ids,
+            "completion_ids": completion_ids,
+            "logprobs": None,
+            "env_mask": env_masks,
+            "trajectory_results": trajectory_results,
+        }
+
+    return rollout_func
 
 
 def build_prompt_dataset(tasks: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -199,6 +380,26 @@ def build_prompt_dataset(tasks: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]
         )
         rows.append({
             "prompt": [{"role": "user", "content": prompt}],
+            "task_id": task["id"],
+        })
+    return rows
+
+
+def build_multiturn_prompt_dataset(tasks: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Build conversational prompts for TRL native multi-turn tool calling."""
+    rows = []
+    for task in tasks:
+        rows.append({
+            "prompt": [
+                {
+                    "role": "system",
+                    "content": (
+                        "你是 arXiv 论文 Agent。根据任务选择工具；读取每次工具返回后再决定下一步。"
+                        "需要多个工具时必须逐步执行，任务真正完成后给出简短最终回答。"
+                    ),
+                },
+                {"role": "user", "content": task["task"]},
+            ],
             "task_id": task["id"],
         })
     return rows

--- a/AgenticArxiv/rl/multiturn_env.py
+++ b/AgenticArxiv/rl/multiturn_env.py
@@ -1,0 +1,123 @@
+"""TRL multi-turn environment adapter for AgenticArxiv.
+
+Each GRPO generation receives an independent instance.  Public methods are
+exposed to ``GRPOTrainer(environment_factory=...)`` as native tools; ``reset``
+creates a fresh session so search/download/cache state never leaks between
+rollouts.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Any, Optional
+
+from models.schemas import Paper
+from models.store_memory import MemoryStore
+from rl.env import MockArxivEnv
+
+
+class AgenticArxivMultiTurnEnv:
+    """Independent, replayable arXiv environment for one multi-turn rollout."""
+
+    def __init__(self, snapshot_path: Optional[Path] = None):
+        self.backend = MockArxivEnv(
+            snapshot_path=Path(snapshot_path) if snapshot_path else None,
+            mode="replay" if snapshot_path else "auto",
+            offline_download=True,
+        )
+        self.store = MemoryStore()
+        self.session_id = ""
+
+    def reset(self, task_id: str = "", **_: Any) -> str:
+        """Reset per-rollout state and return optional initial observation."""
+        self.store = MemoryStore()
+        suffix = task_id or "task"
+        self.session_id = f"grpo_{suffix}_{uuid.uuid4().hex[:10]}"
+        return "环境已重置；请根据任务调用工具，完成后直接给出最终回答。"
+
+    def get_recently_submitted_cs_papers(
+        self, aspect: str = "*", days: int = 7, max_results: int = 50
+    ) -> list[dict[str, Any]]:
+        """Search recent computer-science papers.
+
+        Args:
+            aspect: arXiv CS suffix such as AI, LG, CL, CV, or *.
+            days: Search window in days, from 1 to 30.
+            max_results: Maximum number of papers, from 1 to 100.
+
+        Returns:
+            Paper metadata dictionaries used by later tools in this rollout.
+        """
+        result = self.backend.execute_tool(
+            "get_recently_submitted_cs_papers",
+            {"aspect": aspect, "days": days, "max_results": max_results},
+        )
+        papers = [Paper(**item) for item in result]
+        self.store.set_last_papers(self.session_id, papers)
+        return result
+
+    def download_arxiv_pdf(self, ref: str | int = 1) -> dict[str, Any]:
+        """Download a paper selected from the latest search results.
+
+        Args:
+            ref: One-based result index, arXiv id, or title fragment.
+
+        Returns:
+            Download status and local path. Training uses an offline PDF stub.
+        """
+        paper = self.store.resolve_paper(self.session_id, ref)
+        if paper is None:
+            raise ValueError("未找到论文；请先搜索，再按序号、ID 或标题下载")
+        self.store.set_last_active_paper_id(self.session_id, paper.id)
+        return {
+            "paper_id": paper.id,
+            "pdf_url": paper.pdf_url,
+            "status": "READY",
+            "offline": True,
+        }
+
+    def translate_arxiv_pdf(self, ref: str | int = 1) -> dict[str, Any]:
+        """Translate a paper selected from the latest search results.
+
+        Args:
+            ref: One-based result index, arXiv id, or title fragment.
+
+        Returns:
+            Deterministic translation status used during RL training.
+        """
+        paper = self.store.resolve_paper(self.session_id, ref)
+        if paper is None:
+            raise ValueError("未找到论文；请先搜索，再按序号、ID 或标题翻译")
+        self.store.set_last_active_paper_id(self.session_id, paper.id)
+        return {"paper_id": paper.id, "status": "READY", "offline": True}
+
+    def get_paper_cache_status(self, ref: str | int = 1) -> dict[str, Any]:
+        """Inspect cached state for a paper in the current rollout.
+
+        Args:
+            ref: One-based result index, arXiv id, or title fragment.
+
+        Returns:
+            Whether the paper is known in the current rollout session.
+        """
+        paper = self.store.resolve_paper(self.session_id, ref)
+        return {
+            "known": paper is not None,
+            "paper_id": paper.id if paper is not None else None,
+        }
+
+
+def make_environment_factory(snapshot_path: Path):
+    """Return the zero-argument factory required by TRL GRPOTrainer."""
+    path = Path(snapshot_path)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"多轮 GRPO 需要离线快照: {path}。"
+            "请先运行 python -m AgenticArxiv.rl.build_snapshot"
+        )
+
+    def factory() -> AgenticArxivMultiTurnEnv:
+        return AgenticArxivMultiTurnEnv(path)
+
+    return factory

--- a/AgenticArxiv/rl/precision.py
+++ b/AgenticArxiv/rl/precision.py
@@ -16,7 +16,9 @@ def precision_flags() -> dict:
     import torch
 
     if not torch.cuda.is_available():
-        return {}
+        # Transformers 5.x requires CPU training to be selected explicitly;
+        # an empty dict can otherwise leave the default bf16 path enabled.
+        return {"use_cpu": True}
     if torch.cuda.is_bf16_supported():
         return {"bf16": True}
     return {"fp16": True}

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -6,8 +6,8 @@ GRPO（Group Relative Policy Optimization）：
 - 数据：**不需要预先生成**。GRPO 是在线算法，只要 prompt + 可验证奖励，
         数据集直接由 benchmark/tasks.py 派生
 
-奖励定义见 rl/grpo_reward.py：把模型生成的一步补成最小完整轨迹，
-再交给 rl/reward.py 已有的 RewardCalculator 打分，不引入第二套标准。
+奖励定义见 rl/grpo_reward.py：TRL 原生执行多轮 tool-calling，把每轮环境
+observation 插回上下文，并将完整轨迹交给 RewardCalculator 打分。
 
 训练中每 N 步自动运行 canary 评估（在固定小任务集上验证模型未退化），
 训练结束后可选运行阶段验证（检查模型是否达到最低质量阈值）。
@@ -49,8 +49,10 @@ from rl.grpo_reward import (
     build_prompt_dataset,
     load_mock_env,
     make_grpo_reward_fn,
+    make_multiturn_rollout_func,
     parse_react_action,
 )
+from rl.multiturn_env import make_environment_factory
 from rl.reward import RewardCalculator
 from rl.stage_verifier import StageVerifier
 
@@ -141,6 +143,7 @@ def main(
     beta: float = 0.04,
     num_generations: int = 4,
     max_completion_length: int = 256,
+    max_turns: int = 4,
     temperature: float = 1.0,
     snapshot: str = None,
     allow_zero_variance: bool = False,
@@ -183,13 +186,17 @@ def main(
 
     # --- 奖励函数 ---
     snapshot_path = Path(snapshot) if snapshot else DEFAULT_SNAPSHOT
-    env = load_mock_env(snapshot_path)
-    if env is None:
-        print(f"⚠️  未找到快照 {snapshot_path}，奖励将不执行工具"
-              f"（仅由格式/工具名/参数决定）。生成快照: python -m AgenticArxiv.rl.build_snapshot")
-    else:
-        print(f"🗂  使用离线快照执行工具: {snapshot_path}")
-    reward_fn = make_grpo_reward_fn({t["id"]: t for t in tasks}, env=env)
+    if not snapshot_path.exists():
+        raise SystemExit(
+            f"❌ 多轮 GRPO 需要离线快照 {snapshot_path}\n"
+            "   请先运行: python -m AgenticArxiv.rl.build_snapshot"
+        )
+    env = load_mock_env(snapshot_path)  # canary / verifier 使用
+    environment_factory = make_environment_factory(snapshot_path)
+    print(f"🗂  使用独立离线环境执行多轮工具调用: {snapshot_path}")
+    # structured completions 已携带真实 tool observations，不在 reward 端重复执行。
+    reward_fn = make_grpo_reward_fn({t["id"]: t for t in tasks}, env=None)
+    rollout_func = make_multiturn_rollout_func(environment_factory, max_turns=max_turns)
 
     # GRPO 要求生成批量能被 num_generations 整除
     if batch_size % num_generations != 0:
@@ -226,6 +233,7 @@ def main(
         args=config,
         train_dataset=train_dataset,
         processing_class=tokenizer,
+        rollout_func=rollout_func,
     )
 
     # --- Canary 回调：每 N 步在固定任务上评估，检测性能退化 ---
@@ -300,6 +308,10 @@ if __name__ == "__main__":
              "GRPO 不产生任何梯度，训练会静默空转",
     )
     p.add_argument("--max_completion_length", type=int, default=256)
+    p.add_argument(
+        "--max_turns", type=int, default=4,
+        help="每条 rollout 最多执行多少轮工具调用；环境 observation 不计入策略 loss",
+    )
     p.add_argument("--temperature", type=float, default=1.0)
     p.add_argument("--snapshot", default=None)
     p.add_argument(
@@ -319,8 +331,4 @@ if __name__ == "__main__":
         "--verify", action=argparse.BooleanOptionalAction, default=True,
         help="训练结束后运行阶段验证（默认开启）",
     )
-    a = p.parse_args()
-    main(a.model, a.output_dir, a.epochs, a.batch_size, a.grad_accum, a.lr, a.beta,
-         a.num_generations, a.max_completion_length, a.temperature, a.snapshot,
-         a.allow_zero_variance, a.canary_steps, a.min_canary_reward,
-         a.canary_patience, a.verify)
+    main(**vars(p.parse_args()))

--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -84,6 +84,7 @@ def main(
     grad_accum: int = 4,
     lr: float = 2e-5,
     max_length: int = 3072,
+    max_steps: int = -1,
     verify: bool = False,
     min_parse_rate: float = 0.3,
 ):
@@ -116,6 +117,7 @@ def main(
         gradient_accumulation_steps=grad_accum,
         learning_rate=lr,
         max_length=max_length,    # TRL>=0.20 用 max_length（旧名 max_seq_length 已移除）
+        max_steps=max_steps,
         logging_steps=10,
         save_steps=100,
         save_total_limit=3,
@@ -163,6 +165,10 @@ if __name__ == "__main__":
         "--max_length", type=int, default=3072,
         help="超过此长度的样本会被从右截断，而右边正是 assistant 目标；"
              "训练前会做长度体检，不匹配直接报错",
+    )
+    parser.add_argument(
+        "--max_steps", type=int, default=-1,
+        help="限制优化步数；-1 表示按 epochs 完整训练，可用于 CPU 烟雾测试",
     )
     parser.add_argument(
         "--verify", action="store_true", default=False,

--- a/AgenticArxiv/tests/test_canary.py
+++ b/AgenticArxiv/tests/test_canary.py
@@ -58,7 +58,14 @@ class _FakeTokenizer:
     def __call__(self, text, return_tensors="pt", **kwargs):
         # 返回假的 input_ids（长度为 10 的 prompt）
         ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]])
-        return SimpleNamespace(input_ids=ids, shape=ids.shape)
+        class FakeBatch(dict):
+            def __getattr__(self, name):
+                return self[name]
+
+            def to(self, device):
+                return FakeBatch({k: v.to(device) for k, v in self.items()})
+
+        return FakeBatch(input_ids=ids)
 
     def batch_decode(self, ids, skip_special_tokens=True):
         # 返回预设的 completion 文本

--- a/AgenticArxiv/tests/test_grpo_reward.py
+++ b/AgenticArxiv/tests/test_grpo_reward.py
@@ -24,7 +24,10 @@ import tools.pdf_translate_tool  # noqa: F401,E402
 from benchmark.tasks import get_all_tasks  # noqa: E402
 from rl.grpo_reward import (  # noqa: E402
     build_prompt_dataset,
+    build_multiturn_prompt_dataset,
     make_grpo_reward_fn,
+    make_multiturn_rollout_func,
+    messages_to_trajectory,
     parse_react_action,
     synthesize_trajectory,
 )
@@ -85,6 +88,112 @@ class TestSynthesizeTrajectory(unittest.TestCase):
         traj = synthesize_trajectory(BAD_JSON)
         self.assertEqual(traj["history"][0]["action"], "PARSE_ERROR")
         self.assertTrue(traj["history"][0]["parse_failed"])
+
+
+class TestMultiTurnTrajectory(unittest.TestCase):
+    def test_structured_messages_preserve_real_tool_chain(self):
+        completion = [
+            {
+                "role": "assistant",
+                "content": "先搜索",
+                "tool_calls": [{
+                    "type": "function",
+                    "function": {
+                        "name": "get_recently_submitted_cs_papers",
+                        "arguments": {"aspect": "CV", "days": 7, "max_results": 3},
+                    },
+                }],
+            },
+            {"role": "tool", "name": "get_recently_submitted_cs_papers", "content": "3 papers"},
+            {
+                "role": "assistant",
+                "content": "再下载",
+                "tool_calls": [{
+                    "type": "function",
+                    "function": {"name": "download_arxiv_pdf", "arguments": {"ref": 1}},
+                }],
+            },
+            {"role": "tool", "name": "download_arxiv_pdf", "content": "READY"},
+            {"role": "assistant", "content": "已完成"},
+        ]
+        traj = messages_to_trajectory(completion)
+        actions = [step["action"] for step in traj["history"]]
+        self.assertEqual(len(actions), 3)
+        self.assertIn("get_recently_submitted_cs_papers", actions[0])
+        self.assertIn("download_arxiv_pdf", actions[1])
+        self.assertEqual(actions[2], "FINISH")
+        self.assertEqual(traj["history"][0]["observation"], "3 papers")
+        self.assertEqual(traj["history"][1]["observation"], "READY")
+
+    def test_reward_uses_all_turns(self):
+        completion = [
+            {
+                "role": "assistant", "content": "",
+                "tool_calls": [{"type": "function", "function": {
+                    "name": "get_recently_submitted_cs_papers",
+                    "arguments": {"aspect": "CV", "days": 7, "max_results": 3},
+                }}],
+            },
+            {"role": "tool", "name": "get_recently_submitted_cs_papers", "content": "3 papers"},
+            {
+                "role": "assistant", "content": "",
+                "tool_calls": [{"type": "function", "function": {
+                    "name": "download_arxiv_pdf", "arguments": {"ref": 1},
+                }}],
+            },
+            {"role": "tool", "name": "download_arxiv_pdf", "content": "READY"},
+            {"role": "assistant", "content": "done"},
+        ]
+        fn = make_grpo_reward_fn(TASKS)
+        reward = fn(completions=[completion], task_id=["composite_01"])[0]
+        self.assertEqual(reward, 1.0)
+
+    def test_custom_rollout_masks_environment_tokens(self):
+        class Tokenizer:
+            def apply_chat_template(self, prompt, tokenize=True, add_generation_prompt=True):
+                return [1, 2]
+
+            def __call__(self, text, add_special_tokens=False):
+                return {"input_ids": [200 + i for i, _ in enumerate(text)]}
+
+            def decode(self, ids, skip_special_tokens=True):
+                if ids and ids[0] == 101:
+                    return CORRECT
+                return BARE_FINISH
+
+        class Model:
+            training = True
+
+        class Trainer:
+            processing_class = Tokenizer()
+            num_generations = 1
+            num_generations_eval = 1
+            max_completion_length = 256
+            model = Model()
+
+            def __init__(self): self.calls = 0
+
+            def _generate_single_turn(self, prompt_ids, images, fields):
+                self.calls += 1
+                token = 101 if self.calls == 1 else 102
+                return [[token] for _ in prompt_ids], None, {}
+
+        class Environment:
+            def reset(self): return None
+
+            def get_recently_submitted_cs_papers(self, **kwargs):
+                return [{"id": "x", "title": "paper"}]
+
+        output = make_multiturn_rollout_func(Environment, max_turns=2)(
+            [[{"role": "user", "content": "task"}]], Trainer()
+        )
+        history = output["trajectory_results"][0]["history"]
+        self.assertEqual(len(history), 2)
+        self.assertIn("get_recently_submitted_cs_papers", history[0]["action"])
+        self.assertEqual(history[1]["action"], "FINISH")
+        self.assertIn(0, output["env_mask"][0])
+        self.assertIn(1, output["env_mask"][0])
+        self.assertEqual(len(output["completion_ids"][0]), len(output["env_mask"][0]))
 
 
 class TestRewardOrdering(unittest.TestCase):
@@ -152,6 +261,11 @@ class TestPromptDataset(unittest.TestCase):
         self.assertIn("Action:", content)
         self.assertIn("get_recently_submitted_cs_papers", content)
         self.assertIn("task_id", rows[0])
+
+    def test_multiturn_prompt_is_conversational(self):
+        rows = build_multiturn_prompt_dataset(get_all_tasks())
+        self.assertEqual([m["role"] for m in rows[0]["prompt"]], ["system", "user"])
+        self.assertIn("读取每次工具返回", rows[0]["prompt"][0]["content"])
 
 
 if __name__ == "__main__":

--- a/AgenticArxiv/tests/test_multiturn_env.py
+++ b/AgenticArxiv/tests/test_multiturn_env.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import unittest
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PACKAGE_ROOT))
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+from rl.multiturn_env import AgenticArxivMultiTurnEnv  # noqa: E402
+
+
+PAPER = {
+    "id": "2601.00001v1",
+    "title": "A Test Paper",
+    "authors": ["A"],
+    "summary": "test",
+    "published": "2026-01-01 00:00:00",
+    "updated": "2026-01-01 00:00:00",
+    "pdf_url": "https://arxiv.org/pdf/2601.00001v1",
+    "primary_category": "cs.AI",
+    "categories": ["cs.AI"],
+    "comment": None,
+    "links": [],
+}
+
+
+class FakeBackend:
+    def execute_tool(self, name, args):
+        if name == "get_recently_submitted_cs_papers":
+            return [PAPER]
+        raise AssertionError(name)
+
+
+class MultiTurnEnvTest(unittest.TestCase):
+    def setUp(self):
+        self.env = AgenticArxivMultiTurnEnv()
+        self.env.backend = FakeBackend()
+        self.env.reset(task_id="composite_01")
+
+    def test_search_then_download_uses_same_session_state(self):
+        papers = self.env.get_recently_submitted_cs_papers("AI", 7, 3)
+        downloaded = self.env.download_arxiv_pdf(1)
+        self.assertEqual(len(papers), 1)
+        self.assertEqual(downloaded["paper_id"], PAPER["id"])
+        self.assertTrue(downloaded["offline"])
+
+    def test_reset_clears_paper_memory(self):
+        self.env.get_recently_submitted_cs_papers("AI", 7, 3)
+        self.env.reset(task_id="next")
+        with self.assertRaises(ValueError):
+            self.env.download_arxiv_pdf(1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AgenticArxiv/tests/test_training_guards.py
+++ b/AgenticArxiv/tests/test_training_guards.py
@@ -118,7 +118,7 @@ class PrecisionFlagsTest(unittest.TestCase):
             return precision_flags()
 
     def test_no_mixed_precision_off_cuda(self):
-        self.assertEqual(self._flags(cuda=False, bf16=False), {})
+        self.assertEqual(self._flags(cuda=False, bf16=False), {"use_cpu": True})
 
     def test_prefers_bf16_when_supported(self):
         self.assertEqual(self._flags(cuda=True, bf16=True), {"bf16": True})

--- a/README.en.md
+++ b/README.en.md
@@ -198,7 +198,7 @@ python -m AgenticArxiv.rl.train_grpo
 - No value model required (PPO's drawback: high VRAM overhead)
 - Suitable for small models (e.g., Qwen2.5-1.5B)
 
-**Reward scoring** (`rl/grpo_reward.py`): the model's single-step completion is parsed into a ReAct action, executed with `MockArxivEnv`, and completed into a "minimal full trajectory" before being scored by the five-component `RewardCalculator` — the same standard used by rollout and benchmark, with no second reward definition.
+**Multi-turn rollout and reward scoring** (`rl/grpo_reward.py`): the current policy generates a ReAct action at every turn, an independent `MockArxivEnv` executes it, and the observation is appended back to context until completion or `--max_turns`. Assistant tokens participate in GRPO loss while environment tokens are excluded with `env_mask=0`; the complete trajectory is scored by the shared five-component `RewardCalculator`.
 
 ### Training Quality Guards (auto-verification)
 
@@ -474,7 +474,7 @@ Ordered by priority. Contributions welcome (see 🤝 Contributing).
 
 ### P0 — Near term (close core gaps)
 
-- [ ] **Multi-turn Agentic Rollout**: GRPO currently scores only the model's **single-step** completion as a "synthesized minimal trajectory" — there is no real multi-turn "act → observe → act" interaction. Use TRL's tool-calling / multi-turn support with `MockArxivEnv` as the tool backend and assistant-only loss masking to close the most conspicuous gap against the "Agentic RL" name.
+- [x] **Multi-turn Agentic Rollout**: implemented real "act → observe → act" sampling with an independent `MockArxivEnv` per generation; environment tokens use `env_mask=0`, while the complete assistant trajectory participates in GRPO optimization and reward scoring.
 - [ ] **Training observability**: wire up wandb / TensorBoard (currently `report_to=[]`, no monitoring) and log reward / advantage / KL / per-component curves before tuning hyperparameters.
 
 ### P1 — Mid term (data & evaluation)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,12 @@ python -m AgenticArxiv.rl.train_grpo
 - 无需 value model（PPO 的缺点：显存开销大）
 - 适合小模型（如 Qwen2.5-1.5B）
 
-**奖励打分**（`rl/grpo_reward.py`）：把模型生成的单步 completion 解析为 ReAct 动作，用 `MockArxivEnv` 执行工具后补成「最小完整轨迹」，再交给五分量 `RewardCalculator` 打分——与 rollout / benchmark 共用同一套标准，不引入第二套奖励。
+**多轮 rollout 与奖励打分**（`rl/grpo_reward.py`）：每轮由当前 policy 生成 ReAct 动作，独立 `MockArxivEnv` 执行工具并把 observation 插回上下文，直到 `FINISH`、解析失败或达到 `--max_turns`。所有 assistant token 进入 GRPO loss，环境 observation token 通过 `env_mask=0` 仅作上下文；完整轨迹再交给五分量 `RewardCalculator` 打分，与 rollout / benchmark 共用同一套标准。
+
+```bash
+python -m AgenticArxiv.rl.build_snapshot
+python -m AgenticArxiv.rl.train_grpo --model outputs/sft/final --max_turns 4
+```
 
 ### 训练质量保障（自动校验）
 
@@ -479,7 +484,7 @@ PPO 更适合生产级大模型训练（7B+），本项目作为学习 demo 不�
 
 ### P0 — 近期（填补核心缺口）
 
-- [ ] **多轮 Agentic Rollout**：当前 GRPO 只对模型生成的**单步** completion 做「合成最小轨迹」打分，未实现真正的多轮「行动 → 环境反馈 → 再行动」交互采样。用 TRL 的 tool-calling / multi-turn 机制 + `MockArxivEnv` 作工具后端，配合 assistant-only loss mask（只让模型 token 参与训练），补齐与「Agentic RL」之名最不相称的缺口。
+- [x] **多轮 Agentic Rollout**：已实现真正的「行动 → 环境反馈 → 再行动」交互采样；每条 generation 使用独立 `MockArxivEnv`，环境 token 以 `env_mask=0` 排除策略 loss，完整 assistant 轨迹参与 GRPO 更新与五分量奖励。
 - [ ] **训练可观测性**：接入 wandb / TensorBoard（当前 `report_to=[]`，无任何监控），记录 reward / advantage / kl / 各奖励分量曲线，再谈超参调优。
 
 ### P1 — 中期（数据与评测）


### PR DESCRIPTION
## Summary

- add a real multi-turn ReAct environment for GRPO rollouts
- feed tool observations back into the policy while masking environment tokens from the loss
- compute rewards from the full multi-turn trajectory and preserve single-turn compatibility
- document the multi-turn training path and add focused regression coverage
- fix CPU/canary training guards encountered during the smoke run

## Validation

- `PYTHONIOENCODING=utf-8 .venv/Scripts/python.exe -m unittest discover -s AgenticArxiv/tests`
- 131 tests passed
- initialized the GRPO multi-turn path with the 135M smoke-test model
