### PR TITLE
fix(rl): treat JSON-wrapped FINISH as termination, not a tool call

### DIFF
--- a/AgenticArxiv/rl/grpo_reward.py
+++ b/AgenticArxiv/rl/grpo_reward.py
@@ -27,6 +27,7 @@ import re
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence
 
+from benchmark.metrics import NON_TOOL_ACTIONS
 from rl.reward import RewardCalculator
 
 # 与 agents/agent_engine.py 的解析规则保持一致
@@ -52,7 +53,7 @@ def parse_react_action(completion: str):
     action_text = match.group(1).strip()
     if not action_text:
         return "parse_error", None
-    if action_text.upper().startswith("FINISH"):
+    if action_text.upper().startswith(NON_TOOL_ACTIONS):
         return "finish", None
 
     json_match = re.search(r"(\{.*\})", action_text, re.DOTALL)
@@ -66,6 +67,11 @@ def parse_react_action(completion: str):
 
     if not isinstance(parsed, dict) or not parsed.get("name"):
         return "parse_error", None
+    # 模型常把结束写成 Action: {"name": "FINISH", "args": {}}。当成工具调用会让
+    # rollout 拿到「未知工具」的 observation 继续跑满 max_turns，并给一条本已
+    # 正确收尾的轨迹记上一次失败调用 —— 奖励因此与 benchmark 的判定不一致。
+    if str(parsed["name"]).strip().upper() in NON_TOOL_ACTIONS:
+        return "finish", None
     return "call", {"name": parsed["name"], "args": parsed.get("args") or {}}
 
 

--- a/AgenticArxiv/tests/test_grpo_reward.py
+++ b/AgenticArxiv/tests/test_grpo_reward.py
@@ -43,6 +43,8 @@ WRONG_ARGS = ('Thought: 需要检索\n'
               '"args":{"aspect":"CR","days":30,"max_results":99}}')
 WRONG_TOOL = 'Thought: 下载\nAction: {"name":"download_arxiv_pdf","args":{"ref":1}}'
 BARE_FINISH = 'Thought: 完成了\nAction: FINISH'
+JSON_FINISH = 'Thought: 完成了\nAction: {"name": "FINISH", "args": {}}'
+JSON_FORCE_STOP = 'Thought: 放弃\nAction: {"name": "FORCE_STOP", "args": {}}'
 BAD_JSON = "Thought: t\nAction: {'name': 'get_recently_submitted_cs_papers',}"
 NO_ACTION = "Thought: 我先想想该怎么做"
 
@@ -60,6 +62,25 @@ class TestParseReactAction(unittest.TestCase):
 
     def test_finish(self):
         self.assertEqual(parse_react_action(BARE_FINISH)[0], "finish")
+
+    def test_json_wrapped_finish_is_not_a_tool_call(self):
+        """模型常把结束写成和工具调用一样的 JSON 外壳。
+
+        当成工具调用会连锁出三件事：rollout 拿到「未知工具: FINISH」的
+        observation 并继续跑满 max_turns；一条本已正确收尾的轨迹被记上一次
+        失败调用；奖励因此低于 benchmark 对同一条轨迹的判定。
+        """
+        self.assertEqual(parse_react_action(JSON_FINISH), ("finish", None))
+        self.assertEqual(parse_react_action(JSON_FORCE_STOP), ("finish", None))
+
+    def test_finish_case_insensitive(self):
+        self.assertEqual(parse_react_action('Thought: t\nAction: {"name": "finish"}')[0],
+                         "finish")
+
+    def test_real_tool_still_parsed_after_finish_guard(self):
+        kind, action = parse_react_action(WRONG_TOOL)
+        self.assertEqual(kind, "call")
+        self.assertEqual(action["name"], "download_arxiv_pdf")
 
     def test_bad_json_is_parse_error(self):
         """prompt 要求严格 JSON，坏 JSON 不应被降级修复，否则格式惩罚失效。"""


### PR DESCRIPTION
## 问题

`parse_react_action` 只认裸字符串形式的结束动作：

