### PR TITLE
feat(benchmark): expand the task set to 52 with declarative specs

### DIFF
--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -177,9 +177,16 @@ def _extract_tool_sequence(history: List[Dict]) -> List[str]:
 
 
 def _check_tool_sequence(actual: List[str], expected: List[str]) -> bool:
-    """检查实际工具调用是否与预期序列完全一致（严格顺序、无多余/重复调用）"""
+    """检查实际工具调用是否与预期序列完全一致（严格顺序、无多余/重复调用）。
+
+    expected 为空表示**正确行为是一次工具都不调**（category="infeasible"：
+    请求超出能力边界或指向不存在的对象）。此前这里无条件返回 True，于是
+    幻觉调用也算「准确」——`_outcome_score` 会因为 task_completed and
+    tool_call_accurate 给出满分，硬调不存在的第 20 篇反而拿到 outcome=+1.0。
+    rl/reward.py 的 `_tool_score` 在同样输入下给 0.0，两边本就不一致。
+    """
     if not expected:
-        return True
+        return not actual
     return actual == expected
 
 

--- a/AgenticArxiv/benchmark/run_benchmark.py
+++ b/AgenticArxiv/benchmark/run_benchmark.py
@@ -22,7 +22,7 @@ if PROJECT_ROOT not in sys.path:
     sys.path.insert(0, PROJECT_ROOT)
 
 from tools.bootstrap import require_all_tools
-from benchmark.tasks import get_all_tasks, get_tasks_by_category, get_task_by_id
+from benchmark.tasks import get_all_tasks
 from benchmark.runner import BenchmarkRunner
 from benchmark.report import BenchmarkReport
 from config import settings
@@ -42,8 +42,9 @@ def main():
     )
     parser.add_argument(
         "--tasks", type=str, default=None,
-        choices=["search", "download", "translate", "cache", "composite"],
-        help="按类别筛选测试任务",
+        choices=["search", "download", "translate", "cache", "composite",
+                 "ref_form", "optional", "state", "long_chain", "infeasible"],
+        help="按类别筛选测试任务。后五个类别只存在于 --task-set expanded",
     )
     parser.add_argument(
         "--task-ids", nargs="+", default=None,
@@ -75,6 +76,11 @@ def main():
              "代价是不再覆盖真实 API 集成。",
     )
     parser.add_argument("--snapshot", default=None, help="指定快照路径（默认 data/mock_arxiv_snapshot.json）")
+    parser.add_argument(
+        "--task-set", choices=["default", "expanded"], default="default",
+        help="default=benchmark/tasks.py 的 8 条；expanded=扩充后的 52 条"
+             "（指代形态、可选参数、跨步状态、多跳链路、不可行请求）",
+    )
     args = parser.parse_args()
 
     # 工具没注册齐就别开跑：registry 不全时模型不会报错，它会编造工具名，
@@ -85,19 +91,36 @@ def main():
     if args.no_thinking:
         llm_extra["chat_template_kwargs"] = {"enable_thinking": False}
 
+    # 任务池
+    if args.task_set == "expanded":
+        from benchmark.tasks_expanded import get_expanded_tasks, offline_only_ids
+        pool = get_expanded_tasks()
+        if not args.offline:
+            # 这些任务的标准答案绑定 data/mock_arxiv_snapshot.json（例如标题子串
+            # 指向快照里的特定论文），联网跑会拿到另一批论文，判分没有意义
+            skip = set(offline_only_ids())
+            dropped = [t["id"] for t in pool if t["id"] in skip]
+            pool = [t for t in pool if t["id"] not in skip]
+            if dropped:
+                print(f"提示：{len(dropped)} 条任务的标准答案绑定快照，"
+                      f"未加 --offline 故跳过，例如 {dropped[:3]}")
+    else:
+        pool = get_all_tasks()
+
     # 筛选任务
     if args.task_ids:
-        task_list = [t for tid in args.task_ids if (t := get_task_by_id(tid)) is not None]
+        by_id = {t["id"]: t for t in pool}
+        task_list = [by_id[tid] for tid in args.task_ids if tid in by_id]
         if not task_list:
             print(f"错误: 未找到任务 {args.task_ids}")
             sys.exit(1)
     elif args.tasks:
-        task_list = get_tasks_by_category(args.tasks)
+        task_list = [t for t in pool if t.get("category") == args.tasks]
         if not task_list:
-            print(f"错误: 类别 '{args.tasks}' 无任务")
+            print(f"错误: 类别 '{args.tasks}' 在当前任务集里无任务")
             sys.exit(1)
     else:
-        task_list = get_all_tasks()
+        task_list = pool
 
     model = args.model or settings.models.agent_model
 

--- a/AgenticArxiv/benchmark/runner.py
+++ b/AgenticArxiv/benchmark/runner.py
@@ -93,7 +93,8 @@ class BenchmarkRunner:
                         if task_def.get("category") in ("download", "translate"):
                             self._cleanup_paper_artifacts(session_id)
 
