### PR TITLE
Feat/training observability v2

### DIFF
--- a/AgenticArxiv/requirements-extra.txt
+++ b/AgenticArxiv/requirements-extra.txt
@@ -4,3 +4,7 @@ fastapi
 uvicorn[standard]
 sqlalchemy>=2.0
 pymysql
+
+# ===== 训练曲线后端（--report_to，按需装一个） =====
+tensorboard   # 零配置、离线可用，推荐；查看: tensorboard --logdir outputs/<stage>/logs
+# wandb       # 需要联网与 API key

--- a/AgenticArxiv/rl/grpo_reward.py
+++ b/AgenticArxiv/rl/grpo_reward.py
@@ -40,6 +40,10 @@ _ACTION_RE = re.compile(r"Action:\s*(.*?)(?=\nObservation:|$)", re.DOTALL)
 # 静默失效，奖励退回 messages_to_trajectory（任何非空文本都算一步 FINISH）。
 MIN_TRL_FOR_ROLLOUT_FUNC = "0.28.0"
 
+# 工具执行失败时写进 observation 的前缀。抽成常量是为了让
+# rl/observability.py 统计 tool_error_rate 时不必字面量匹配一段会漂的文案。
+TOOL_ERROR_PREFIX = "工具执行失败: "
+
 
 def parse_react_action(completion: str):
     """从模型输出中解析动作。
@@ -131,7 +135,7 @@ def synthesize_trajectory(
             else:
                 observation = str(result)[:500]
         except Exception as exc:                      # noqa: BLE001
-            observation = f"工具执行失败: {exc}"
+            observation = f"{TOOL_ERROR_PREFIX}{exc}"
 
     return {
         "history": [
@@ -213,11 +217,18 @@ def make_grpo_reward_fn(
     tasks_by_id: Dict[str, Dict[str, Any]],
     env: Any = None,
     reward_calc: Optional[RewardCalculator] = None,
+    tracker: Any = None,
 ) -> Callable[..., List[float]]:
     """构造 TRL GRPOTrainer 用的 reward function。
 
     TRL 会把数据集中除 prompt/completion 之外的列按列名作为关键字参数传入，
     因此数据集需要带一个 `task_id` 列。