```python
# rl/grpo_reward.py:55
if action_text.upper().startswith("FINISH"):
    return "finish", None
```

模型经常把结束写成和工具调用完全一样的 JSON 外壳。这种输入会跳过上面的判断，
落到下面的 JSON 分支，被当成一次工具调用：

```
Action: {"name": "FINISH", "args": {}}   →   ('call', {'name': 'FINISH', 'args': {}})
```

## 为什么多轮 rollout 落地后这件事变严重了

单步路径下它只让 `synthesize_trajectory` 少补一步。进了 `make_multiturn_rollout_func`
的循环，同一个返回值会连锁出三件事：

1. dispatch 走到 `raise ValueError(f"未知工具: {action['name']}")`（`grpo_reward.py:325`），
   被 except 兜住后模型收到 `工具执行失败: 未知工具: FINISH` 的 observation；
2. 因为没走 `kind == "finish"` 的分支（`:302`），该条 rollout **不终止**，
   被重新放回 `next_active`（`:342`），继续跑满 `max_turns`——白烧 token，
   而且后续轮次是在一段自相矛盾的上下文上续写的；
3. `histories` 里多出一条 action=FINISH、observation=执行失败的记录，
   一条**本已正确收尾**的轨迹被记上一次失败调用，`RewardCalculator` 因此给出
   低于实际表现的分数。

第 3 条与本模块 docstring 明确承诺的「**不引入第二套奖励标准**」相悖。
benchmark 侧 `metrics._parse_tool_action` 早已把这个形态排除在
`tool_call_sequence` 之外（否则完全正确的轨迹会被判成 `accurate=False`），
奖励侧却把它当成一次失败的工具调用——同一条轨迹，两套判定。

## 复现

```python
from rl.grpo_reward import parse_react_action
parse_react_action('Thought: 完成\nAction: {"name": "FINISH", "args": {}}')
```

| | 返回值 |
|---|---|
| 修复前 | `('call', {'name': 'FINISH', 'args': {}})` |
| 修复后 | `('finish', None)` |

## 修法

复用 `benchmark/metrics.py` 里已有的 `NON_TOOL_ACTIONS`
（`("FINISH", "FORCE_STOP", "ERROR")`），让奖励侧、benchmark 侧、
`agents/base_agent.py::is_terminal_action` 共用同一份终止动作定义：

```python
if not isinstance(parsed, dict) or not parsed.get("name"):
    return "parse_error", None
if str(parsed["name"]).strip().upper() in NON_TOOL_ACTIONS:
    return "finish", None
```

顺带把裸字符串那一支从硬编码的 `"FINISH"` 换成同一个元组，
`FORCE_STOP` / `ERROR` 两种形态也一并收口。

**关于导入来源**：没有从 `agents.base_agent` 导 `is_terminal_action`，
因为那会把 `LLMClient` → `loguru` 整条 agent 依赖链拖进 GRPO 的奖励路径。
`rl/reward.py` 本来就 `from benchmark.metrics import ...`，走
`benchmark.metrics` 不新增任何依赖边。

## 兼容性

原来的 `startswith` 语义完整保留（`Action: FINISH.`、`Action: FINISH 任务完成`
这类带后缀的写法仍判为结束），只是新增了 JSON 外壳与另外两个终止动作。

## 测试

`tests/test_grpo_reward.py` 新增 3 个用例：

- `test_json_wrapped_finish_is_not_a_tool_call` —— `FINISH` / `FORCE_STOP` 的 JSON 外壳
- `test_finish_case_insensitive` —— `{"name": "finish"}`
- `test_real_tool_still_parsed_after_finish_guard` —— 确认真实工具调用没被新判断误伤

全量 `python -m unittest discover -s tests`：**134 passed**。

## 一点说明

`Action: {"name": "FINISH", ...}` 这个形态是在 **benchmark** 上实测到的
（258 次运行中 5 次；某条条件分支任务上 8/16），**不是**在 GRPO rollout 中统计的——
rollout 用的模型与采样温度不同，实际频率会有差异。但触发路径与上面的
连锁后果已在当前 `main` 上复现确认。
