### PR TITLE
fix(tools): a single missing dependency disables every tool, and the model starts inventing tool names

### DIFF
--- a/AgenticArxiv/agents/agent_engine.py
+++ b/AgenticArxiv/agents/agent_engine.py
@@ -9,6 +9,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils.llm_client import LLMClient
 from tools.tool_registry import registry
+from tools.bootstrap import missing_tools, register_all_tools, registered_tool_count
 from agents.base_agent import BaseAgent, is_terminal_action
 from agents.prompt_templates import get_react_prompt, format_tool_description
 from utils.logger import log
@@ -20,14 +21,17 @@ class ReActAgent(BaseAgent):
     def __init__(self, llm_client: LLMClient, side_effect_mgr=None, env=None, max_iterations: int = 5, llm_extra=None):
         super().__init__(llm_client, side_effect_mgr=side_effect_mgr, env=env,
                          max_iterations=max_iterations, llm_extra=llm_extra)
-        try:
-            import tools.arxiv_tool  # noqa: F401
-            import tools.pdf_download_tool  # noqa: F401
-            import tools.pdf_translate_tool  # noqa: F401
-            import tools.cache_status_tool  # noqa: F401
-            log.info(f"已导入工具模块，注册了 {len(registry.list_tools())} 个工具")
-        except ImportError as e:
-            log.warning(f"导入工具模块失败: {e}")
+        # 逐个模块独立导入：四个 import 曾共用一个 try，缺任何一个第三方依赖
+        # 就会让四个工具**全部**注册不上，而 registry 为空时模型不会报错，
+        # 它会编工具名。详见 tools/bootstrap.py。
+        failures = register_all_tools()
+        for module, error in failures.items():
+            log.warning(f"工具模块 {module} 导入失败: {error}")
+        missing = missing_tools()
+        if missing:
+            log.warning(f"以下工具不可用，模型可能改为编造工具名: {missing}")
+        else:
+            log.info(f"工具已全部注册（{registered_tool_count()} 个）")
 
     def discover_tools(self) -> List[Dict[str, Any]]:
         return registry.list_tools()

--- a/AgenticArxiv/benchmark/run_benchmark.py
+++ b/AgenticArxiv/benchmark/run_benchmark.py
@@ -21,6 +21,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
+from tools.bootstrap import require_all_tools
 from benchmark.tasks import get_all_tasks, get_tasks_by_category, get_task_by_id
 from benchmark.runner import BenchmarkRunner
 from benchmark.report import BenchmarkReport
@@ -75,6 +76,10 @@ def main():
     )
     parser.add_argument("--snapshot", default=None, help="指定快照路径（默认 data/mock_arxiv_snapshot.json）")
     args = parser.parse_args()
+
+    # 工具没注册齐就别开跑：registry 不全时模型不会报错，它会编造工具名，
+    # benchmark 照样跑完并给出成功率 —— 那种数字比没有数字更危险。
+    require_all_tools("Benchmark")
 
     llm_extra = {}
     if args.no_thinking:

--- a/AgenticArxiv/mcp_protocol/mcp_agent.py
+++ b/AgenticArxiv/mcp_protocol/mcp_agent.py
@@ -22,6 +22,7 @@ from agents.base_agent import BaseAgent, is_terminal_action
 from agents.prompt_templates import get_react_prompt, format_tool_description
 from utils.llm_client import LLMClient
 from utils.logger import log
+from tools.bootstrap import missing_tools, register_all_tools, registered_tool_count
 
 
 MCP_SERVER_MODULE = "mcp_protocol.server"
@@ -39,13 +40,17 @@ class MCPAgent(BaseAgent):
         self._mcp_tools: List[Dict[str, Any]] = []
 
         # 确保底层工具已注册（供 _execute_with_side_effects 使用）