+
+    Args:
+        tracker: 可选的 `rl.observability.RewardComponentTracker`。只返回
+            `breakdown.total` 会把五个分量丢掉，而课程会在前 30 步改变各分量
+            的权重 —— 没有分量曲线就无法判断 reward 上升是策略变强还是权重
+            表在动。传入 tracker 即把分量、权重与轨迹健康度一并记进训练日志。
     """
     calc = reward_calc or RewardCalculator()
 
@@ -247,6 +258,8 @@ def make_grpo_reward_fn(
             breakdown, _ = calc.compute_reward_breakdown(
                 task_def, result, training_step=step
             )
+            if tracker is not None:
+                tracker.record(breakdown, result)
             rewards.append(float(breakdown.total))
         return rewards
 
@@ -366,7 +379,7 @@ def make_multiturn_rollout_func(environment_factory, max_turns: int = 4):
                         raise ValueError(f"未知工具: {action['name']}")
                     observation = str(result)[:1000]
                 except Exception as exc:  # noqa: BLE001
-                    observation = f"工具执行失败: {exc}"
+                    observation = f"{TOOL_ERROR_PREFIX}{exc}"
 
                 histories[index].append({
                     "thought": thought,

--- a/AgenticArxiv/rl/observability.py
+++ b/AgenticArxiv/rl/observability.py
@@ -1,0 +1,200 @@
+"""训练可观测性：把奖励曲线从 console scrollback 搬到 TensorBoard / wandb。
+
+三个训练脚本此前的日志后端是不一致的，而且两种方式都不对：
+
+  - train_grpo.py 写死 ``report_to=[]``，任何后端都进不去；
+  - train_sft.py / train_dpo.py 根本不设 ``report_to``，HF 会解析成 "all"，
+    也就是「装了什么就启用什么」—— 同一份代码在本机和集群上行为不同，
+    集群上恰好装了 wandb 就会在训练开始时卡住等 API key。
+
+这里给三个阶段统一一个显式的 ``--report_to``，并且在后端没装时**直接报错**，
+而不是静默地什么都不记（静默失败正是这个仓库反复踩过的坑）。
+
+除了 TRL 自带的 reward / kl / grad_norm，本模块还负责把五个奖励分量单独记出来。
+这不是锦上添花：``RewardCalculator`` 带一个 30 步的课程，前期把 tool/argument/
+outcome 的权重压到 1/3，之后恢复满权重。也就是说**只看 total reward 无法判断
+曲线上升是策略变强还是权重表在动**。五个分量各自恒在 [-1, 1] 且与权重无关，
+配合同时记录的当前权重，才能把这两件事分开。
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+# HF 的集成名 -> 需要装的包名。用于在启用前给出可操作的报错。
+_BACKEND_REQUIREMENTS = {
+    "tensorboard": "tensorboard",
+    "wandb": "wandb",
+    "mlflow": "mlflow",
+    "comet_ml": "comet_ml",
+    "neptune": "neptune",
+    "clearml": "clearml",
+    "dvclive": "dvclive",
+    "swanlab": "swanlab",
+    "trackio": "trackio",
+}
+
+
+def resolve_report_to(value: Optional[str]) -> List[str]:
+    """把 ``--report_to`` 的取值规范成 HF 认识的列表，并校验后端可用。
+
+    与 HF 的默认行为有意不同：HF 在 ``report_to=None`` 时解析成 "all"，
+    等于「装了什么用什么」。这里要求显式声明，且——
+
+      - ``"none"`` / ``""``  -> ``[]``，明确表示不记录；
+      - ``"auto"``          -> 装了 tensorboard 就用，没装则退回 ``[]`` 并提示；
+      - 具体后端名           -> 没装就抛错，不静默降级。
+
+    Returns:
+        传给 ``TrainingArguments.report_to`` 的列表。
+    """
+    raw = (value or "none").strip().lower()
+    if raw in ("none", "no", "off", ""):
+        return []
+
+    if raw == "auto":
+        if _backend_available("tensorboard"):
+            return ["tensorboard"]
+        print("ℹ️  --report_to auto：未安装 tensorboard，本次不记录训练曲线。"
+              "   需要曲线请先 pip install tensorboard")
+        return []
+
+    names = [name.strip() for name in raw.split(",") if name.strip()]
+    for name in names:
+        if name not in _BACKEND_REQUIREMENTS:
+            raise SystemExit(
+                f"❌ 未知的 --report_to 后端: {name}\n"
+                f"   可选: none / auto / {' / '.join(sorted(_BACKEND_REQUIREMENTS))}"
+            )
+        if not _backend_available(name):
+            package = _BACKEND_REQUIREMENTS[name]
+            raise SystemExit(
+                f"❌ --report_to {name} 需要先安装 {package}: pip install {package}\n"
+                "   （这里选择直接失败而不是静默跳过：训练跑完却没有任何曲线，"
+                "比启动时报错难查得多）"
+            )
+    return names
+
+
+def _backend_available(name: str) -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec(_BACKEND_REQUIREMENTS.get(name, name)) is not None
+
+
+class RewardComponentTracker:
+    """收集每条 rollout 的奖励分量与轨迹健康度，汇总进训练日志。
+
+    走 TRL ``GRPOTrainer._metrics`` 这个口子：TRL 在 ``log()`` 里会把它按 key
+    取均值、并进 ``logs``、再分发给所有 report_to 后端，最后清空。也就是说
+    这里只管 append，聚合与清空都由 TRL 负责，梯度累积下的多次调用会被正确
+    平均成一个点。
+
+    ``bind`` 失败（TRL 改了内部结构）时对象退化成 no-op —— 训练不该因为
+    日志记不了就崩，但会打印一次提示，避免变成又一处静默失效。
+    """
+
+    #: 与 RewardBreakdown 对齐的五个分量
+    COMPONENTS = ("format", "tool", "argument", "process", "outcome")
+
+    def __init__(self) -> None:
+        self._sink: Optional[Dict[str, List[float]]] = None
+        self._pending: Dict[str, List[float]] = {}
+        self.bound = False
+
+    # --- 接线 -------------------------------------------------------------
+    def bind(self, trainer: Any) -> bool:
+        """接到 trainer 的指标缓冲区。返回是否接上。"""
+        metrics = getattr(trainer, "_metrics", None)
+        if not isinstance(metrics, Mapping) or "train" not in metrics:
+            print("⚠️  当前 TRL 版本没有可用的 _metrics 缓冲区，"
+                  "奖励分量曲线本次不会被记录（训练本身不受影响）")
+            return False
+        self._sink = metrics["train"]
+        self.bound = True
+        # bind 之前 record 的数据不丢
+        for key, values in self._pending.items():
+            self._sink[key].extend(values)
+        self._pending.clear()
+        return True
+
+    def _emit(self, key: str, value: float) -> None:
+        if self.bound:
+            self._sink[key].append(float(value))
+        else:
+            self._pending.setdefault(key, []).append(float(value))
+
+    # --- 采集 -------------------------------------------------------------
+    def record(self, breakdown: Any, trajectory: Optional[Mapping[str, Any]] = None) -> None:
+        """记录一条 rollout 的奖励分量、当前课程权重与轨迹健康度。"""
+        for name in self.COMPONENTS:
+            value = getattr(breakdown, name, None)
+            if value is not None:
+                self._emit(f"reward_components/{name}", value)
+
+        weights = getattr(breakdown, "weights", None)
+        if weights is not None:
+            # 同时记权重，否则无法区分「策略变强」与「课程把权重放开了」
+            for name, weight in asdict(weights).items():
+                self._emit(f"reward_weights/{name}", weight)
+
+        if trajectory is not None:
+            self._record_trajectory(trajectory)
+
+    def _record_trajectory(self, trajectory: Mapping[str, Any]) -> None:
+        history = trajectory.get("history") or []
+        if not history:
+            return
+        stats = trajectory_health(history)
+        for key, value in stats.items():
+            self._emit(f"rollout/{key}", value)
+
+
+def trajectory_health(history: Sequence[Mapping[str, Any]]) -> Dict[str, float]:
+    """从一条 ReAct 轨迹里抽出多轮 rollout 的健康度指标。
+
+    多轮采样落地后，``reward`` 掉下去可能是策略退化，也可能是环境侧出了问题
+    （比如工具一直报错、或者模型压根没学会收尾而是每次都跑满 max_turns）。
+    这几个量把这两类原因分开。
+
+    Returns:
+        - ``turns``：这条轨迹用了几步
+        - ``finished``：是否以 FINISH 正常收尾（0/1）。持续为 0 说明模型在
+          「跑满轮数」而不是「决定结束」，此时 reward 低与工具能力无关。
+        - ``parse_error_rate``：解析失败步数占比
+        - ``tool_error_rate``：工具调用步中执行失败的占比
+    """
+    from rl.grpo_reward import TOOL_ERROR_PREFIX
+
+    turns = len(history)
+    actions = [str(step.get("action", "")) for step in history]
+    parse_errors = sum(
+        1 for step, action in zip(history, actions)
+        if step.get("parse_failed") or action == "PARSE_ERROR"
+    )
+    tool_steps = [
+        step for step, action in zip(history, actions)
+        if action not in ("FINISH", "PARSE_ERROR")
+    ]
+    tool_errors = sum(
+        1 for step in tool_steps
+        if str(step.get("observation", "")).startswith(TOOL_ERROR_PREFIX)
+    )
+    return {
+        "turns": float(turns),
+        "finished": 1.0 if actions and actions[-1] == "FINISH" else 0.0,
+        "parse_error_rate": parse_errors / turns,
+        "tool_error_rate": (tool_errors / len(tool_steps)) if tool_steps else 0.0,
+    }
+
+
+def describe_logging(report_to: Sequence[str], logging_dir: Optional[str]) -> str:
+    """训练启动时打印一行人能看懂的说明（含查看命令）。"""
+    if not report_to:
+        return ("📉 未启用训练曲线记录（--report_to none）。"
+                "要看 reward / kl / 各奖励分量，用 --report_to tensorboard")
+    if "tensorboard" in report_to and logging_dir:
+        return (f"📈 训练曲线 -> {report_to}，日志目录 {logging_dir}\n"
+                f"   查看: tensorboard --logdir {logging_dir}")
+    return f"📈 训练曲线 -> {report_to}"