-                        agent = self._create_agent(agent_type)
+                        agent = self._create_agent(
+                            agent_type, task_def.get("max_iterations"))
                         raw = agent.run(
                             task=task_def["task"],
                             agent_model=self.model,
@@ -157,18 +158,27 @@ class BenchmarkRunner:
             log.info(f"[Benchmark] 离线模式，回放快照 {path}")
         return self._env
 
-    def _create_agent(self, agent_type: str):
+    def _create_agent(self, agent_type: str, max_iterations: Optional[int] = None):
+        """按任务声明的轮数预算创建 Agent。
+
+        Agent 默认 5 轮 = 最多 4 次工具调用 + 一次 FINISH。链更长的任务必须
+        显式抬高，否则会被判成 FORCE_STOP —— 那是「预算不够」而不是「不会
+        规划」，混在一起会让长链任务的失败率没法解读。
+        """
         side_fx = self._side_effects()
         env = self._tool_env()
+        kwargs = {"side_effect_mgr": side_fx, "env": env, "llm_extra": self.llm_extra}
+        if max_iterations is not None:
+            kwargs["max_iterations"] = max_iterations
         if agent_type == "mcp":
             from mcp_protocol.mcp_agent import MCPAgent
-            return MCPAgent(self.llm_client, side_effect_mgr=side_fx, env=env, llm_extra=self.llm_extra)
+            return MCPAgent(self.llm_client, **kwargs)
         elif agent_type == "skill_cli":
             from skill_cli.skill_agent import SkillAgent
-            return SkillAgent(self.llm_client, side_effect_mgr=side_fx, env=env, llm_extra=self.llm_extra)
+            return SkillAgent(self.llm_client, **kwargs)
         else:
             from agents.agent_engine import ReActAgent
-            return ReActAgent(self.llm_client, side_effect_mgr=side_fx, env=env, llm_extra=self.llm_extra)
+            return ReActAgent(self.llm_client, **kwargs)
 
     @staticmethod
     def _cleanup_paper_artifacts(session_id: str):

--- a/AgenticArxiv/benchmark/task_spec.py
+++ b/AgenticArxiv/benchmark/task_spec.py
@@ -1,0 +1,132 @@
+"""任务声明层：`expected_tools` / `expected_tool_args` 由同一份 steps 派生。
+
+对应 README TODO P1「任务集扩充 …… 并支持自动派生 `expected_tools` /
+`expected_tool_args`，奖励才有区分度」。
+
+## 为什么要这一层
+
+原来每条任务手写两份平行的标准答案：
+
+    "expected_tools":     ["download_arxiv_pdf"],
+    "expected_tool_args": [{"ref": 1}],
+
+两份列表靠人肉保持对齐，一旦漏写就会**静默**削弱奖励——`argument_match_score`
+在 `expected_tool_args` 为 None 时返回 None，`RewardCalculator` 会把 argument
+这一档整个踢出加权分母，任务照跑、分照打，只是参数从此不再被检查。
+`benchmark/tasks.py` 里 `download_01` / `translate_01` / `cache_01` 三条
+就处在这个状态。
+
+这里把两份列表收敛成一份 `steps`，两者都从它派生，结构上不可能漂移。
+
+## 参数化家族
+
+`family()` 让一个模板 + 一组参数展开成多条任务：任务的自然语言描述和标准答案
+都由**同一份参数**渲染，因此描述里写 `days=7`、标准答案却是 `days=30` 这种
+不一致也无法发生。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class Step:
+    """一次工具调用。task 的标准答案由若干 Step 组成。"""
+
+    tool: str
+    args: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TaskSpec:
+    """一条基准任务的声明式定义。
+
+    Attributes:
+        steps: 标准解法的工具调用序列。空序列表示**正确行为是不调用任何工具**
+            （见 category="infeasible"）——这不是"没写标准答案"，两者在
+            `expected_tool_args` 上的区别是 `[]` 与 `None`。
+        setup: 跑任务前先替会话铺好的状态（由 runner 直接执行，不计入轨迹）。
+        max_iterations: 该任务允许的 ReAct 轮数上限。Agent 默认 5 轮，也就是
+            最多 4 次工具调用 + 一次 FINISH；更长的链必须显式抬高，否则会被
+            判成 FORCE_STOP 而非能力不足。
+    """
+
+    id: str
+    task: str
+    steps: Tuple[Step, ...] = ()
+    category: str = "misc"
+    difficulty: str = "medium"
+    setup: Tuple[Step, ...] = ()
+    template: Optional[str] = None
+    requires_offline: bool = False
+    note: str = ""
+    termination: str = "FINISH"
+    max_iterations: Optional[int] = None
+
+    def to_task(self) -> Dict[str, Any]:
+        """展开成 benchmark / RL 两侧共用的任务字典。"""
+        task: Dict[str, Any] = {
+            "id": self.id,
+            "task": self.task,
+            # 两份标准答案同源，长度必然相等
+            "expected_tools": [s.tool for s in self.steps],
+            "expected_tool_args": [dict(s.args) for s in self.steps],
+            "expected_termination": self.termination,
+            "category": self.category,
+            "difficulty": self.difficulty,
+        }
+        if self.setup:
+            task["setup"] = [{"name": s.tool, "args": dict(s.args)} for s in self.setup]
+        if self.template:
+            task["template"] = self.template
+        if self.requires_offline:
+            task["requires_offline"] = True
+        if self.note:
+            task["note"] = self.note
+        if self.max_iterations is not None:
+            task["max_iterations"] = self.max_iterations
+        return task
+
+
+def family(
+    *,
+    text: Callable[[Mapping[str, Any]], str],
+    steps: Callable[[Mapping[str, Any]], Sequence[Step]],
+    params: Iterable[Mapping[str, Any]],
+    task_id: Callable[[Mapping[str, Any]], str],
+    **shared: Any,
+) -> List[TaskSpec]:
+    """把一个模板按参数展开成一族任务。
+
+    `text` 和 `steps` 收到同一份参数，因此任务描述与标准答案不会各说各话。
+
+    Args:
+        text: 参数 -> 自然语言任务描述
+        steps: 参数 -> 标准工具调用序列
+        params: 参数组
+        task_id: 参数 -> 任务 id
+        **shared: 该族共享的 TaskSpec 字段（category / difficulty / template …）
+    """
+    out: List[TaskSpec] = []
+    for p in params:
+        out.append(TaskSpec(
+            id=task_id(p),
+            task=text(p),
+            steps=tuple(steps(p)),
+            **shared,
+        ))
+    return out
+
+
+def build(specs: Iterable[TaskSpec]) -> List[Dict[str, Any]]:
+    """展开成任务字典列表，顺带查一遍 id 唯一。"""
+    tasks = [s.to_task() for s in specs]
+    seen: Dict[str, int] = {}
+    for t in tasks:
+        seen[t["id"]] = seen.get(t["id"], 0) + 1
+    dupes = sorted(k for k, v in seen.items() if v > 1)
+    if dupes:
+        raise ValueError(f"任务 id 重复: {dupes}")
+    return tasks

--- a/AgenticArxiv/benchmark/tasks_expanded.py
+++ b/AgenticArxiv/benchmark/tasks_expanded.py
@@ -1,0 +1,606 @@
+"""标准化测试集：由 task_spec 声明式定义展开。
+
+相比 benchmark/tasks.py 的 8 条，补齐了几个此前完全没覆盖的维度：
+
+  - **指代形态**（ref_form）：同一篇论文的序号 / arXiv ID / 标题子串 / null 四种写法
+  - **可选参数**（optional）：force / service / threads / keep_dual
+  - **跨步状态**（state）：「刚下载的那篇」这类必须靠会话状态才能解析的指代
+  - **多跳链路**（composite / long_chain）：2~5 步的工具链
+  - **不可行请求**（infeasible）：正确行为是**不调用任何工具**
+
+`expected_tools` 与 `expected_tool_args` 都从 `steps` 派生（见
+benchmark/task_spec.py），不存在两份标准答案漂移的可能。
+
+category=ref_form 与 state 中标 requires_offline 的任务，ground truth 绑定
+data/mock_arxiv_snapshot.json，需配合 run_benchmark.py --offline 运行。
+其中 4 条 ref_stress_* 用的标题子串经过挑选：完整短语与截断后的首词会命中
+**不同**的论文，因此能区分「参数是否被完整传递」。
+"""
+
+from typing import Any, Dict, List
+
+from benchmark.task_spec import Step, TaskSpec, build, family
+
+# arXiv CS 子类 -> 中文名，供任务描述渲染
+_CN = {
+    "AI": "人工智能", "LG": "机器学习", "CL": "自然语言处理",
+    "CV": "计算机视觉", "RO": "机器人学", "CR": "密码学与安全",
+}
+
+# 四种自然语言说法轮换，避免模型靠句式模板而不是语义来抽参数
+_SEARCH_PHRASINGS = (
+    "检索最近{days}天内{cn}(cs.{a})方向的论文，最多{n}篇",
+    "帮我找一下最近{days}天{cn}(cs.{a})的新论文，最多{n}篇",
+    "获取最近{days}天{cn}方向(cs.{a})的最新论文，数量上限{n}篇",
+    "搜索 cs.{a} 方向最近{days}天的论文，最多返回{n}篇",
+)
+
+_SEARCH_PARAMS = [
+    {"a": "AI", "days": 1, "n": 3, "phrasing": 0},
+    {"a": "AI", "days": 30, "n": 25, "phrasing": 1},
+    {"a": "LG", "days": 3, "n": 10, "phrasing": 2},
+    {"a": "LG", "days": 14, "n": 1, "phrasing": 3},
+    {"a": "CL", "days": 7, "n": 5, "phrasing": 0},
+    {"a": "CL", "days": 30, "n": 10, "phrasing": 1},
+    {"a": "CV", "days": 1, "n": 1, "phrasing": 2},
+    {"a": "CV", "days": 14, "n": 3, "phrasing": 3},
+    {"a": "RO", "days": 3, "n": 8, "phrasing": 0},
+    {"a": "RO", "days": 30, "n": 25, "phrasing": 1},
+    {"a": "CR", "days": 7, "n": 5, "phrasing": 2},
+    {"a": "CR", "days": 14, "n": 10, "phrasing": 3},
+]
+
+# 任务描述与标准答案由同一份参数渲染，因此「描述里写 7 天、答案里写 30 天」
+# 这种不一致在结构上就不可能发生。
+_SEARCH = family(
+    task_id=lambda p: f"search_{p['a']}_{p['days']}d_{p['n']}",
+    text=lambda p: _SEARCH_PHRASINGS[p["phrasing"]].format(
+        days=p["days"], cn=_CN[p["a"]], a=p["a"], n=p["n"]),
+    steps=lambda p: [Step("get_recently_submitted_cs_papers",
+                          {"aspect": p["a"], "days": p["days"], "max_results": p["n"]})],
+    params=_SEARCH_PARAMS,
+    category="search",
+    difficulty="easy",
+)
+
+_SEED_AI5 = (Step("get_recently_submitted_cs_papers",
+                  {"aspect": "AI", "days": 7, "max_results": 5}),)
+
+_OTHERS: List[TaskSpec] = [
+    # ---------- optional ----------
+    TaskSpec(
+        id='opt_force_dl',
+        task='强制重新下载第1篇论文',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 1, 'force': True}),
+        ),
+        category='optional',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+    ),
+    TaskSpec(
+        id='opt_keep_dual',
+        task='翻译第1篇论文，保留双语版本',
+        steps=(
+            Step('translate_arxiv_pdf', {'ref': 1, 'keep_dual': True}),
+        ),
+        category='optional',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+        ),
+    ),
+    TaskSpec(
+        id='opt_service',
+        task='用 google 服务翻译第1篇论文',
+        steps=(
+            Step('translate_arxiv_pdf', {'ref': 1, 'service': 'google'}),
+        ),
+        category='optional',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+        ),
+    ),
+    TaskSpec(
+        id='opt_threads',
+        task='翻译第1篇论文，用8个线程',
+        steps=(
+            Step('translate_arxiv_pdf', {'ref': 1, 'threads': 8}),
+        ),
+        category='optional',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+        ),
+    ),
+    TaskSpec(
+        id='opt_force_tr',
+        task='强制重新翻译第1篇论文',
+        steps=(
+            Step('translate_arxiv_pdf', {'ref': 1, 'force': True}),
+        ),
+        category='optional',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+        ),
+    ),
+    # ---------- ref_form ----------
+    TaskSpec(
+        id='ref_stress_learning_state',
+        task='下载标题里包含 "Learning State" 的那篇论文',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 'Learning State'}),
+        ),
+        category='ref_form',
+        difficulty='hard',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+        requires_offline=True,
+        note='截断成 Learning 会命中 2608.14539v1（错误）',
+    ),
+    TaskSpec(
+        id='ref_stress_state_across',
+        task='查看标题里含 "State Across" 那篇论文的缓存状态',
+        steps=(
+            Step('get_paper_cache_status', {'ref': 'State Across'}),
+        ),
+        category='ref_form',
+        difficulty='hard',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+        requires_offline=True,
+        note='截断成 State 会命中 2608.14530v1（错误）',
+    ),
+    TaskSpec(
+        id='ref_stress_image_restoration',
+        task='下载标题包含 "Image Restoration" 的论文',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 'Image Restoration'}),
+        ),
+        category='ref_form',
+        difficulty='hard',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CV', 'days': 7, 'max_results': 5}),
+        ),
+        requires_offline=True,
+        note='截断成 Image 会命中 2608.14546v1（错误）',
+    ),
+    TaskSpec(
+        id='ref_stress_uncertainty_aware',
+        task='把标题里有 "An Uncertainty-Aware" 的那篇下载下来',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 'An Uncertainty-Aware'}),
+        ),
+        category='ref_form',
+        difficulty='hard',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CV', 'days': 7, 'max_results': 5}),
+        ),
+        requires_offline=True,
+        note='截断成 An 会命中 2608.14546v1（错误）',
+    ),
+    TaskSpec(
+        id='ref_ctrl_word_marionette',
+        task='下载标题里包含 Marionette 的那篇论文',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 'Marionette'}),
+        ),
+        category='ref_form',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+        requires_offline=True,
+        note='单词，无引号需求',
+    ),
+    TaskSpec(
+        id='ref_ctrl_word_handover',
+        task='下载标题包含 Handover 的论文',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 'Handover'}),
+        ),
+        category='ref_form',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+        requires_offline=True,
+        note='单词，无引号需求',
+    ),
+    TaskSpec(
+        id='ref_ctrl_id_download',
+        task='下载 2608.14528v1 这篇论文',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': '2608.14528v1'}),
+        ),
+        category='ref_form',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+        requires_offline=True,
+        note='完整ID含字母，不会被类型推断改变',
+    ),
+    TaskSpec(
+        id='ref_ctrl_id_cache',
+        task='查一下 2608.14543v1 的缓存状态',
+        steps=(
+            Step('get_paper_cache_status', {'ref': '2608.14543v1'}),
+        ),
+        category='ref_form',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CV', 'days': 7, 'max_results': 5}),
+        ),
+        requires_offline=True,
+        note='同上',
+    ),
+    TaskSpec(
+        id='ref_ctrl_null_translate',
+        task='把刚才那篇论文翻译一下',
+        steps=(
+            Step('translate_arxiv_pdf', {'ref': None}),
+        ),
+        category='ref_form',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 2}),
+        ),
+        requires_offline=True,
+        note='prompt 要求传 JSON null',
+    ),
+    TaskSpec(
+        id='ref_ctrl_null_cache',
+        task='看看刚操作的那篇论文缓存好了没',
+        steps=(
+            Step('get_paper_cache_status', {'ref': None}),
+        ),
+        category='ref_form',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 3}),
+        ),
+        requires_offline=True,
+        note='同上',
+    ),
+    # ---------- composite ----------
+    TaskSpec(
+        id='multi_cv3_dl1',
+        task='搜索最近7天计算机视觉(cs.CV)的论文(最多3篇)，然后下载第1篇',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CV', 'days': 7, 'max_results': 3}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+        ),
+        category='composite',
+        difficulty='hard',
+    ),
+    TaskSpec(
+        id='multi_cl5_dl2_cache',
+        task='检索最近7天自然语言处理(cs.CL)论文5篇，下载第2篇，再查它的缓存状态',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CL', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 2}),
+            Step('get_paper_cache_status', {'ref': 2}),
+        ),
+        category='composite',
+        difficulty='hard',
+    ),
+    TaskSpec(
+        id='multi_ai5_dl1_tr',
+        task='找最近7天人工智能(cs.AI)的论文5篇，下载第1篇并翻译它',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+            Step('translate_arxiv_pdf', {'ref': 1}),
+        ),
+        category='composite',
+        difficulty='hard',
+    ),
+    TaskSpec(
+        id='multi_ro3_dl_two',
+        task='检索最近3天机器人学(cs.RO)论文3篇，把前两篇都下载下来',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'RO', 'days': 3, 'max_results': 3}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+            Step('download_arxiv_pdf', {'ref': 2}),
+        ),
+        category='composite',
+        difficulty='hard',
+    ),
+    TaskSpec(
+        id='multi_cr5_cache1',
+        task='搜索最近7天密码学与安全(cs.CR)论文5篇，查看第1篇的缓存状态',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CR', 'days': 7, 'max_results': 5}),
+            Step('get_paper_cache_status', {'ref': 1}),
+        ),
+        category='composite',
+        difficulty='hard',
+    ),
+    TaskSpec(
+        id='multi_lg10_dl3',
+        task='获取最近14天机器学习(cs.LG)论文10篇，下载第3篇',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'LG', 'days': 14, 'max_results': 10}),
+            Step('download_arxiv_pdf', {'ref': 3}),
+        ),
+        category='composite',
+        difficulty='hard',
+    ),
+    TaskSpec(
+        id='multi_cv5_dl1_cache_tr',
+        task='检索计算机视觉(cs.CV)最近7天5篇论文，下载第1篇，确认缓存后翻译',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CV', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+            Step('get_paper_cache_status', {'ref': 1}),
+            Step('translate_arxiv_pdf', {'ref': 1}),
+        ),
+        category='composite',
+        difficulty='hard',
+    ),
+    TaskSpec(
+        id='multi_ai3_tr1',
+        task='搜最近7天AI论文3篇，直接翻译第1篇',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 3}),
+            Step('translate_arxiv_pdf', {'ref': 1}),
+        ),
+        category='composite',
+        difficulty='hard',
+    ),
+    # ---------- state ----------
+    TaskSpec(
+        id='state_ref_ordinal_cn',
+        task='把第三篇论文下载下来',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 3}),
+        ),
+        category='state',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+    ),
+    TaskSpec(
+        id='state_ref_last_active',
+        task='刚才下载的那篇，帮我翻译一下',
+        steps=(
+            Step('translate_arxiv_pdf', {'ref': None}),
+        ),
+        category='state',
+        difficulty='hard',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 2}),
+        ),
+    ),
+    TaskSpec(
+        id='state_ref_cache_active',
+        task='查一下我刚下载的那篇论文的缓存状态',
+        steps=(
+            Step('get_paper_cache_status', {'ref': None}),
+        ),
+        category='state',
+        difficulty='hard',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 2}),
+        ),
+    ),
+    TaskSpec(
+        id='state_cache_two',
+        task='第1篇和第2篇，分别查一下缓存状态',
+        steps=(
+            Step('get_paper_cache_status', {'ref': 1}),
+            Step('get_paper_cache_status', {'ref': 2}),
+        ),
+        category='state',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+    ),
+    TaskSpec(
+        id='state_dl_then_cache',
+        task='下载第1篇，然后确认它是否已经缓存',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 1}),
+            Step('get_paper_cache_status', {'ref': 1}),
+        ),
+        category='state',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+    ),
+    TaskSpec(
+        id='state_cache_before_dl',
+        task='先看看第2篇有没有下载过，没有的话下载它',
+        steps=(
+            Step('get_paper_cache_status', {'ref': 2}),
+            Step('download_arxiv_pdf', {'ref': 2}),
+        ),
+        category='state',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+        ),
+    ),
+    TaskSpec(
+        id='state_ref_last_of_10',
+        task='把最后那篇（第10篇）下载下来',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 10}),
+        ),
+        category='state',
+        difficulty='medium',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CL', 'days': 7, 'max_results': 10}),
+        ),
+    ),
+    TaskSpec(
+        id='state_translate_active',
+        task='翻译刚才那篇论文',
+        steps=(
+            Step('translate_arxiv_pdf', {'ref': None}),
+        ),
+        category='state',
+        difficulty='hard',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+        ),
+    ),
+]
+
+
+# ============================================================================
+# 不可行请求：正确行为是**不调用任何工具**
+# ============================================================================
+# 现有任务全都在奖励「做对了什么」，没有一条惩罚「做了不该做的事」。
+# 但 Agent 最典型的失效模式恰恰是幻觉调用——会话里只有 5 篇，却硬要下载第 20 篇。
+# 这类任务的 steps 为空，`_tool_score` 在 expected 为空时只有一条路：
+# 不调工具得 1.0，调了就得 0.0。
+#
+# 它同时是 reward hacking 的探针：只靠「多调工具」刷分的策略在这里必然掉分。
+_INFEASIBLE: List[TaskSpec] = [
+    TaskSpec(
+        id='infeasible_index_out_of_range',
+        task='把第20篇论文下载下来',
+        category='infeasible',
+        difficulty='hard',
+        setup=_SEED_AI5,
+        note='会话里只有 5 篇；正确反应是说明做不到，而不是编一个 ref 去调用',
+    ),
+    TaskSpec(
+        id='infeasible_unknown_id',
+        task='下载 2999.99999v1 这篇论文',
+        category='infeasible',
+        difficulty='hard',
+        setup=_SEED_AI5,
+        requires_offline=True,
+        note='该 arXiv ID 不在快照里；解析不到就不应该调用下载',
+    ),
+    TaskSpec(
+        id='infeasible_no_session',
+        task='把刚才那篇论文翻译一下',
+        category='infeasible',
+        difficulty='hard',
+        note='没有 setup，会话是空的——「刚才那篇」无从指代。'
+             '这是与 ref_ctrl_null_translate 的对照组：同样的话术，'
+             '有会话时该调用，没会话时不该调用',
+    ),
+    TaskSpec(
+        id='infeasible_unsupported_action',
+        task='把第1篇论文的作者邮箱找出来发一封约稿邮件',
+        category='infeasible',
+        difficulty='hard',
+        setup=_SEED_AI5,
+        note='四个工具都做不到这件事；正确反应是说明能力边界',
+    ),
+]
+
+
+# ============================================================================
+# 长链：4~5 步
+# ============================================================================
+# 项目定位是长程工具调用，但原 43 条里 4 步的只有 1 条、3 步 3 条，74% 是单步。
+# 这一族把链长顶到 Agent 的实际上限。
+#
+# 注意 max_iterations：Agent 默认 5 轮 = 最多 4 次工具调用 + 一次 FINISH。
+# 5 步链必须显式抬高，否则会被判成 FORCE_STOP —— 那是「预算不够」而不是
+# 「不会规划」，两者混在一起会让这一族的失败率完全没法解读。
+_LONG_CHAIN: List[TaskSpec] = [
+    TaskSpec(
+        id='chain_ai5_dl2_tr2',
+        task='找最近7天人工智能(cs.AI)的论文5篇，把第1篇和第2篇都下载下来，然后翻译第2篇',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'AI', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+            Step('download_arxiv_pdf', {'ref': 2}),
+            Step('translate_arxiv_pdf', {'ref': 2}),
+        ),
+        category='long_chain',
+        difficulty='hard',
+    ),
+    TaskSpec(
+        id='chain_cv5_cache_dl_tr_cache',
+        task='检索最近7天计算机视觉(cs.CV)论文5篇，先查第1篇缓存状态，下载它，翻译它，最后再查一次缓存',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CV', 'days': 7, 'max_results': 5}),
+            Step('get_paper_cache_status', {'ref': 1}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+            Step('translate_arxiv_pdf', {'ref': 1}),
+            Step('get_paper_cache_status', {'ref': 1}),
+        ),
+        category='long_chain',
+        difficulty='hard',
+        max_iterations=7,
+        note='5 次工具调用 + FINISH，默认 5 轮预算不够，显式给到 7',
+    ),
+    TaskSpec(
+        id='chain_cl5_dl3_tr3',
+        task='搜索最近7天自然语言处理(cs.CL)论文5篇，下载第3篇，确认缓存后翻译它',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'CL', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 3}),
+            Step('get_paper_cache_status', {'ref': 3}),
+            Step('translate_arxiv_pdf', {'ref': 3}),
+        ),
+        category='long_chain',
+        difficulty='hard',
+    ),
+    TaskSpec(
+        id='chain_ro5_dl_three',
+        task='检索最近7天机器人学(cs.RO)论文5篇，把前三篇依次下载下来',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'RO', 'days': 7, 'max_results': 5}),
+            Step('download_arxiv_pdf', {'ref': 1}),
+            Step('download_arxiv_pdf', {'ref': 2}),
+            Step('download_arxiv_pdf', {'ref': 3}),
+        ),
+        category='long_chain',
+        difficulty='hard',
+        note='同一工具连调三次、只有 ref 递增，考察是否会漏调或重复调同一篇',
+    ),
+    TaskSpec(
+        id='chain_lg10_dl_tr_last',
+        task='获取最近14天机器学习(cs.LG)论文10篇，下载最后一篇，然后翻译它并保留双语',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {'aspect': 'LG', 'days': 14, 'max_results': 10}),
+            Step('download_arxiv_pdf', {'ref': 10}),
+            Step('translate_arxiv_pdf', {'ref': 10, 'keep_dual': True}),
+        ),
+        category='long_chain',
+        difficulty='hard',
+        note='把「最后一篇」的序数推断和可选参数叠在同一条链上',
+    ),
+]
+
+
+EXPANDED_TASKS: List[Dict[str, Any]] = build(_SEARCH + _OTHERS + _INFEASIBLE + _LONG_CHAIN)
+
+
+def get_expanded_tasks() -> List[Dict[str, Any]]:
+    return list(EXPANDED_TASKS)
+
+
+def get_by_category(category: str) -> List[Dict[str, Any]]:
+    return [t for t in EXPANDED_TASKS if t["category"] == category]
+
+
+def offline_only_ids() -> List[str]:
+    return [t["id"] for t in EXPANDED_TASKS if t.get("requires_offline")]

--- a/AgenticArxiv/rl/reward.py
+++ b/AgenticArxiv/rl/reward.py
@@ -165,8 +165,11 @@ class RewardCalculator:
 
     @staticmethod
     def _tool_score(actual: Sequence[str], expected: Sequence[str]) -> float:
+        # expected 为空表示正确行为是一次工具都不调（category="infeasible"）。
+        # 调了就给 -1.0 而不是 0.0：普通任务调错工具时 f1=0 → 2*0-1 = -1，
+        # 「本该什么都不做却动了手」不该比「做错了」罚得更轻。
         if not expected:
-            return 1.0 if not actual else 0.0
+            return 1.0 if not actual else -1.0
         lcs = _lcs_length(actual, expected)
         precision = lcs / len(actual) if actual else 0.0
         recall = lcs / len(expected)

--- a/AgenticArxiv/tests/fixtures_expanded_v1.json
+++ b/AgenticArxiv/tests/fixtures_expanded_v1.json
@@ -1,0 +1,1060 @@
+[
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "AI",
+    "days": 1,
+    "max_results": 3
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_AI_1d_3",
+  "task": "检索最近1天内人工智能(cs.AI)方向的论文，最多3篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "AI",
+    "days": 30,
+    "max_results": 25
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_AI_30d_25",
+  "task": "帮我找一下最近30天人工智能(cs.AI)的新论文，最多25篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "LG",
+    "days": 3,
+    "max_results": 10
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_LG_3d_10",
+  "task": "获取最近3天机器学习方向(cs.LG)的最新论文，数量上限10篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "LG",
+    "days": 14,
+    "max_results": 1
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_LG_14d_1",
+  "task": "搜索 cs.LG 方向最近14天的论文，最多返回1篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CL",
+    "days": 7,
+    "max_results": 5
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_CL_7d_5",
+  "task": "检索最近7天内自然语言处理(cs.CL)方向的论文，最多5篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CL",
+    "days": 30,
+    "max_results": 10
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_CL_30d_10",
+  "task": "帮我找一下最近30天自然语言处理(cs.CL)的新论文，最多10篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CV",
+    "days": 1,
+    "max_results": 1
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_CV_1d_1",
+  "task": "获取最近1天计算机视觉方向(cs.CV)的最新论文，数量上限1篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CV",
+    "days": 14,
+    "max_results": 3
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_CV_14d_3",
+  "task": "搜索 cs.CV 方向最近14天的论文，最多返回3篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "RO",
+    "days": 3,
+    "max_results": 8
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_RO_3d_8",
+  "task": "检索最近3天内机器人学(cs.RO)方向的论文，最多8篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "RO",
+    "days": 30,
+    "max_results": 25
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_RO_30d_25",
+  "task": "帮我找一下最近30天机器人学(cs.RO)的新论文，最多25篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CR",
+    "days": 7,
+    "max_results": 5
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_CR_7d_5",
+  "task": "获取最近7天密码学与安全方向(cs.CR)的最新论文，数量上限5篇"
+ },
+ {
+  "category": "search",
+  "difficulty": "easy",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CR",
+    "days": 14,
+    "max_results": 10
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers"
+  ],
+  "id": "search_CR_14d_10",
+  "task": "搜索 cs.CR 方向最近14天的论文，最多返回10篇"
+ },
+ {
+  "category": "state",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": 3
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf"
+  ],
+  "id": "state_ref_ordinal_cn",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "把第三篇论文下载下来"
+ },
+ {
+  "category": "state",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": null
+   }
+  ],
+  "expected_tools": [
+   "translate_arxiv_pdf"
+  ],
+  "id": "state_ref_last_active",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   },
+   {
+    "args": {
+     "ref": 2
+    },
+    "name": "download_arxiv_pdf"
+   }
+  ],
+  "task": "刚才下载的那篇，帮我翻译一下"
+ },
+ {
+  "category": "state",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": null
+   }
+  ],
+  "expected_tools": [
+   "get_paper_cache_status"
+  ],
+  "id": "state_ref_cache_active",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   },
+   {
+    "args": {
+     "ref": 2
+    },
+    "name": "download_arxiv_pdf"
+   }
+  ],
+  "task": "查一下我刚下载的那篇论文的缓存状态"
+ },
+ {
+  "category": "state",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": 1
+   },
+   {
+    "ref": 2
+   }
+  ],
+  "expected_tools": [
+   "get_paper_cache_status",
+   "get_paper_cache_status"
+  ],
+  "id": "state_cache_two",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "第1篇和第2篇，分别查一下缓存状态"
+ },
+ {
+  "category": "state",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": 1
+   },
+   {
+    "ref": 1
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf",
+   "get_paper_cache_status"
+  ],
+  "id": "state_dl_then_cache",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "下载第1篇，然后确认它是否已经缓存"
+ },
+ {
+  "category": "state",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": 2
+   },
+   {
+    "ref": 2
+   }
+  ],
+  "expected_tools": [
+   "get_paper_cache_status",
+   "download_arxiv_pdf"
+  ],
+  "id": "state_cache_before_dl",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "先看看第2篇有没有下载过，没有的话下载它"
+ },
+ {
+  "category": "state",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": 10
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf"
+  ],
+  "id": "state_ref_last_of_10",
+  "setup": [
+   {
+    "args": {
+     "aspect": "CL",
+     "days": 7,
+     "max_results": 10
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "把最后那篇（第10篇）下载下来"
+ },
+ {
+  "category": "state",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": null
+   }
+  ],
+  "expected_tools": [
+   "translate_arxiv_pdf"
+  ],
+  "id": "state_translate_active",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   },
+   {
+    "args": {
+     "ref": 1
+    },
+    "name": "download_arxiv_pdf"
+   }
+  ],
+  "task": "翻译刚才那篇论文"
+ },
+ {
+  "category": "composite",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CV",
+    "days": 7,
+    "max_results": 3
+   },
+   {
+    "ref": 1
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers",
+   "download_arxiv_pdf"
+  ],
+  "id": "multi_cv3_dl1",
+  "task": "搜索最近7天计算机视觉(cs.CV)的论文(最多3篇)，然后下载第1篇"
+ },
+ {
+  "category": "composite",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CL",
+    "days": 7,
+    "max_results": 5
+   },
+   {
+    "ref": 2
+   },
+   {
+    "ref": 2
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers",
+   "download_arxiv_pdf",
+   "get_paper_cache_status"
+  ],
+  "id": "multi_cl5_dl2_cache",
+  "task": "检索最近7天自然语言处理(cs.CL)论文5篇，下载第2篇，再查它的缓存状态"
+ },
+ {
+  "category": "composite",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "AI",
+    "days": 7,
+    "max_results": 5
+   },
+   {
+    "ref": 1
+   },
+   {
+    "ref": 1
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers",
+   "download_arxiv_pdf",
+   "translate_arxiv_pdf"
+  ],
+  "id": "multi_ai5_dl1_tr",
+  "task": "找最近7天人工智能(cs.AI)的论文5篇，下载第1篇并翻译它"
+ },
+ {
+  "category": "composite",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "RO",
+    "days": 3,
+    "max_results": 3
+   },
+   {
+    "ref": 1
+   },
+   {
+    "ref": 2
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers",
+   "download_arxiv_pdf",
+   "download_arxiv_pdf"
+  ],
+  "id": "multi_ro3_dl_two",
+  "task": "检索最近3天机器人学(cs.RO)论文3篇，把前两篇都下载下来"
+ },
+ {
+  "category": "composite",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CR",
+    "days": 7,
+    "max_results": 5
+   },
+   {
+    "ref": 1
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers",
+   "get_paper_cache_status"
+  ],
+  "id": "multi_cr5_cache1",
+  "task": "搜索最近7天密码学与安全(cs.CR)论文5篇，查看第1篇的缓存状态"
+ },
+ {
+  "category": "composite",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "LG",
+    "days": 14,
+    "max_results": 10
+   },
+   {
+    "ref": 3
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers",
+   "download_arxiv_pdf"
+  ],
+  "id": "multi_lg10_dl3",
+  "task": "获取最近14天机器学习(cs.LG)论文10篇，下载第3篇"
+ },
+ {
+  "category": "composite",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "CV",
+    "days": 7,
+    "max_results": 5
+   },
+   {
+    "ref": 1
+   },
+   {
+    "ref": 1
+   },
+   {
+    "ref": 1
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers",
+   "download_arxiv_pdf",
+   "get_paper_cache_status",
+   "translate_arxiv_pdf"
+  ],
+  "id": "multi_cv5_dl1_cache_tr",
+  "task": "检索计算机视觉(cs.CV)最近7天5篇论文，下载第1篇，确认缓存后翻译"
+ },
+ {
+  "category": "composite",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "aspect": "AI",
+    "days": 7,
+    "max_results": 3
+   },
+   {
+    "ref": 1
+   }
+  ],
+  "expected_tools": [
+   "get_recently_submitted_cs_papers",
+   "translate_arxiv_pdf"
+  ],
+  "id": "multi_ai3_tr1",
+  "task": "搜最近7天AI论文3篇，直接翻译第1篇"
+ },
+ {
+  "category": "optional",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "force": true,
+    "ref": 1
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf"
+  ],
+  "id": "opt_force_dl",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "强制重新下载第1篇论文"
+ },
+ {
+  "category": "optional",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "keep_dual": true,
+    "ref": 1
+   }
+  ],
+  "expected_tools": [
+   "translate_arxiv_pdf"
+  ],
+  "id": "opt_keep_dual",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   },
+   {
+    "args": {
+     "ref": 1
+    },
+    "name": "download_arxiv_pdf"
+   }
+  ],
+  "task": "翻译第1篇论文，保留双语版本"
+ },
+ {
+  "category": "optional",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": 1,
+    "service": "google"
+   }
+  ],
+  "expected_tools": [
+   "translate_arxiv_pdf"
+  ],
+  "id": "opt_service",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   },
+   {
+    "args": {
+     "ref": 1
+    },
+    "name": "download_arxiv_pdf"
+   }
+  ],
+  "task": "用 google 服务翻译第1篇论文"
+ },
+ {
+  "category": "optional",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": 1,
+    "threads": 8
+   }
+  ],
+  "expected_tools": [
+   "translate_arxiv_pdf"
+  ],
+  "id": "opt_threads",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   },
+   {
+    "args": {
+     "ref": 1
+    },
+    "name": "download_arxiv_pdf"
+   }
+  ],
+  "task": "翻译第1篇论文，用8个线程"
+ },
+ {
+  "category": "optional",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "force": true,
+    "ref": 1
+   }
+  ],
+  "expected_tools": [
+   "translate_arxiv_pdf"
+  ],
+  "id": "opt_force_tr",
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   },
+   {
+    "args": {
+     "ref": 1
+    },
+    "name": "download_arxiv_pdf"
+   }
+  ],
+  "task": "强制重新翻译第1篇论文"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": "Learning State"
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf"
+  ],
+  "id": "ref_stress_learning_state",
+  "note": "截断成 Learning 会命中 2608.14539v1（错误）",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "下载标题里包含 \"Learning State\" 的那篇论文"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": "State Across"
+   }
+  ],
+  "expected_tools": [
+   "get_paper_cache_status"
+  ],
+  "id": "ref_stress_state_across",
+  "note": "截断成 State 会命中 2608.14530v1（错误）",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "查看标题里含 \"State Across\" 那篇论文的缓存状态"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": "Image Restoration"
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf"
+  ],
+  "id": "ref_stress_image_restoration",
+  "note": "截断成 Image 会命中 2608.14546v1（错误）",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "CV",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "下载标题包含 \"Image Restoration\" 的论文"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "hard",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": "An Uncertainty-Aware"
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf"
+  ],
+  "id": "ref_stress_uncertainty_aware",
+  "note": "截断成 An 会命中 2608.14546v1（错误）",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "CV",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "把标题里有 \"An Uncertainty-Aware\" 的那篇下载下来"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": "Marionette"
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf"
+  ],
+  "id": "ref_ctrl_word_marionette",
+  "note": "单词，无引号需求",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "下载标题里包含 Marionette 的那篇论文"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": "Handover"
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf"
+  ],
+  "id": "ref_ctrl_word_handover",
+  "note": "单词，无引号需求",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "下载标题包含 Handover 的论文"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": "2608.14528v1"
+   }
+  ],
+  "expected_tools": [
+   "download_arxiv_pdf"
+  ],
+  "id": "ref_ctrl_id_download",
+  "note": "完整ID含字母，不会被类型推断改变",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "下载 2608.14528v1 这篇论文"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": "2608.14543v1"
+   }
+  ],
+  "expected_tools": [
+   "get_paper_cache_status"
+  ],
+  "id": "ref_ctrl_id_cache",
+  "note": "同上",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "CV",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   }
+  ],
+  "task": "查一下 2608.14543v1 的缓存状态"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": null
+   }
+  ],
+  "expected_tools": [
+   "translate_arxiv_pdf"
+  ],
+  "id": "ref_ctrl_null_translate",
+  "note": "prompt 要求传 JSON null",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   },
+   {
+    "args": {
+     "ref": 2
+    },
+    "name": "download_arxiv_pdf"
+   }
+  ],
+  "task": "把刚才那篇论文翻译一下"
+ },
+ {
+  "category": "ref_form",
+  "difficulty": "medium",
+  "expected_termination": "FINISH",
+  "expected_tool_args": [
+   {
+    "ref": null
+   }
+  ],
+  "expected_tools": [
+   "get_paper_cache_status"
+  ],
+  "id": "ref_ctrl_null_cache",
+  "note": "同上",
+  "requires_offline": true,
+  "setup": [
+   {
+    "args": {
+     "aspect": "AI",
+     "days": 7,
+     "max_results": 5
+    },
+    "name": "get_recently_submitted_cs_papers"
+   },
+   {
+    "args": {
+     "ref": 3
+    },
+    "name": "download_arxiv_pdf"
+   }
+  ],
+  "task": "看看刚操作的那篇论文缓存好了没"
+ }
+]

--- a/AgenticArxiv/tests/test_task_spec.py
+++ b/AgenticArxiv/tests/test_task_spec.py
@@ -1,0 +1,243 @@
+"""任务声明层的测试。
+
+两条主线：
+  1. `expected_tools` / `expected_tool_args` 由同一份 steps 派生，不可能漂移；
+  2. 重构不能动到原有 43 条 —— data/splits/v1.json 里的成功率是 ~1600 次
+     运行测出来的，任务文本或标准答案一变，那些数字就全部作废。
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmark.task_spec import Step, TaskSpec, build, family  # noqa: E402
+from benchmark.tasks_expanded import EXPANDED_TASKS  # noqa: E402
+
+FIXTURE = Path(__file__).parent / "fixtures_expanded_v1.json"
+
+
+class DerivationTest(unittest.TestCase):
+    def test_tools_and_args_come_from_the_same_steps(self):
+        spec = TaskSpec(
+            id="t", task="x",
+            steps=(Step("get_recently_submitted_cs_papers", {"aspect": "AI"}),
+                   Step("download_arxiv_pdf", {"ref": 1})),
+        )
+        task = spec.to_task()
+        self.assertEqual(task["expected_tools"],
+                         ["get_recently_submitted_cs_papers", "download_arxiv_pdf"])
+        self.assertEqual(task["expected_tool_args"], [{"aspect": "AI"}, {"ref": 1}])
+
+    def test_no_task_can_have_mismatched_ground_truth(self):
+        """benchmark/tasks.py 里 download_01 / translate_01 / cache_01 就是
+        expected_tools 有一项、expected_tool_args 为 None 的状态——
+        argument_match_score 返回 None，参数这一档被整个踢出加权分母，
+        任务照跑、分照打，只是参数从此不再被检查。这里保证扩充集不会重演。
+        """
+        for t in EXPANDED_TASKS:
+            with self.subTest(task=t["id"]):
+                self.assertIsNotNone(t["expected_tool_args"], t["id"])
+                self.assertEqual(len(t["expected_tools"]), len(t["expected_tool_args"]))
+
+    def test_empty_steps_means_no_tool_call_not_missing_ground_truth(self):
+        """两者必须区分得开：`[]` = 正确行为是不调工具，`None` = 忘了写。"""
+        task = TaskSpec(id="t", task="做不到的事").to_task()
+        self.assertEqual(task["expected_tools"], [])
+        self.assertEqual(task["expected_tool_args"], [])
+
+    def test_args_are_copied_not_shared(self):
+        shared = {"ref": 1}
+        spec = TaskSpec(id="t", task="x", steps=(Step("download_arxiv_pdf", shared),))
+        task = spec.to_task()
+        task["expected_tool_args"][0]["ref"] = 99
+        self.assertEqual(shared["ref"], 1)
+
+    def test_duplicate_ids_rejected(self):
+        with self.assertRaises(ValueError):
+            build([TaskSpec(id="dup", task="a"), TaskSpec(id="dup", task="b")])
+
+
+class FamilyTest(unittest.TestCase):
+    def test_text_and_ground_truth_share_one_param_set(self):
+        """描述里写 7 天、标准答案却写 30 天——这种不一致要在结构上不可能。"""
+        specs = family(
+            task_id=lambda p: f"s_{p['days']}",
+            text=lambda p: f"检索最近{p['days']}天的论文",
+            steps=lambda p: [Step("get_recently_submitted_cs_papers", {"days": p["days"]})],
+            params=[{"days": 7}, {"days": 30}],
+            category="search",
+        )
+        for spec in specs:
+            task = spec.to_task()
+            days = task["expected_tool_args"][0]["days"]
+            self.assertIn(f"最近{days}天", task["task"])
+
+
+class BackwardCompatibilityTest(unittest.TestCase):
+    """原 43 条必须逐字段不变，否则 data/splits/v1.json 的成功率全部作废。"""
+
+    def setUp(self):
+        self.old = {t["id"]: t for t in json.loads(FIXTURE.read_text(encoding="utf-8"))}
+        self.new = {t["id"]: t for t in EXPANDED_TASKS}
+
+    def test_no_original_task_disappeared(self):
+        self.assertEqual(set(self.old) - set(self.new), set())
+
+    def test_every_original_task_is_byte_identical(self):
+        for task_id, old in self.old.items():
+            with self.subTest(task=task_id):
+                self.assertEqual(json.dumps(old, sort_keys=True, ensure_ascii=False),
+                                 json.dumps(self.new[task_id], sort_keys=True, ensure_ascii=False))
+
+    def test_split_file_ids_all_still_exist(self):
+        split_path = Path(__file__).resolve().parents[2] / "data" / "splits" / "v1.json"
+        if not split_path.exists():
+            self.skipTest("没有持久化切分")
+        payload = json.loads(split_path.read_text(encoding="utf-8"))
+        known = set(self.new)
+        for group, ids in payload["split"].items():
+            with self.subTest(group=group):
+                self.assertEqual(set(ids) - known, set(), f"切分 {group} 引用了不存在的任务")
+
+
+class ExpandedSetShapeTest(unittest.TestCase):
+    def test_reaches_the_fifty_task_target(self):
+        """README TODO P1 要求扩充到 50+。"""
+        self.assertGreaterEqual(len(EXPANDED_TASKS), 50)
+
+    def test_ids_unique(self):
+        ids = [t["id"] for t in EXPANDED_TASKS]
+        self.assertEqual(len(ids), len(set(ids)))
+
+    def test_has_infeasible_tasks(self):
+        """整套任务此前只奖励「做对了什么」，从不惩罚「做了不该做的事」。"""
+        infeasible = [t for t in EXPANDED_TASKS if t["category"] == "infeasible"]
+        self.assertGreaterEqual(len(infeasible), 3)
+        for t in infeasible:
+            with self.subTest(task=t["id"]):
+                self.assertEqual(t["expected_tools"], [], "不可行任务的正确行为是不调工具")
+
+    def test_long_chains_declare_enough_iterations(self):
+        """Agent 默认 5 轮 = 4 次工具调用 + FINISH。
+
+        超出预算的链会被判成 FORCE_STOP —— 那是「预算不够」而不是「不会规划」，
+        混在一起会让长链任务的失败率完全没法解读。
+        """
+        for t in EXPANDED_TASKS:
+            needed = len(t["expected_tools"]) + 1        # +1 给 FINISH
+            budget = t.get("max_iterations", 5)
+            with self.subTest(task=t["id"]):
+                self.assertGreaterEqual(
+                    budget, needed,
+                    f"{t['id']} 需要 {needed} 轮，预算只有 {budget}",
+                )
+
+    def test_every_ref_using_task_has_papers_in_session(self):
+        """用序号 / null 指代但既不自己搜、又没有 setup 的任务是无解的。"""
+        for t in EXPANDED_TASKS:
+            if t["category"] == "infeasible":
+                continue      # 无解正是这一类的题意
+            uses_ref = any("ref" in (a or {}) for a in t["expected_tool_args"])
+            self_searches = (t["expected_tools"] or [None])[0] == "get_recently_submitted_cs_papers"
+            with self.subTest(task=t["id"]):
+                if uses_ref and not self_searches:
+                    self.assertIn("setup", t, f"{t['id']} 用了 ref 却没有会话状态")
+
+    def test_setup_provides_enough_papers_for_every_ordinal_ref(self):
+        for t in EXPANDED_TASKS:
+            if "setup" not in t:
+                continue
+            seeded = max((a["args"].get("max_results", 0) for a in t["setup"]
+                          if a["name"] == "get_recently_submitted_cs_papers"), default=0)
+            ordinals = [a["ref"] for a in t["expected_tool_args"]
+                        if isinstance(a.get("ref"), int)]
+            if ordinals:
+                with self.subTest(task=t["id"]):
+                    self.assertLessEqual(max(ordinals), seeded,
+                                         f"{t['id']} 引用第 {max(ordinals)} 篇，setup 只铺了 {seeded} 篇")
+
+
+class InfeasibleScoringTest(unittest.TestCase):
+    """不可行任务必须真的能把「幻觉调用」和「正确拒绝」拉开分差。
+
+    只加任务不够 —— 加之前 `_check_tool_sequence` 在 expected 为空时无条件
+    返回 True，硬调一个不存在的 ref 也算 accurate，outcome 还给满分。
+    """
+
+    def _score(self, task_id, history):
+        from rl.reward import RewardCalculator
+        task = next(t for t in EXPANDED_TASKS if t["id"] == task_id)
+        result = {"history": history, "timing": {}, "token_usage": {},
+                  "iteration_count": len(history)}
+        return RewardCalculator().compute_reward_breakdown(task, result, training_step=100)
+
+    REFUSE = [{"thought": "会话里只有 5 篇，做不到", "action": "FINISH", "observation": "任务完成"}]
+    HALLUCINATE = [
+        {"thought": "下载第20篇", "action": '{"name": "download_arxiv_pdf", "args": {"ref": 20}}',
+         "observation": "工具执行失败: 未找到论文"},
+        {"thought": "", "action": "FINISH", "observation": "任务完成"},
+    ]
+
+    def test_refusing_scores_full_marks(self):
+        breakdown, metrics = self._score("infeasible_index_out_of_range", self.REFUSE)
+        self.assertTrue(metrics.tool_call_accurate)
+        self.assertEqual(breakdown.tool, 1.0)
+
+    def test_hallucinated_call_is_penalised(self):
+        breakdown, metrics = self._score("infeasible_index_out_of_range", self.HALLUCINATE)
+        self.assertFalse(metrics.tool_call_accurate)
+        self.assertEqual(breakdown.tool, -1.0)
+
+    def test_gap_is_wide_enough_to_learn_from(self):
+        """分差太小，GRPO 组内相对优势就区分不出这两种行为。"""
+        good, _ = self._score("infeasible_index_out_of_range", self.REFUSE)
+        bad, _ = self._score("infeasible_index_out_of_range", self.HALLUCINATE)
+        self.assertGreater(good.total - bad.total, 0.5)
+
+    def test_penalty_matches_calling_the_wrong_tool_on_a_normal_task(self):
+        """「本该什么都不做却动了手」不该比「做错了」罚得更轻。"""
+        from rl.reward import RewardCalculator
+        calc = RewardCalculator()
+        self.assertEqual(calc._tool_score(["download_arxiv_pdf"], []), -1.0)
+        self.assertEqual(calc._tool_score(["download_arxiv_pdf"],
+                                          ["get_recently_submitted_cs_papers"]), -1.0)
+
+
+class RunnerHonoursIterationBudgetTest(unittest.TestCase):
+    """任务声明的 max_iterations 必须真的传到 Agent。
+
+    只在任务字典里写上预算是不够的 —— runner 以前无条件用 Agent 的默认 5 轮，
+    5 步链因此必然 FORCE_STOP，看起来像「不会规划」，实际是预算不够。
+    """
+
+    def _runner(self):
+        from benchmark.runner import BenchmarkRunner
+        runner = BenchmarkRunner.__new__(BenchmarkRunner)   # 不走 __init__，免得建 LLM 客户端
+        runner.llm_extra = None
+        runner._llm_client = object()      # ReActAgent 只是存下来，不会调用
+        runner._side_effects = lambda: None
+        runner._tool_env = lambda: None
+        return runner
+
+    def test_budget_reaches_the_agent(self):
+        agent = self._runner()._create_agent("regex", 7)
+        self.assertEqual(agent.max_iterations, 7)
+
+    def test_default_is_left_untouched_when_task_declares_nothing(self):
+        agent = self._runner()._create_agent("regex", None)
+        self.assertEqual(agent.max_iterations, 5)
+
+    def test_task_dict_budget_is_what_gets_passed(self):
+        """端到端：从任务字典取到的值，就是 Agent 拿到的值。"""
+        task = next(t for t in EXPANDED_TASKS
+                    if t["id"] == "chain_cv5_cache_dl_tr_cache")
+        agent = self._runner()._create_agent("regex", task.get("max_iterations"))
+        self.assertEqual(agent.max_iterations, task["max_iterations"])
+        self.assertGreater(agent.max_iterations, len(task["expected_tools"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AgenticArxiv/tests/test_tool_sequence_strict.py
+++ b/AgenticArxiv/tests/test_tool_sequence_strict.py
@@ -39,8 +39,21 @@ class StrictToolSequenceTest(unittest.TestCase):
         actual = ["get_recently_submitted_cs_papers"]
         self.assertFalse(_check_tool_sequence(actual, self.EXPECTED))
 
-    def test_empty_expected_always_ok(self):
-        self.assertTrue(_check_tool_sequence(["anything"], []))
+    def test_empty_expected_means_no_tool_call(self):
+        """expected 为空 = 正确行为是一次工具都不调，不是「没声明标准答案」。
+
+        这条原本断言的是 `_check_tool_sequence(["anything"], []) is True`，
+        当时没有任何任务的 expected_tools 为空，那个返回值只是个安全默认。
+        引入 category="infeasible"（请求超出能力边界或指向不存在的对象）后，
+        空 expected 有了确切含义：无条件返回 True 会让幻觉调用也算「准确」，
+        `_outcome_score` 因 task_completed and tool_call_accurate 给出满分——
+        硬调不存在的第 20 篇反而拿到 outcome=+1.0。
+
+        rl/reward.py 的 `_tool_score` 在同样输入下返回 0.0（既不算对也不算错），
+        与这里的 True 本就不一致；现在两边统一成「调了就是错」。
+        """
+        self.assertTrue(_check_tool_sequence([], []))
+        self.assertFalse(_check_tool_sequence(["anything"], []))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Addresses the README TODO under **P1**:

> **任务集扩充**：`benchmark/tasks.py` 仅 7 个任务，扩充到 50+，并支持自动派生
> `expected_tools` / `expected_tool_args`，奖励才有区分度。

Both halves — the count and the auto-derivation.

## Why auto-derivation matters

Every task used to hand-maintain two parallel copies of the ground truth:

```python
"expected_tools":     ["download_arxiv_pdf"],
"expected_tool_args": [{"ref": 1}],
```

Keeping them aligned was a manual job, and forgetting one **fails silently**:
`argument_match_score` returns `None` when `expected_tool_args` is missing, and
`RewardCalculator` then drops the entire `argument` component out of the
weighted denominator. The task still runs, a score still comes out — arguments
just stop being checked from that point on.

Three tasks in `benchmark/tasks.py` are in exactly that state today:

```
download_01    tools=['download_arxiv_pdf']      args=None
translate_01   tools=['translate_arxiv_pdf']     args=None
cache_01       tools=['get_paper_cache_status']  args=None
```

New module `benchmark/task_spec.py`: a task declares one list of `steps`, and
both ground-truth lists are derived from it, so they cannot drift. `family()`
expands one template plus a set of parameters into a family of tasks, with the
natural-language description and the ground truth rendered from **the same**
parameters — so "the text says 7 days but the answer says 30" is also
structurally impossible.

## The task set

43 → 52, filling two dimensions that had no coverage at all:

| Category | Count | What it probes |
|---|---|---|
| `search` | 12 | Chinese description → `aspect` / `days` / `max_results` |
| `ref_form` | 10 | One paper referred to four ways: ordinal / arXiv id / title fragment / null |
| `composite` | 8 | 2–3 step chains |
| `state` | 8 | Cross-step references such as "the one I just downloaded" |
| `optional` | 5 | `force` / `service` / `threads` / `keep_dual` |
| **`long_chain`** | **5** | **3–5 steps (new)** |
| **`infeasible`** | **4** | **Correct behaviour is to call no tool at all (new)** |

**`infeasible`** is the more important of the two. Until now every task
rewarded *doing the right thing* and nothing penalised *doing something that
should not have been done* — yet hallucinating a call against a nonexistent
object is the single most typical agent failure. These tasks have empty
`steps`: the session holds 5 papers and the request asks for the 20th, the
arXiv id does not exist, the session is empty so "the one from before" has no
referent, or the request is simply outside what these four tools can do.

One of them, `infeasible_no_session`, is a deliberate control for
`ref_ctrl_null_translate`: **identical phrasing**, correct to call a tool when
a session exists and incorrect when it does not.

**`long_chain`** addresses a mismatch with the project's own positioning: 74%
of the original 43 tasks were single-step and only one had 4 steps, in a
project whose stated subject is long-horizon tool use.

## Two scoring bugs this surfaced

Introducing empty `expected_tools` exposed a pre-existing disagreement between
the benchmark and reward sides:

- `metrics._check_tool_sequence` returned `True` unconditionally when
  `expected` was empty, so a hallucinated call counted as *accurate*, and
  `_outcome_score` — which keys off `task_completed and tool_call_accurate` —
  awarded full marks. Calling a nonexistent 20th paper scored `outcome=+1.0`.
- `reward._tool_score` returned `0.0` for the same input: neither right nor
  wrong.

Both now treat it as wrong, with the penalty aligned to calling the wrong tool
(`-1.0`) — "acting when the right move was to do nothing" should not be
punished more leniently than "acting incorrectly".

Measured on the same hallucinated trajectory:

| | total | tool | outcome | accurate |
|---|---|---|---|---|
| Correctly refuses | +1.000 | +1.00 | +1.00 | True |
| Hallucinated call — before | +0.665 | +0.00 | **+1.00** | **True** |
| Hallucinated call — after | **+0.440** | **−1.00** | +0.25 | **False** |

The gap widens from 0.335 to 0.56.

## Iteration budget

The agent's `max_iterations` defaults to 5 — at most 4 tool calls plus one
`FINISH` — and the runner never overrode it. A 5-step chain would therefore
always end in `FORCE_STOP`, which reads as "cannot plan" when the real cause is
"ran out of budget"; mixing the two makes the failure rate of long-chain tasks
uninterpretable. Tasks may now declare `max_iterations` and the runner passes
it through.

## Compatibility

All 43 original tasks are preserved field-for-field, pinned by
`tests/fixtures_expanded_v1.json`. This matters: the success rates in
`data/splits/v1.json` come from roughly 1600 runs, and any change to a task's
text or ground truth invalidates all of them.

## Measured difficulty of the new tasks

Qwen2.5-1.5B-Instruct + regex agent, 8 trials each, offline snapshot replay.
Three previously-measured anchor tasks were included in the same run to confirm
comparability (two reproduced exactly; the third differed by a single trial,
1/8 vs 2/8).

All nine new tasks land in the **floor** band (≤12.5%):

- `infeasible`: **0/32 runs called no tool.** The model never refuses. Adding
  an explicit "if you cannot do this, say so and finish without calling
  anything" clause to the prompt and re-running all 32 changed nothing — still
  0.000 across all four. Trajectories show it terminating cleanly, just after
  having called tools first, so this is not a parsing artifact.
- `long_chain`: 60% hit the iteration cap, averaging 7823 tokens per run.

They are therefore **evaluation** tasks, not RL training tasks: a floor-band
task produces zero within-group reward variance and no gradient, exactly like a
ceiling-band one. Their value is that they make two previously invisible
failure modes measurable.

## Tests

`tests/test_task_spec.py`, 22 cases:

- **Derivation** — the two ground-truth lists come from one `steps` list; no
  task can have mismatched lengths; `[]` (call nothing) is distinguishable from
  `None` (ground truth not declared)
- **Backward compatibility** — every one of the original 43 is byte-identical,
  and every id referenced by `data/splits/v1.json` still exists
- **Shape** — ≥50 tasks; every `infeasible` task has empty `expected_tools`;
  every task's declared budget covers its own chain length; every task using a
  ref either searches first or has `setup`; every `setup` seeds enough papers
  for the ordinals the task references
- **Runner plumbing** — a declared `max_iterations` actually reaches the agent,
  and the default is left alone when a task declares nothing

`tests/test_tool_sequence_strict.py` has one test rewritten rather than
silently changed: it previously asserted `_check_tool_sequence(["anything"],
[]) is True`, which was a safe default back when no task had empty
`expected_tools`. The docstring records why the semantics changed.

Full suite (`python -m unittest discover -s tests`): **185 passed, 1 skipped**
(the skip is the `data/splits/v1.json` cross-check, which is not part of this
PR).
