### PR TITLE
Fix/multiturn rollout cardinality

### DIFF
--- a/AgenticArxiv/requirements.txt
+++ b/AgenticArxiv/requirements.txt
@@ -1,9 +1,11 @@
 # ===== RL 训练核心依赖 =====
 torch>=2.0.0
 transformers>=4.45.0
-# 训练脚本使用 TRL 现行 API（SFTConfig.max_length、Trainer(processing_class=...)），
-# 这些在 trl<0.20 上不存在。下限按实际验证过的版本给出（已在 trl 0.29.1 上验证）。
-trl>=0.20.0
+# 训练脚本使用 TRL 现行 API（SFTConfig.max_length、Trainer(processing_class=...)）。
+# 下限由多轮 GRPO 决定：TRL 从 0.28.0 起才在非 vLLM 路径上调用 rollout_func，
+# 更早的版本会让多轮 rollout 静默失效（不报错，但每条轨迹退化成一步 FINISH）。
+# 已在 trl 0.29.1 上验证。
+trl>=0.28.0
 datasets>=2.14.0
 accelerate>=0.25.0
 

--- a/AgenticArxiv/rl/grpo_reward.py
+++ b/AgenticArxiv/rl/grpo_reward.py
@@ -34,6 +34,12 @@ from rl.reward import RewardCalculator
 _THOUGHT_RE = re.compile(r"Thought:\s*(.*?)(?=\nAction:|$)", re.DOTALL)
 _ACTION_RE = re.compile(r"Action:\s*(.*?)(?=\nObservation:|$)", re.DOTALL)
 
+# TRL 从 0.28.0 起才会在**非 vLLM** 路径上调用 rollout_func，签名也才是
+# rollout_func(prompts, trainer)。更早的版本里它只在 use_vllm 且
+# vllm_mode == "server" 时被调用 —— 默认配置下压根不会执行，多轮 rollout
+# 静默失效，奖励退回 messages_to_trajectory（任何非空文本都算一步 FINISH）。
+MIN_TRL_FOR_ROLLOUT_FUNC = "0.28.0"
+
 
 def parse_react_action(completion: str):
     """从模型输出中解析动作。
@@ -248,6 +254,31 @@ def make_grpo_reward_fn(
     return grpo_reward_fn
 
 
+def rollout_func_supported(trl_version: str) -> bool:
+    """当前 TRL 是否会在非 vLLM 路径上调用 rollout_func。"""
+    from packaging.version import Version
+
+    return Version(trl_version) >= Version(MIN_TRL_FOR_ROLLOUT_FUNC)
+
+
+def require_rollout_func_support() -> None:
+    """TRL 太老就直接拦下，而不是让多轮 rollout 静默失效。
+
+    这类失败特别难查：训练照常跑完、loss 也在动，只是每条 rollout 都退化成
+    「一步 FINISH」，词沙拉也能拿到正分。宁可在启动时报错。
+    """
+    from importlib.metadata import version
+
+    installed = version("trl")
+    if not rollout_func_supported(installed):
+        raise SystemExit(
+            f"❌ 多轮 GRPO rollout 需要 trl >= {MIN_TRL_FOR_ROLLOUT_FUNC}，当前是 {installed}\n"
+            f"   更早的版本只在 vLLM server 模式下调用 rollout_func，默认配置下多轮采样\n"
+            f"   不会执行且不会报错 —— 奖励会退化成「任何非空输出都算完成」。\n"
+            f"   升级: pip install -U 'trl>={MIN_TRL_FOR_ROLLOUT_FUNC}'"
+        )
+
+
 def make_multiturn_rollout_func(environment_factory, max_turns: int = 4):
     """Create a TRL custom rollout function for textual ReAct models.
 