-        try:
-            import tools.arxiv_tool  # noqa: F401
-            import tools.pdf_download_tool  # noqa: F401
-            import tools.pdf_translate_tool  # noqa: F401
-            import tools.cache_status_tool  # noqa: F401
-        except ImportError as e:
-            log.warning(f"导入工具模块失败: {e}")
+        # 逐个模块独立导入：四个 import 曾共用一个 try，缺任何一个第三方依赖
+        # 就会让四个工具**全部**注册不上，而 registry 为空时模型不会报错，
+        # 它会编工具名。详见 tools/bootstrap.py。
+        failures = register_all_tools()
+        for module, error in failures.items():
+            log.warning(f"工具模块 {module} 导入失败: {error}")
+        missing = missing_tools()
+        if missing:
+            log.warning(f"以下工具不可用，模型可能改为编造工具名: {missing}")
+        else:
+            log.info(f"工具已全部注册（{registered_tool_count()} 个）")
 
     def discover_tools(self) -> List[Dict[str, Any]]:
         if self._mcp_tools:

--- a/AgenticArxiv/skill_cli/skill_agent.py
+++ b/AgenticArxiv/skill_cli/skill_agent.py
@@ -15,6 +15,7 @@ PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
+from tools.bootstrap import missing_tools, register_all_tools, registered_tool_count
 from agents.base_agent import BaseAgent
 from utils.llm_client import LLMClient
 from utils.logger import log
@@ -44,13 +45,17 @@ class SkillAgent(BaseAgent):
         self._skill_doc = self._load_skill_doc()
 
         # 确保底层工具已注册（供 _execute_with_side_effects 使用）
-        try:
-            import tools.arxiv_tool  # noqa: F401
-            import tools.pdf_download_tool  # noqa: F401
-            import tools.pdf_translate_tool  # noqa: F401
-            import tools.cache_status_tool  # noqa: F401
-        except ImportError as e:
-            log.warning(f"导入工具模块失败: {e}")
+        # 逐个模块独立导入：四个 import 曾共用一个 try，缺任何一个第三方依赖
+        # 就会让四个工具**全部**注册不上，而 registry 为空时模型不会报错，
+        # 它会编工具名。详见 tools/bootstrap.py。
+        failures = register_all_tools()
+        for module, error in failures.items():
+            log.warning(f"工具模块 {module} 导入失败: {error}")
+        missing = missing_tools()
+        if missing:
+            log.warning(f"以下工具不可用，模型可能改为编造工具名: {missing}")
+        else:
+            log.info(f"工具已全部注册（{registered_tool_count()} 个）")
 
     @staticmethod
     def _load_skill_doc() -> str:

--- a/AgenticArxiv/tests/test_tool_bootstrap.py
+++ b/AgenticArxiv/tests/test_tool_bootstrap.py
@@ -1,0 +1,124 @@
+"""工具注册的测试。
+
+核心是一条：**缺一个第三方依赖不能让四个工具全都消失**。
+
+原来三个 Agent 各自复制了同一段代码，四个 import 共用一个 try。
+`tools.arxiv_tool` 依赖第三方包 `arxiv` 且排在第一个，环境里没有它时，
+连纯本地零依赖的 `cache_status_tool` 也一起注册不上。而 registry 为空时
+模型不会报错 —— 它会编工具名，benchmark 照样跑完并写出成功率。
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import tools.arxiv_tool  # noqa: F401,E402
+import tools.cache_status_tool  # noqa: F401,E402
+import tools.pdf_download_tool  # noqa: F401,E402
+import tools.pdf_translate_tool  # noqa: F401,E402
+from tools.bootstrap import (  # noqa: E402
+    TOOL_MODULES,
+    missing_tools,
+    register_all_tools,
+    registered_tool_count,
+    require_all_tools,
+)
+
+
+class RegisterAllToolsTest(unittest.TestCase):
+    def test_all_four_register_in_a_healthy_environment(self):
+        self.assertEqual(register_all_tools(), {})
+        self.assertEqual(missing_tools(), [])
+        self.assertEqual(registered_tool_count(), len(TOOL_MODULES))
+
+    def test_one_broken_module_does_not_take_down_the_rest(self):
+        """这是整个模块存在的理由。
+
+        缺 `arxiv` 时只应该少 get_recently_submitted_cs_papers 一个，
+        另外三个纯本地工具必须照常可用。
+        """
+        real_import = __import__
+
+        def fake_import(name, *a, **kw):
+            if name == "tools.arxiv_tool":
+                raise ModuleNotFoundError("No module named 'arxiv'")
+            return real_import(name, *a, **kw)
+
+        with mock.patch("importlib.import_module") as im:
+            def side_effect(module):
+                if module == "tools.arxiv_tool":
+                    raise ModuleNotFoundError("No module named 'arxiv'")
+                return real_import(module)
+            im.side_effect = side_effect
+            failures = register_all_tools()
+
+        self.assertEqual(sorted(failures), ["tools.arxiv_tool"])
+        self.assertIn("arxiv", failures["tools.arxiv_tool"])
+        # 其余三个模块仍然被尝试导入了，没有因为第一个失败而跳过
+        self.assertEqual(len(failures), 1)
+
+
+class RequireAllToolsTest(unittest.TestCase):
+    def test_passes_when_everything_is_registered(self):
+        require_all_tools("单元测试")     # 不抛异常即可
+
+    def test_raises_with_actionable_message_when_a_tool_is_missing(self):
+        with mock.patch("tools.bootstrap.missing_tools",
+                        return_value=["get_recently_submitted_cs_papers"]), \
+             mock.patch("tools.bootstrap.register_all_tools",
+                        return_value={"tools.arxiv_tool": "ModuleNotFoundError: No module named 'arxiv'"}):
+            with self.assertRaises(SystemExit) as ctx:
+                require_all_tools("Benchmark")
+        message = str(ctx.exception)
+        self.assertIn("Benchmark", message)
+        self.assertIn("get_recently_submitted_cs_papers", message)
+        self.assertIn("pip install arxiv", message)
+        # 必须点明后果，否则读的人会以为「少个工具而已，能跑就行」
+        self.assertIn("编造工具名", message)
+
+    def test_benchmark_entrypoint_checks_before_running(self):
+        """跑 96 条之后才发现工具没装上，代价太大。"""
+        source = (Path(__file__).resolve().parents[1]
+                  / "benchmark" / "run_benchmark.py").read_text(encoding="utf-8")
+        self.assertIn("require_all_tools", source)
+        self.assertLess(source.index("require_all_tools(\"Benchmark\")"),
+                        source.index("BenchmarkRunner("),
+                        "校验必须在真正开跑之前")
+
+
+class AgentsUseTheSharedBootstrapTest(unittest.TestCase):
+    """三个 Agent 曾各自复制同一段注册代码，改一处漏两处。"""
+
+    AGENTS = ("agents/agent_engine.py", "mcp_protocol/mcp_agent.py",
+              "skill_cli/skill_agent.py")
+
+    def test_no_agent_keeps_its_own_shared_try_block(self):
+        root = Path(__file__).resolve().parents[1]
+        for rel in self.AGENTS:
+            source = (root / rel).read_text(encoding="utf-8")
+            with self.subTest(agent=rel):
+                self.assertIn("register_all_tools", source)
+                self.assertNotIn("import tools.arxiv_tool", source,
+                                 f"{rel} 仍在自己导入工具模块")
+
+    def test_bootstrap_import_comes_after_sys_path_setup(self):
+        """tools 包要等 PROJECT_ROOT 进 sys.path 之后才可导入。"""
+        root = Path(__file__).resolve().parents[1]
+        for rel in self.AGENTS:
+            lines = (root / rel).read_text(encoding="utf-8").split("\n")
+            path_line = next((i for i, l in enumerate(lines)
+                              if "sys.path.insert" in l), None)
+            boot_line = next((i for i, l in enumerate(lines)
+                              if "from tools.bootstrap import" in l), None)
+            with self.subTest(agent=rel):
+                self.assertIsNotNone(boot_line, f"{rel} 没有引入 bootstrap")
+                if path_line is not None:
+                    self.assertGreater(boot_line, path_line,
+                                       f"{rel} 的 bootstrap import 早于 sys.path 设置")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AgenticArxiv/tools/bootstrap.py
+++ b/AgenticArxiv/tools/bootstrap.py
@@ -1,0 +1,90 @@
+"""工具注册的统一入口。
+
+## 为什么需要这个模块
+
+三个 Agent（regex / mcp / skill_cli）各自复制了同一段注册代码：
+
+    try:
+        import tools.arxiv_tool
+        import tools.pdf_download_tool
+        import tools.pdf_translate_tool
+        import tools.cache_status_tool
+    except ImportError as e:
+        log.warning(f"导入工具模块失败: {e}")
+
+四个 import 共用一个 try，所以**缺任何一个依赖，四个工具就全都注册不上**。
+`tools.arxiv_tool` 依赖第三方包 `arxiv`，它排在第一个 —— 环境里没有 `arxiv`
+时，连纯本地、零依赖的 `cache_status_tool` 也一起消失。
+
+后果不是报错而是**换了个人格**：registry 为空 → prompt 里的工具列表是空的
+→ 模型开始编工具名。实测在一台没装 `arxiv` 的机器上跑 benchmark，模型调用了
+`search_arxiv`、`check_download_history` 这些根本不存在的工具，96 条运行全部
+正常产出报告、给出成功率、写进 CSV，没有任何一处提示工具没装上。
+
+这里把注册收敛成一处，并且：
+  - 逐个模块独立导入，一个失败不牵连其余；
+  - 返回失败明细而不是吞掉；
+  - 给需要「结果必须可信」的入口（benchmark / RL）一个硬校验函数。
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import Dict, List
+
+from tools.tool_registry import registry
+
+#: 模块 -> 它提供的工具名。用于校验「导入成功」是否真的等于「工具可用」。
+TOOL_MODULES: Dict[str, str] = {
+    "tools.arxiv_tool": "get_recently_submitted_cs_papers",
+    "tools.pdf_download_tool": "download_arxiv_pdf",
+    "tools.pdf_translate_tool": "translate_arxiv_pdf",
+    "tools.cache_status_tool": "get_paper_cache_status",
+}
+
+
+def register_all_tools() -> Dict[str, str]:
+    """逐个导入工具模块，返回 {模块名: 错误信息}（全部成功则为空字典）。
+
+    每个模块独立 try —— 一个第三方依赖缺失不应该让其余工具也消失。
+    """
+    failures: Dict[str, str] = {}
+    for module in TOOL_MODULES:
+        try:
+            importlib.import_module(module)
+        except Exception as exc:                      # noqa: BLE001
+            failures[module] = f"{type(exc).__name__}: {exc}"
+    return failures
+
+
+def missing_tools() -> List[str]:
+    """当前 registry 里还缺哪些工具。"""
+    registered = {t["name"] for t in registry.list_tools()}
+    return sorted(name for name in TOOL_MODULES.values() if name not in registered)
+
+
+def registered_tool_count() -> int:
+    """已注册工具数。让调用方不必各自 import registry。"""
+    return len(registry.list_tools())
+
+
+def require_all_tools(context: str = "本次运行") -> None:
+    """工具没注册齐就直接失败。
+
+    给 benchmark / RL 这类「跑完才发现结果无意义」代价极高的入口用。
+    工具列表不全时模型不会报错，它会编工具名，然后一切照常产出 ——
+    那种数字比没有数字更危险。
+    """
+    failures = register_all_tools()
+    missing = missing_tools()
+    if not missing:
+        return
+
+    lines = [f"❌ {context}需要全部 {len(TOOL_MODULES)} 个工具，当前缺少: {missing}"]
+    for module, error in failures.items():
+        lines.append(f"   {module}: {error}")
+    lines.append("   工具列表不全时模型不会报错，而是会编造工具名 ——")
+    lines.append("   benchmark 照样跑完并给出成功率，那些数字是无意义的。")
+    if any("arxiv" in e for e in failures.values()):
+        lines.append("   缺 arxiv 包时: pip install arxiv")
+    raise SystemExit("\n".join(lines))