--- a/AgenticArxiv/rl/train_dpo.py
+++ b/AgenticArxiv/rl/train_dpo.py
@@ -24,6 +24,7 @@ from trl import DPOConfig, DPOTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from datasets import load_dataset
 
+from rl.observability import describe_logging, resolve_report_to
 from rl.stage_verifier import StageVerifier
 
 
@@ -39,9 +40,13 @@ def main(
     output_dir: str = None,
     verify: bool = False,
     min_reward: float = -0.3,
+    report_to: str = "none",
+    run_name: str = None,
 ):
     """DPO 训练主函数"""
 
+    # 先校验日志后端再加载模型：参数写错时应立刻失败
+    backends = resolve_report_to(report_to)
     # 1. 配置
     model_path = Path(model) if model else REPO_ROOT / "outputs" / "sft" / "final"
     model_name = str(model_path)
@@ -71,6 +76,9 @@ def main(
     print(f"   样本数: {len(train_dataset)}")
 
     # 3. 配置 DPO
+    logging_dir = str(Path(out_dir) / "logs")
+    print(describe_logging(backends, logging_dir if backends else None))
+
     config = DPOConfig(
         output_dir=str(out_dir),
         num_train_epochs=3,
@@ -81,6 +89,9 @@ def main(
         logging_steps=10,
         save_steps=100,
         save_total_limit=3,
+        report_to=backends,
+        logging_dir=logging_dir,
+        run_name=run_name or Path(out_dir).name,
         **_precision_flags(),     # 只有 CUDA 才开 fp16
     )
 
@@ -127,5 +138,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--min_reward", type=float, default=-0.3,
         help="DPO 验证的最低平均奖励阈值（默认 -0.3）",
+    )
+    parser.add_argument(
+        "--report_to", default="none",
+        help="训练曲线记到哪：none / auto / tensorboard / wandb（可逗号分隔）",
+    )
+    parser.add_argument(
+        "--run_name", default=None,
+        help="本次运行在 TensorBoard / wandb 里的名字，默认取 output_dir 末段",
     )
     main(**vars(parser.parse_args()))

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -53,6 +53,11 @@ from rl.grpo_reward import (
     parse_react_action,
 )
 from rl.multiturn_env import make_environment_factory
+from rl.observability import (
+    RewardComponentTracker,
+    describe_logging,
+    resolve_report_to,
+)
 from rl.reward import RewardCalculator
 from rl.stage_verifier import StageVerifier
 
@@ -151,7 +156,13 @@ def main(
     min_canary_reward: float = -1.0,
     canary_patience: int = 3,
     verify: bool = True,
+    report_to: str = "none",
+    run_name: str = None,
 ):
+    # 先校验日志后端再加载模型：参数写错时应立刻失败，而不是等模型加载完
+    backends = resolve_report_to(report_to)
+    logging_dir = str(REPO_ROOT / output_dir / "logs")
+
     model_path = REPO_ROOT / model
     if model_path.exists():
         resolved = str(model_path)
@@ -195,7 +206,8 @@ def main(
     environment_factory = make_environment_factory(snapshot_path)
     print(f"🗂  使用独立离线环境执行多轮工具调用: {snapshot_path}")
     # structured completions 已携带真实 tool observations，不在 reward 端重复执行。
-    reward_fn = make_grpo_reward_fn({t["id"]: t for t in tasks}, env=None)
+    tracker = RewardComponentTracker()
+    reward_fn = make_grpo_reward_fn({t["id"]: t for t in tasks}, env=None, tracker=tracker)
     rollout_func = make_multiturn_rollout_func(environment_factory, max_turns=max_turns)
 
     # GRPO 要求生成批量能被 num_generations 整除
@@ -215,7 +227,9 @@ def main(
         "temperature": temperature,
         "logging_steps": 1,
         "save_strategy": "no",
-        "report_to": [],
+        "report_to": backends,
+        "logging_dir": logging_dir,
+        "run_name": run_name or Path(output_dir).name,
         **_precision_flags(),
     }
     # GRPOConfig 的字段在 TRL 各版本间有增删，按实际安装版本过滤，
@@ -226,6 +240,7 @@ def main(
         print(f"  提示：当前 TRL 不支持这些 GRPOConfig 参数，已忽略 -> {dropped}")
     config = GRPOConfig(**{k: v for k, v in cfg_kwargs.items() if k in valid})
 
+    print(describe_logging(backends, logging_dir if backends else None))
     print(f"🚀 开始 GRPO 训练（每个 prompt 采样 {num_generations} 条，规则奖励）")
     trainer = GRPOTrainer(
         model=policy,
@@ -235,6 +250,10 @@ def main(
         processing_class=tokenizer,
         rollout_func=rollout_func,
     )
+    # 必须在 trainer 建好之后接线：分量指标要塞进 TRL 的 _metrics 缓冲区，
+    # 由 TRL 在 log() 里取均值后再分发给 report_to 的各个后端。
+    if backends:
+        tracker.bind(trainer)
 
     # --- Canary 回调：每 N 步在固定任务上评估，检测性能退化 ---
     canary_cb = None
@@ -330,5 +349,15 @@ if __name__ == "__main__":
     p.add_argument(
         "--verify", action=argparse.BooleanOptionalAction, default=True,
         help="训练结束后运行阶段验证（默认开启）",
+    )
+    p.add_argument(
+        "--report_to", default="none",
+        help="训练曲线记到哪：none / auto / tensorboard / wandb（可逗号分隔）。"
+             "记录 reward、kl、grad_norm、frac_reward_zero_std，"
+             "以及 format/tool/argument/process/outcome 五个奖励分量与当前课程权重",
+    )
+    p.add_argument(
+        "--run_name", default=None,
+        help="本次运行在 TensorBoard / wandb 里的名字，默认取 output_dir 末段",
     )
     main(**vars(p.parse_args()))

--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -25,6 +25,7 @@ from trl import SFTConfig, SFTTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from datasets import load_dataset
 
+from rl.observability import describe_logging, resolve_report_to
 from rl.stage_verifier import StageVerifier
 
 
@@ -87,9 +88,14 @@ def main(
     max_steps: int = -1,
     verify: bool = False,
     min_parse_rate: float = 0.3,
+    report_to: str = "none",
+    run_name: str = None,
 ):
     train_data_path = Path(data) if data else REPO_ROOT / "data" / "sft" / "sft_train.jsonl"
     out_path = REPO_ROOT / output_dir if not Path(output_dir).is_absolute() else Path(output_dir)
+    # 先校验日志后端再加载模型：参数写错时应立刻失败
+    backends = resolve_report_to(report_to)
+    logging_dir = str(out_path / "logs")
 
     print(f"📦 加载模型: {model}")
     tokenizer = AutoTokenizer.from_pretrained(model)
@@ -121,9 +127,13 @@ def main(
         logging_steps=10,
         save_steps=100,
         save_total_limit=3,
+        report_to=backends,
+        logging_dir=logging_dir,
+        run_name=run_name or out_path.name,
         **_precision_flags(),     # 只有 CUDA 才开 fp16
     )
 
+    print(describe_logging(backends, logging_dir if backends else None))
     print(f"🚀 开始 SFT 训练...")
     trainer = SFTTrainer(
         model=policy,
@@ -177,5 +187,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "--min_parse_rate", type=float, default=0.3,
         help="SFT 验证的最低可解析率阈值（默认 0.3）",
+    )
+    parser.add_argument(
+        "--report_to", default="none",
+        help="训练曲线记到哪：none / auto / tensorboard / wandb（可逗号分隔）",
+    )
+    parser.add_argument(
+        "--run_name", default=None,
+        help="本次运行在 TensorBoard / wandb 里的名字，默认取 output_dir 末段",
     )
     main(**vars(parser.parse_args()))

--- a/AgenticArxiv/tests/test_observability.py
+++ b/AgenticArxiv/tests/test_observability.py
@@ -1,0 +1,220 @@
+"""训练可观测性的测试。
+
+重点不在「能不能记」，而在两件容易静默出错的事：
+  1. --report_to 指了个没装的后端时必须报错，不能安静地什么都不记；
+  2. 五个奖励分量必须真的进到 TRL 的指标缓冲区，否则曲线里只有一个
+     被课程权重污染过的 total。
+"""
+
+import sys
+import unittest
+from collections import defaultdict
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from rl.grpo_reward import TOOL_ERROR_PREFIX, make_grpo_reward_fn  # noqa: E402
+from rl.observability import (  # noqa: E402
+    RewardComponentTracker,
+    describe_logging,
+    resolve_report_to,
+    trajectory_health,
+)
+from rl.reward import RewardCalculator  # noqa: E402
+
+
+class FakeTrainer:
+    """只暴露 TRL GRPOTrainer 用来汇总自定义指标的那个缓冲区。"""
+
+    def __init__(self):
+        self._metrics = {"train": defaultdict(list), "eval": defaultdict(list)}
+
+
+class ResolveReportToTest(unittest.TestCase):
+    def test_none_variants_disable(self):
+        for value in (None, "", "none", "NONE", " off ", "no"):
+            self.assertEqual(resolve_report_to(value), [], value)
+
+    def test_known_backend_passes_when_installed(self):
+        with mock.patch("rl.observability._backend_available", return_value=True):
+            self.assertEqual(resolve_report_to("tensorboard"), ["tensorboard"])
+            self.assertEqual(resolve_report_to("wandb,tensorboard"),
+                             ["wandb", "tensorboard"])
+
+    def test_missing_backend_fails_loudly(self):
+        """静默降级是这个仓库反复踩过的坑：训练跑完才发现没有任何曲线。"""
+        with mock.patch("rl.observability._backend_available", return_value=False):
+            with self.assertRaises(SystemExit) as ctx:
+                resolve_report_to("tensorboard")
+        self.assertIn("pip install tensorboard", str(ctx.exception))
+
+    def test_unknown_backend_fails(self):
+        with self.assertRaises(SystemExit):
+            resolve_report_to("tensorbored")
+
+    def test_auto_falls_back_without_raising(self):
+        """auto 是唯一允许降级的取值，因为它表达的就是「有就用」。"""
+        with mock.patch("rl.observability._backend_available", return_value=False):
+            self.assertEqual(resolve_report_to("auto"), [])
+        with mock.patch("rl.observability._backend_available", return_value=True):
+            self.assertEqual(resolve_report_to("auto"), ["tensorboard"])
+
+
+class TrajectoryHealthTest(unittest.TestCase):
+    def test_finished_trajectory(self):
+        history = [
+            {"action": '{"name": "get_recently_submitted_cs_papers"}', "observation": "成功获取 5 篇论文"},
+            {"action": "FINISH", "observation": "任务完成"},
+        ]
+        stats = trajectory_health(history)
+        self.assertEqual(stats["turns"], 2.0)
+        self.assertEqual(stats["finished"], 1.0)
+        self.assertEqual(stats["parse_error_rate"], 0.0)
+        self.assertEqual(stats["tool_error_rate"], 0.0)
+
+    def test_ran_out_of_turns_is_not_finished(self):
+        """跑满 max_turns 和主动收尾必须区分开。
+
+        两者 reward 都可能低，但前者是「没学会结束」，后者是「工具用错了」，
+        处理方式完全不同 —— 只看 reward 曲线分不出来。
+        """
+        history = [{"action": '{"name": "download_arxiv_pdf"}', "observation": "ok"}] * 4
+        self.assertEqual(trajectory_health(history)["finished"], 0.0)
+
+    def test_parse_error_rate(self):
+        history = [
+            {"action": "PARSE_ERROR", "observation": "无法解析 Action", "parse_failed": True},
+            {"action": "FINISH", "observation": "任务完成"},
+        ]
+        self.assertEqual(trajectory_health(history)["parse_error_rate"], 0.5)
+
+    def test_tool_error_rate_uses_shared_prefix(self):
+        """用 grpo_reward 导出的常量判定，避免两处各写一份会漂的中文文案。"""
+        history = [
+            {"action": '{"name": "download_arxiv_pdf"}',
+             "observation": f"{TOOL_ERROR_PREFIX}未找到论文"},
+            {"action": '{"name": "download_arxiv_pdf"}', "observation": "ok"},
+            {"action": "FINISH", "observation": "任务完成"},
+        ]
+        stats = trajectory_health(history)
+        self.assertEqual(stats["tool_error_rate"], 0.5)   # FINISH 不算进分母
+        self.assertEqual(stats["parse_error_rate"], 0.0)
+
+
+class TrackerTest(unittest.TestCase):
+    def test_bind_and_record(self):
+        tracker = RewardComponentTracker()
+        trainer = FakeTrainer()
+        self.assertTrue(tracker.bind(trainer))
+
+        calc = RewardCalculator()
+        task = {"id": "t", "task": "x", "expected_tools": ["get_recently_submitted_cs_papers"],
+                "expected_termination": "FINISH"}
+        result = {"history": [
+            {"action": '{"name": "get_recently_submitted_cs_papers", "args": {}}',
+             "observation": "成功获取 5 篇论文"},
+            {"action": "FINISH", "observation": "任务完成"},
+        ], "timing": {}, "token_usage": {}, "iteration_count": 2}
+        breakdown, _ = calc.compute_reward_breakdown(task, result, training_step=0)
+        tracker.record(breakdown, result)
+
+        keys = trainer._metrics["train"]
+        for name in RewardComponentTracker.COMPONENTS:
+            self.assertIn(f"reward_components/{name}", keys, name)
+            self.assertIn(f"reward_weights/{name}", keys, name)
+        for name in ("turns", "finished", "parse_error_rate", "tool_error_rate"):
+            self.assertIn(f"rollout/{name}", keys, name)
+
+    def test_records_before_bind_are_not_lost(self):
+        """reward fn 在 trainer 构造前就造好了，先 record 后 bind 是常态。"""
+        tracker = RewardComponentTracker()
+        calc = RewardCalculator()
+        task = {"id": "t", "task": "x", "expected_tools": [], "expected_termination": "FINISH"}
+        result = {"history": [{"action": "FINISH", "observation": "任务完成"}],
+                  "timing": {}, "token_usage": {}, "iteration_count": 1}
+        breakdown, _ = calc.compute_reward_breakdown(task, result)
+        tracker.record(breakdown, result)
+
+        trainer = FakeTrainer()
+        tracker.bind(trainer)
+        self.assertIn("reward_components/format", trainer._metrics["train"])
+
+    def test_bind_failure_degrades_to_noop(self):
+        """TRL 换了内部结构时，日志记不上不该把训练带崩。"""
+        tracker = RewardComponentTracker()
+        self.assertFalse(tracker.bind(object()))
+        calc = RewardCalculator()
+        task = {"id": "t", "task": "x", "expected_tools": [], "expected_termination": "FINISH"}
+        result = {"history": [{"action": "FINISH", "observation": "ok"}],
+                  "timing": {}, "token_usage": {}, "iteration_count": 1}
+        breakdown, _ = calc.compute_reward_breakdown(task, result)
+        tracker.record(breakdown, result)     # 不抛异常即可
+
+    def test_curriculum_moves_total_while_components_hold_still(self):
+        """这是「必须单独记分量」的核心论据，用一条固定轨迹钉住。
+
+        同一条轨迹（策略完全没变），跨过第 30 步的课程边界后：
+            total  +0.3125  ->  -0.03125
+        而五个分量一模一样。原因是课程把 tool/argument/outcome 的权重从
+        1/3 恢复到满权重，这条轨迹的 tool 分量是 -1，权重放开后被放大。
+
+        也就是说 total reward 在策略没有任何变化时**下跌**了。只看
+        total 曲线会把它误读成策略退化。
+        """
+        calc = RewardCalculator()
+        task = {"id": "t", "task": "x",
+                "expected_tools": ["get_recently_submitted_cs_papers"],
+                "expected_termination": "FINISH"}
+        # 故意调错工具：让各分量取值不同，否则加权平均对权重不敏感
+        result = {"history": [
+            {"action": '{"name": "download_arxiv_pdf", "args": {"ref": 1}}',
+             "observation": "ok"},
+            {"action": "FINISH", "observation": "任务完成"},
+        ], "timing": {}, "token_usage": {}, "iteration_count": 2}
+
+        early, _ = calc.compute_reward_breakdown(task, result, training_step=0)
+        late, _ = calc.compute_reward_breakdown(task, result, training_step=100)
+
+        for name in RewardComponentTracker.COMPONENTS:
+            self.assertAlmostEqual(getattr(early, name), getattr(late, name), places=6, msg=name)
+        self.assertAlmostEqual(early.total, 0.3125, places=4)
+        self.assertAlmostEqual(late.total, -0.03125, places=5)
+        self.assertLess(late.total, early.total)
+
+
+class RewardFnTrackerWiringTest(unittest.TestCase):
+    def test_reward_fn_feeds_tracker(self):
+        tracker = RewardComponentTracker()
+        trainer = FakeTrainer()
+        tracker.bind(trainer)
+        tasks = {"t": {"id": "t", "task": "x",
+                       "expected_tools": ["get_recently_submitted_cs_papers"],
+                       "expected_termination": "FINISH"}}
+        fn = make_grpo_reward_fn(tasks, env=None, tracker=tracker)
+        rewards = fn(
+            completions=['Thought: 检索\nAction: {"name": "get_recently_submitted_cs_papers", "args": {}}'],
+            task_id=["t"],
+        )
+        self.assertEqual(len(rewards), 1)
+        self.assertIn("reward_components/tool", trainer._metrics["train"])
+
+    def test_reward_fn_without_tracker_still_works(self):
+        tasks = {"t": {"id": "t", "task": "x", "expected_tools": [],
+                       "expected_termination": "FINISH"}}
+        fn = make_grpo_reward_fn(tasks, env=None)
+        self.assertEqual(len(fn(completions=["Thought: 完成\nAction: FINISH"], task_id=["t"])), 1)
+
+
+class DescribeLoggingTest(unittest.TestCase):
+    def test_disabled_message_tells_you_how_to_enable(self):
+        text = describe_logging([], None)
+        self.assertIn("--report_to tensorboard", text)
+
+    def test_tensorboard_message_includes_command(self):
+        text = describe_logging(["tensorboard"], "/tmp/run/logs")
+        self.assertIn("tensorboard --logdir /tmp/run/logs", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/README.en.md
+++ b/README.en.md
@@ -200,6 +200,23 @@ python -m AgenticArxiv.rl.train_grpo
 
 **Multi-turn rollout and reward scoring** (`rl/grpo_reward.py`): the current policy generates a ReAct action at every turn, an independent `MockArxivEnv` executes it, and the observation is appended back to context until completion or `--max_turns`. Assistant tokens participate in GRPO loss while environment tokens are excluded with `env_mask=0`; the complete trajectory is scored by the shared five-component `RewardCalculator`.
 
+```bash
+python -m AgenticArxiv.rl.build_snapshot
+python -m AgenticArxiv.rl.train_grpo --model outputs/sft/final --max_turns 4
+
+# Record training curves (same flag across all three stages)
+python -m AgenticArxiv.rl.train_grpo --model outputs/sft/final --report_to tensorboard
+tensorboard --logdir outputs/grpo/logs
+```
+
+**Training curves** (`rl/observability.py`): `--report_to` accepts `none` / `auto` / `tensorboard` / `wandb` (comma-separated), shared by all three stages. On top of TRL's built-in metrics it logs:
+
+| Metric group | Contents | Why log it separately |
+|---|---|---|
+| `reward_components/*` | format / tool / argument / process / outcome | each bounded to `[-1,1]` and independent of the weights |
+| `reward_weights/*` | current curriculum weights | the curriculum suppresses tool/argument/outcome weights for the first 30 steps, so total reward alone reads "weights opened up" as "policy regressed" |
+| `rollout/*` | turns / finished / parse_error_rate / tool_error_rate | when reward drops, separates "policy regressed" from "never learned to stop, burns every turn up to max_turns" |
+
 ### Training Quality Guards (auto-verification)
 
 The training pipeline bakes in several layers of automatic validation that turn "silent training failures" into loud errors:
@@ -209,6 +226,7 @@ The training pipeline bakes in several layers of automatic validation that turn 
 - **Canary evaluation**: samples on fixed tasks every N steps and early-stops if performance degrades below the threshold repeatedly (`CanaryCallback`)
 - **Stage verification**: each stage's output model must pass a minimum quality threshold — SFT parse rate ≥ 0.3, DPO mean reward ≥ −0.3, GRPO mean reward ≥ −0.2 (`StageVerifier`, skip with `--no-verify`)
 - **Adaptive mixed precision**: bf16 first on CUDA, falling back to fp16, disabled on CPU / MPS (`rl/precision.py`)
+- **Logging-backend validation**: a backend named in `--report_to` that is not installed fails before the model is loaded, so you never finish a run only to find no curves (`rl/observability.py`)
 
 ---
 
@@ -247,7 +265,8 @@ AgenticArXiv-RL/
 │  │  ├─ build_snapshot.py         # Build arXiv offline snapshot (only network step)
 │  │  ├─ canary.py                 # Periodic in-training evaluation (early stop)
 │  │  ├─ stage_verifier.py         # Per-stage model quality threshold verification
-│  │  └─ precision.py              # Mixed-precision strategy (bf16/fp16/CPU)
+│  │  ├─ precision.py              # Mixed-precision strategy (bf16/fp16/CPU)
+│  │  └─ observability.py          # Logging backends + reward-component curves
 │  ├─ models/                        # Storage layer (store_memory for RL, store_mysql for Web)
 │  ├─ services/                      # Side-effect services (event_bus / log / runtime)
 │  ├─ api/ · mcp_protocol/ · skill_cli/   # Archived Web / MCP / Skill compatibility layers
@@ -475,7 +494,7 @@ Ordered by priority. Contributions welcome (see 🤝 Contributing).
 ### P0 — Near term (close core gaps)
 
 - [x] **Multi-turn Agentic Rollout**: implemented real "act → observe → act" sampling with an independent `MockArxivEnv` per generation; environment tokens use `env_mask=0`, while the complete assistant trajectory participates in GRPO optimization and reward scoring.
-- [ ] **Training observability**: wire up wandb / TensorBoard (currently `report_to=[]`, no monitoring) and log reward / advantage / KL / per-component curves before tuning hyperparameters.
+- [x] **Training observability**: SFT / DPO / GRPO share one `--report_to` flag (none / auto / tensorboard / wandb); a missing backend fails loudly instead of silently recording nothing. Beyond TRL's built-in reward / kl / grad_norm / `frac_reward_zero_std`, the five reward components (format/tool/argument/process/outcome) and the current curriculum weights are logged separately — the curriculum reweights components over the first 30 steps, so total reward alone cannot tell "the policy improved" from "the weights moved" — plus `rollout/` turns / finished / parse_error_rate / tool_error_rate for diagnosing multi-turn sampling itself.
 
 ### P1 — Mid term (data & evaluation)
 

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -204,6 +204,7 @@ El pipeline de entrenamiento incorpora varias capas de validación automática q
 - **Evaluación canary**: muestrea sobre tareas fijas cada N pasos y detiene antes de tiempo si el desempeño degrada bajo el umbral repetidamente (`CanaryCallback`)
 - **Verificación por etapa**: el modelo saliente de cada fase debe superar un umbral mínimo de calidad — tasa de parseo SFT ≥ 0.3, reward promedio DPO ≥ −0.3, reward promedio GRPO ≥ −0.2 (`StageVerifier`, se omite con `--no-verify`)
 - **Precisión mixta adaptativa**: bf16 primero en CUDA, con respaldo a fp16, desactivada en CPU / MPS (`rl/precision.py`)
+- **Validación del backend de registro**: un backend indicado en `--report_to` que no esté instalado falla antes de cargar el modelo, para no terminar un entrenamiento y descubrir que no hay ninguna curva (`rl/observability.py`)
 
 ---
 
@@ -242,7 +243,8 @@ AgenticArXiv-RL/
 │  │  ├─ build_snapshot.py         # Genera snapshot offline de arXiv (único paso con red)
 │  │  ├─ canary.py                 # Evaluación periódica en entrenamiento (detención temprana)
 │  │  ├─ stage_verifier.py         # Verificación de umbral de calidad por fase
-│  │  └─ precision.py              # Estrategia de precisión mixta (bf16/fp16/CPU)
+│  │  ├─ precision.py              # Estrategia de precisión mixta (bf16/fp16/CPU)
+│  │  └─ observability.py          # Backends de registro + curvas por componente
 │  ├─ models/                        # Capa de almacenamiento (store_memory para RL, store_mysql para Web)
 │  ├─ services/                      # Servicios de efectos secundarios (event_bus / log / runtime)
 │  ├─ api/ · mcp_protocol/ · skill_cli/   # Capas de compatibilidad Web / MCP / Skill archivadas
@@ -468,8 +470,8 @@ Ordenado por prioridad. ¡Las contribuciones son bienvenidas (ver 🤝 Contribui
 
 ### P0 — Corto plazo (cerrar brechas clave)
 
-- [ ] **Rollout Agentic Multiturno**: el GRPO actual solo puntúa el `completion` de **un solo paso** del modelo como una "trayectoria mínima sintetizada" — no existe una interacción real de múltiples turnos "actuar → observar → actuar". Usa el soporte de tool-calling / multi-turn de TRL con `MockArxivEnv` como backend de herramientas y enmascarado de loss solo de asistente, para cerrar la brecha más visible frente al nombre de "Agentic RL".
-- [ ] **Observabilidad del entrenamiento**: conectar wandb / TensorBoard (actualmente `report_to=[]`, sin monitorización) y registrar curvas de reward / advantage / KL / componentes antes de ajustar hiperparámetros.
+- [x] **Rollout Agentic Multiturno**: implementado el muestreo real «actuar → observar → actuar», con un `MockArxivEnv` independiente por generación; los tokens del entorno usan `env_mask=0`, mientras que la trayectoria completa del asistente participa en la optimización GRPO y en la recompensa de cinco componentes.
+- [x] **Observabilidad del entrenamiento**: SFT / DPO / GRPO comparten un mismo `--report_to` (none / auto / tensorboard / wandb); si el backend no está instalado falla de inmediato en vez de no registrar nada en silencio. Además de reward / kl / grad_norm / `frac_reward_zero_std` que ya trae TRL, se registran por separado los cinco componentes de la recompensa (format/tool/argument/process/outcome) y los pesos actuales del currículo —el currículo cambia los pesos durante los primeros 30 pasos, así que la recompensa total por sí sola no distingue «la política mejoró» de «los pesos se movieron»—, más `rollout/` turns / finished / parse_error_rate / tool_error_rate para diagnosticar el propio muestreo multiturno.
 
 ### P1 — Medio plazo (datos y evaluación)
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,19 @@ python -m AgenticArxiv.rl.train_grpo
 ```bash
 python -m AgenticArxiv.rl.build_snapshot
 python -m AgenticArxiv.rl.train_grpo --model outputs/sft/final --max_turns 4
+
+# 记录训练曲线（三个阶段同一套参数）
+python -m AgenticArxiv.rl.train_grpo --model outputs/sft/final --report_to tensorboard
+tensorboard --logdir outputs/grpo/logs
 ```
+
+**训练曲线**（`rl/observability.py`）：`--report_to` 取 `none` / `auto` / `tensorboard` / `wandb`（可逗号分隔），三个训练阶段共用。除 TRL 自带的 reward / kl / grad_norm / `frac_reward_zero_std` 外，额外记录：
+
+| 指标组 | 内容 | 为什么单独记 |
+|---|---|---|
+| `reward_components/*` | format / tool / argument / process / outcome | 各自恒在 `[-1,1]` 且与权重无关 |
+| `reward_weights/*` | 当前课程权重 | 课程前 30 步压低 tool/argument/outcome 权重，只看 total 会把「权重放开」误读成「策略退化」 |
+| `rollout/*` | turns / finished / parse_error_rate / tool_error_rate | reward 掉下去时区分「策略退化」与「没学会收尾、每次跑满 max_turns」 |
 
 ### 训练质量保障（自动校验）
 
@@ -221,6 +233,7 @@ python -m AgenticArxiv.rl.train_grpo --model outputs/sft/final --max_turns 4
 - **Canary 评估**：训练中每 N 步在固定任务上采样评估，性能退化达到阈值连续多次则提前停止（`CanaryCallback`）
 - **阶段验证**：每个阶段产出模型须过最低质量阈值——SFT 可解析率 ≥ 0.3、DPO 平均奖励 ≥ −0.3、GRPO 平均奖励 ≥ −0.2（`StageVerifier`，`--no-verify` 可跳过）
 - **混合精度自适应**：CUDA 优先 bf16、回退 fp16，CPU / MPS 关闭（`rl/precision.py`）
+- **日志后端校验**：`--report_to` 指定的后端没装时在加载模型前就失败，避免训练跑完才发现没有任何曲线（`rl/observability.py`）
 
 ---
 
@@ -259,7 +272,8 @@ AgenticArXiv-RL/
 │  │  ├─ build_snapshot.py         # 生成 arXiv 离线快照（唯一联网步骤）
 │  │  ├─ canary.py                 # 训练中周期性评估（防退化早停）
 │  │  ├─ stage_verifier.py         # 阶段产出模型质量阈值验证
-│  │  └─ precision.py              # 混合精度策略（bf16/fp16/CPU）
+│  │  ├─ precision.py              # 混合精度策略（bf16/fp16/CPU）
+│  │  └─ observability.py          # 日志后端 + 奖励分量曲线
 │  ├─ models/                        # 存储层（RL 用 store_memory，Web 版用 store_mysql）
 │  ├─ services/                      # 副作用服务（event_bus / log / runtime）
 │  ├─ api/ · mcp_protocol/ · skill_cli/   # 归档的 Web / MCP / Skill 兼容层
@@ -485,7 +499,7 @@ PPO 更适合生产级大模型训练（7B+），本项目作为学习 demo 不�
 ### P0 — 近期（填补核心缺口）
 
 - [x] **多轮 Agentic Rollout**：已实现真正的「行动 → 环境反馈 → 再行动」交互采样；每条 generation 使用独立 `MockArxivEnv`，环境 token 以 `env_mask=0` 排除策略 loss，完整 assistant 轨迹参与 GRPO 更新与五分量奖励。
-- [ ] **训练可观测性**：接入 wandb / TensorBoard（当前 `report_to=[]`，无任何监控），记录 reward / advantage / kl / 各奖励分量曲线，再谈超参调优。
+- [x] **训练可观测性**：SFT / DPO / GRPO 统一 `--report_to`（none / auto / tensorboard / wandb），后端未安装时直接报错而非静默不记。除 TRL 自带的 reward / kl / grad_norm / `frac_reward_zero_std` 外，另单独记录 format/tool/argument/process/outcome 五个奖励分量与当前课程权重——课程会在前 30 步改变权重，只看 total reward 分不出「策略在变强」还是「权重表在动」；再加 `rollout/` 下的 turns / finished / parse_error_rate / tool_error_rate 用于定位多轮采样本身的问题。
 
 ### P1 — 中期（数据与评测）
 


### PR DESCRIPTION


对应 README TODO **P0「训练可观测性」**。

## 现状

`train_grpo.py` 写死 `report_to=[]`，reward / kl / grad_norm 只存在于 console
scrollback，训练一停就没了。而 `train_sft.py` / `train_dpo.py` **根本不设**
`report_to` —— HF 会把 `None` 解析成 `"all"`：

```python
# transformers/training_args.py
if self.report_to is None:
    self.report_to = "all"
if self.report_to == "all" or self.report_to == ["all"]:
    self.report_to = get_available_reporting_integrations()   # 装了什么就启用什么
```

也就是同一份代码在本机和集群上行为不同：集群上恰好装了 wandb，SFT 一启动就会
卡住等 API key。两种默认都不对，而且方向相反。

## 三件事

### 1. 三个阶段统一 `--report_to`

`none` / `auto` / 具体后端名（可逗号分隔）。**后端没装时直接失败**，不静默降级：

```
❌ --report_to wandb 需要先安装 wandb: pip install wandb
   （这里选择直接失败而不是静默跳过：训练跑完却没有任何曲线，比启动时报错难查得多）
```

拼错也报得明白：

```
❌ 未知的 --report_to 后端: tensorbored
   可选: none / auto / clearml / comet_ml / dvclive / mlflow / neptune / swanlab / tensorboard / trackio / wandb
```

`auto` 是唯一允许降级的取值，因为它表达的就是「有就用」。
校验放在**加载模型之前**——参数写错不该等模型加载完才知道。

### 2. 单独记录五个奖励分量与当前课程权重

这是本 PR 的主要内容，也是最容易被当成锦上添花的一条。

`RewardCalculator` 带一个 30 步课程，前期把 tool/argument/outcome 的权重压到
1/3，之后恢复满权重。也就是说**只看 total reward 无法判断曲线变化是策略在动
还是权重表在动**。测试里钉了一个具体例子：

| | step 0 | step 100 |
|---|---|---|
| **total** | **+0.3125** | **−0.03125** |
| format / tool / argument / process / outcome | 完全相同 | 完全相同 |

同一条轨迹、策略没有任何变化，total 跨过课程边界后**下跌**——只看 total 会把
它误读成策略退化。

五个分量各自恒在 `[-1, 1]` 且与权重无关，配合同时记录的 `reward_weights/*`
才能把两者分开。

### 3. 多轮 rollout 健康度

`rollout/turns`、`rollout/finished`、`rollout/parse_error_rate`、
`rollout/tool_error_rate`。

多轮采样落地后，reward 掉下去可能是策略退化，也可能是模型压根没学会收尾、
每次跑满 `max_turns`——两者处理方式完全不同，只看 reward 分不出来。
`finished` 持续为 0 就是后者。

`tool_error_rate` 用 `grpo_reward.TOOL_ERROR_PREFIX` 判定（本 PR 把那段中文
文案抽成了常量），避免两处各写一份会漂的字面量。

## 实现

走 TRL `GRPOTrainer._metrics` 这个口子：TRL 在 `log()` 里按 key 取均值、并进
`logs`、再分发给所有 `report_to` 后端，然后清空。梯度累积下 reward fn 被调用
多次会被正确平均成一个点，聚合与清空都不用自己管。

接线失败时（TRL 改了内部结构）tracker 退化成 no-op 并打印一次提示——训练不该
因为日志记不了就崩，但也不该变成又一处静默失效。reward fn 在 trainer 构造前
就造好了，所以 `record` 早于 `bind` 是常态，先缓存后回填。

## 验证

trl 0.29.1 + 随机初始化的 3M 模型跑通 8 步，读回 event 文件：

```
共 44 个 scalar tag，其中本 PR 新增 14 个：
  train/reward_components/{format,tool,argument,process,outcome}   各 8 点
  train/reward_weights/{format,tool,argument,process,outcome}      各 8 点
  train/rollout/{turns,finished,parse_error_rate,tool_error_rate}  各 8 点
```

三种失败模式分别验证：后端缺失、后端名拼错、正常跑通。

`tests/test_observability.py` 新增 17 个用例，全量
`python -m unittest discover -s tests`：**153 passed**。

## README

三份 README 同步更新：P0「训练可观测性」勾掉、GRPO 段补 `--report_to` 用法与
三组指标说明表、训练质量保障补一条「日志后端校验」、目录树补
`rl/observability.py`。

另把西语版漏掉的 P0 多轮 rollout 勾选对齐到中/英版——上一次更新只改了
`README.md` 与 `README.en.md`，`README.es-ES.md` 仍写着「尚未实现」。

## 一个副产品

#<PR-12> 那个 bug 就是做这件事时发现的：加上分量曲线后，一个随机初始化的模型
显示 `format=+1.0`、`process=+1.0`——词沙拉不可能格式满分。只看 total reward
的 `+0.3125` 是看不出问题的。

这也正好说明 TODO 里「先接可观测性，再谈超参调优」的顺序是对的。