@@ -256,6 +287,7 @@ def make_multiturn_rollout_func(environment_factory, max_turns: int = 4):
     policy tokens use ``env_mask=1`` and therefore participate in GRPO loss.
     The full history is forwarded to the reward function as an extra field.
     """
+    require_rollout_func_support()
     max_turns = max(1, int(max_turns))
 
     def rollout_func(prompts, trainer):

--- a/AgenticArxiv/rl/grpo_reward.py
+++ b/AgenticArxiv/rl/grpo_reward.py
@@ -262,8 +262,11 @@ def make_multiturn_rollout_func(environment_factory, max_turns: int = 4):
         import copy
 
         tokenizer = trainer.processing_class
-        generations = trainer.num_generations if trainer.model.training else trainer.num_generations_eval
-        expanded_prompts = [copy.deepcopy(p) for p in prompts for _ in range(generations)]
+        # 不要再按 num_generations 展开：TRL 交进来的 prompts 已经是重复过的
+        # （num_generations=2 时收到的是 2 条一模一样的 prompt）。再展开一次会让
+        # 返回条数变成 N*G*G，与 TRL 期望的 N*G 对不上，在 shuffle_sequence_dict
+        # 处炸成 IndexError。
+        expanded_prompts = [copy.deepcopy(p) for p in prompts]
         prompt_ids = []
         for prompt in expanded_prompts:
             ids = tokenizer.apply_chat_template(

--- a/AgenticArxiv/tests/test_grpo_reward.py
+++ b/AgenticArxiv/tests/test_grpo_reward.py
@@ -361,5 +361,42 @@ class MultiTurnRolloutCardinalityTest(unittest.TestCase):
         self.assertEqual(trainer.seen_batch_sizes[0], 4)
 
 
+class TrlVersionGuardTest(unittest.TestCase):
+    """TRL 太老时必须启动即失败，而不是让多轮 rollout 静默失效。
+
+    trl < 0.28 只在 use_vllm 且 vllm_mode == "server" 时调用 rollout_func。
+    默认配置下多轮采样根本不执行，也不报错 —— 奖励退回
+    messages_to_trajectory，任何非空 assistant 文本都被当成一步 FINISH，
+    随机初始化的模型输出词沙拉也能拿到正分。
+    """
+
+    def test_version_boundary(self):
+        from rl.grpo_reward import rollout_func_supported
+        for version, supported in (
+            ("0.20.0", False), ("0.25.1", False), ("0.27.9", False),
+            ("0.28.0", True), ("0.29.1", True), ("1.0.0", True),
+        ):
+            with self.subTest(version=version):
+                self.assertEqual(rollout_func_supported(version), supported)
+
+    def test_old_trl_raises_with_upgrade_hint(self):
+        from unittest import mock
+        import rl.grpo_reward as gr
+        # 伪造一个装了旧版 trl 的环境，别依赖本机实际装的版本
+        with mock.patch("importlib.metadata.version", return_value="0.25.1"):
+            with self.assertRaises(SystemExit) as ctx:
+                gr.require_rollout_func_support()
+        message = str(ctx.exception)
+        self.assertIn("trl>=0.28.0", message)   # 给出可执行的升级命令
+        self.assertIn("不会报错", message)       # 点明这是静默失效
+        self.assertIn("0.25.1", message)        # 报出当前实际装的版本
+
+    def test_supported_trl_passes_silently(self):
+        from unittest import mock
+        import rl.grpo_reward as gr
+        with mock.patch("importlib.metadata.version", return_value="0.28.0"):
+            gr.require_rollout_func_support()   # 不抛异常即可
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/AgenticArxiv/tests/test_grpo_reward.py
+++ b/AgenticArxiv/tests/test_grpo_reward.py
@@ -289,5 +289,77 @@ class TestPromptDataset(unittest.TestCase):
         self.assertIn("读取每次工具返回", rows[0]["prompt"][0]["content"])
 
 
+class FakeGenerationTrainer:
+    """够 make_multiturn_rollout_func 跑一轮的最小 trainer 替身。"""
+
+    class _Model:
+        training = True
+
+    def __init__(self, tokenizer, num_generations=2, max_completion_length=16):
+        self.processing_class = tokenizer
+        self.model = self._Model()
+        self.num_generations = num_generations
+        self.num_generations_eval = num_generations
+        self.max_completion_length = max_completion_length
+        self.seen_batch_sizes = []
+
+    def _generate_single_turn(self, prompt_ids, images, multimodal_fields):
+        self.seen_batch_sizes.append(len(prompt_ids))
+        # 每条都直接 FINISH，让 rollout 一轮结束
+        ids = self.processing_class("Thought: 完成\nAction: FINISH",
+                                    add_special_tokens=False)["input_ids"]
+        return [list(ids) for _ in prompt_ids], None, None
+
+
+class MultiTurnRolloutCardinalityTest(unittest.TestCase):
+    """rollout_func 返回的条数必须与 TRL 传进来的 prompts 条数一致。
+
+    TRL 交进来的 prompts 已经按 num_generations 重复过（num_generations=2
+    时收到 2 条一模一样的 prompt）。rollout 里若再展开一次，返回条数会变成
+    N*G*G，TRL 在 shuffle_sequence_dict 处直接抛
+    `IndexError: index 3 is out of bounds for dimension 0 with size 2`，
+    多轮 GRPO 一步都跑不完。
+    """
+
+    def _tokenizer(self):
+        class Tok:
+            def __call__(self, text, add_special_tokens=True):
+                return {"input_ids": [1, 2, 3]}
+
+            def apply_chat_template(self, prompt, tokenize=True, add_generation_prompt=True):
+                return [4, 5]
+
+            def decode(self, ids, skip_special_tokens=True):
+                return "Thought: 完成\nAction: FINISH"
+        return Tok()
+
+    def _rollout(self, num_prompts, num_generations):
+        from rl.grpo_reward import make_multiturn_rollout_func
+
+        class _Env:
+            def reset(self, *a, **k):
+                return ""
+
+        trainer = FakeGenerationTrainer(self._tokenizer(), num_generations=num_generations)
+        fn = make_multiturn_rollout_func(lambda: _Env(), max_turns=2)
+        prompts = [[{"role": "user", "content": "任务"}]] * num_prompts
+        return fn(prompts, trainer), trainer
+
+    def test_output_length_matches_input_length(self):
+        for num_prompts, num_generations in ((2, 2), (4, 2), (6, 3), (1, 1)):
+            with self.subTest(prompts=num_prompts, generations=num_generations):
+                out, _ = self._rollout(num_prompts, num_generations)
+                for key in ("prompt_ids", "completion_ids", "env_mask", "trajectory_results"):
+                    self.assertEqual(
+                        len(out[key]), num_prompts,
+                        f"{key} 条数应等于传入的 prompts 条数，不能再乘一次 num_generations",
+                    )
+
+    def test_generation_batch_is_not_inflated(self):
+        """展开一次会让每步生成量翻 num_generations 倍，显存和耗时都跟着翻。"""
+        _, trainer = self._rollout(num_prompts=4, num_generations=2)
+        self.assertEqual(trainer.seen_batch_sizes[0], 4)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## 问题

`make_multiturn_rollout_func` 把 TRL 交进来的 prompts 又按 `num_generations` 展开了一次：

```python
# rl/grpo_reward.py
generations = trainer.num_generations if trainer.model.training else trainer.num_generations_eval
expanded_prompts = [copy.deepcopy(p) for p in prompts for _ in range(generations)]
```

但 TRL 传进来的 prompts **已经是重复过的**。实测打印（`num_generations=2`）：

```
TRL 传入 prompts 条数      : 2
trainer.num_generations   : 2
两条是否相同               : True        <-- 同一个 prompt 的 2 份副本
返回 prompt_ids 条数       : 4           <-- 又乘了一次
```

于是返回的 `prompt_ids` / `completion_ids` / `env_mask` / `trajectory_results`
全部是 `N*G*G` 条，与 TRL 期望的 `N*G` 对不上。

## 后果分两种，都不是「能跑但效果差」

### trl >= 0.28（含 README 声明验证过的 0.29.1）

`rollout_func` 走非-vLLM 路径，条数对不上，**第一步就崩**：

```
File "trl/trainer/utils.py", line 917, in permute
    return v[permutation]
IndexError: index 3 is out of bounds for dimension 0 with size 2
  0%|          | 0/8 [00:03<?, ?it/s]
```

也就是 README 里那条 `python -m AgenticArxiv.rl.train_grpo --max_turns 4`
在声明支持的版本上一步都跑不完。

### trl < 0.28

`rollout_func` 只在 `use_vllm and vllm_mode == "server"` 下才被调用
（0.25.1 的非-vLLM 分支里写着 `extra_fields = {}  # No extra fields for
non-rollout_func paths`），默认配置下压根不会执行。多轮 rollout **静默失效**，
奖励退回 `messages_to_trajectory(单条 assistant 消息)`——而那个函数会把任何
非空 assistant 文本当成一步 `FINISH`：

```python
elif str(message.get("content") or "").strip():
    history.append({..., "action": "FINISH", "observation": "任务完成"})
```

实测一个**随机初始化**的 3M 模型，输出是纯词沙拉：

```
' channel labour bloodshed metavarwey marginalizedrfParameter McGraw ditches Herbs ...'
```

拿到的分数是：

| | 值 |
|---|---|
| reward | **+0.3125** |
| format 分量 | **+1.0** |
| process 分量 | **+1.0** |
| tool 分量 | −1.0 |

词沙拉被判成「格式完美、过程完美、正常收尾，只是没调工具」。

顺带一提，展开还会让每步实际生成量翻 `num_generations` 倍，显存与耗时同步翻倍。

## 修法

去掉这次展开，直接用 TRL 给的 prompts。

## 修复后

同一个随机模型、同样的命令：

| | 修复前 | 修复后 |
|---|---|---|
| reward | +0.3125 | **−0.8125** |
| format | +1.0 | **−1.0** |
| process | +1.0 | **−1.0** |
| parse_error_rate | 0.0 | **1.0** |

与「输出不可解析」的事实一致。

## 顺带堵上 trl < 0.28 那一支

上面第二种情况光靠这个基数修复是修不掉的——`rollout_func` 在那些版本上根本
不会被调用。所以本 PR 还做了两件事：

- `requirements.txt` 的下限从 `trl>=0.20.0` 提到 `>=0.28.0`。原下限是按
  `SFTConfig.max_length` / `processing_class` 这些 API 定的，没考虑多轮 rollout。
- `make_multiturn_rollout_func` 构造时再查一次实际装的版本——用户环境未必按
  requirements 装：

```
❌ 多轮 GRPO rollout 需要 trl >= 0.28.0，当前是 0.25.1
   更早的版本只在 vLLM server 模式下调用 rollout_func，默认配置下多轮采样
   不会执行且不会报错 —— 奖励会退化成「任何非空输出都算完成」。
   升级: pip install -U 'trl>=0.28.0'
```

## 测试

`MultiTurnRolloutCardinalityTest` 用一个最小 trainer 替身钉住基数契约：

- `test_output_length_matches_input_length` —— 四组 (prompts, generations)
  组合下，`prompt_ids` / `completion_ids` / `env_mask` / `trajectory_results`
  的条数都必须等于传入的 prompts 条数
- `test_generation_batch_is_not_inflated` —— 单步生成批量不被放大

去掉修复后该测试失败（`AssertionError: 18 != 6`）。

`TrlVersionGuardTest` 覆盖版本边界（0.20 / 0.25.1 / 0.27.9 → 不支持；
0.28.0 / 0.29.1 / 1.0.0 → 支持）与报错文案；用 mock 伪造装了旧版 trl 的环境，
不依赖本机实际版本。

全量 `python -m unittest discover -s tests`：**139 passed**。

## 验证环境

trl 0.29.1 / transformers 4.57.1，离线快照 + 随机初始化的 3M 参数模型
（只为验证控制流，不涉及训练效果）。另在 trl 0.25.1 上复现了静默失效那一支。