### PR DESCRIPTION
## Problem

All three agents — `agents/agent_engine.py`, `mcp_protocol/mcp_agent.py`, and
`skill_cli/skill_agent.py` — carry a copy of the same registration block, and
**all four imports share a single `try`**:

```python
try:
    import tools.arxiv_tool          # needs the third-party `arxiv` package, and it is first
    import tools.pdf_download_tool
    import tools.pdf_translate_tool
    import tools.cache_status_tool
except ImportError as e:
    log.warning(f"导入工具模块失败: {e}")
```

`tools.arxiv_tool` requires the third-party `arxiv` package. On a machine
without it, the first line raises and **the remaining three never execute** —
even `cache_status_tool`, which is pure local code with no dependencies at all,
disappears. All four tools are lost, and the only trace is one `log.warning`.

## The failure is not an error — the agent quietly becomes a different agent

An empty registry means the tool list in the prompt is empty, so the model
starts inventing tool names.

Observed while running the benchmark on a machine without `arxiv`:

```
tools=[check_download_history]   ← does not exist
tools=[search_arxiv]             ← does not exist
```

All 96 runs completed "successfully". The run produced `report.md`,
`raw_data.csv`, and `summary.json`, complete with success rates, pass^k, and
token accounting. Nothing anywhere in the report indicated that no tools were
registered.

How the bad data was actually caught: the run deliberately included three
anchor tasks whose success rates had been measured before, and
`state_cache_before_dl` came back at 0.000 against a baseline of 1.000.
Without those anchors this report would have been used as a real result.

## Fix

New module `tools/bootstrap.py`:

- `register_all_tools()` — imports each module **independently**, so one
  failure cannot take down the rest, and returns `{module: error}` instead of
  swallowing the detail;
- `missing_tools()` — checks the registry against `TOOL_MODULES` to see which
  tools are actually absent ("the import did not raise" is not the same as
  "the tool registered");
- `require_all_tools(context)` — a hard check for entry points where
  discovering the problem only after the run is expensive.

The three agents now share it instead of each keeping a copy — previously,
fixing this block in one place left two others untouched.

`benchmark/run_benchmark.py` calls `require_all_tools("Benchmark")` after
`parse_args()` and before any run starts:

```
❌ Benchmark需要全部 4 个工具，当前缺少: ['get_recently_submitted_cs_papers']
   tools.arxiv_tool: ModuleNotFoundError: No module named 'arxiv'
   工具列表不全时模型不会报错，而是会编造工具名 ——
   benchmark 照样跑完并给出成功率，那些数字是无意义的。
   缺 arxiv 包时: pip install arxiv
```

The agents stay lenient (warn, do not abort) — in an interactive session a
partial toolset is still usable. The benchmark and RL paths are strict,
because their output is meant to be used as a conclusion.

## Import ordering, fixed along the way

In `mcp_agent.py` and `skill_agent.py` the `tools.*` import has to come after
`sys.path.insert(0, PROJECT_ROOT)`, or the package cannot be found at all.
A test now pins that ordering.

## Tests

`tests/test_tool_bootstrap.py`, 7 cases:

- `test_one_broken_module_does_not_take_down_the_rest` — the central claim of
  this PR: simulate a missing `arxiv` and assert that exactly one tool is lost
  while the other three remain available
- `test_raises_with_actionable_message_when_a_tool_is_missing` — the error has
  to say what is missing, why, and how to fix it, and must **name the
  consequence** (otherwise it reads as "just one tool short, still runnable")
- `test_benchmark_entrypoint_checks_before_running` — the check happens before
  the run, not after
- `test_no_agent_keeps_its_own_shared_try_block` — no agent imports tool
  modules on its own any more
- `test_bootstrap_import_comes_after_sys_path_setup` — import ordering

Full suite (`python -m unittest discover -s tests`): **163 passed**.
