### PR TITLE
fix(sft): supervise only assistant action tokens

### DIFF
--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -123,6 +123,7 @@ def main(
         gradient_accumulation_steps=grad_accum,
         learning_rate=lr,
         max_length=max_length,    # TRL>=0.20 用 max_length（旧名 max_seq_length 已移除）
+        assistant_only_loss=True, # 新增修改
         max_steps=max_steps,
         logging_steps=10,
         save_steps=100,

--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -42,6 +42,22 @@ def _messages_of(row):
     return list(row.get("prompt") or []) + list(row.get("completion") or [])
 
 
+def _to_prompt_completion(row):
+    """把单轮 messages 样本转换成 TRL 的 prompt-completion 格式。
+
+    项目的 assistant message 只包含 Action。显式拆分 prompt/completion 后，
+    ``completion_only_loss=True`` 可以在不依赖模型 chat template 是否提供
+    assistant mask 的情况下，仅监督 Action。
+    """
+    messages = list(row["messages"])
+    if not messages or messages[-1].get("role") != "assistant":
+        raise ValueError("SFT 样本必须以 assistant message 结尾")
+    return {
+        "prompt": messages[:-1],
+        "completion": messages[-1:],
+    }
+
+
 def _token_length(tokenizer, messages) -> int:
     # 先渲染成字符串再计数：apply_chat_template(tokenize=True) 在 transformers 5.x
     # 返回 BatchEncoding，len() 数到的是字段数而不是 token 数。
@@ -111,6 +127,12 @@ def main(
         )
 
     train_dataset = load_dataset("json", data_files=str(train_data_path), split="train")
+    if "messages" in train_dataset.column_names:
+        train_dataset = train_dataset.map(
+            _to_prompt_completion,
+            remove_columns=["messages"],
+            desc="Converting SFT data to prompt-completion format",
+        )
     print(f"   样本数: {len(train_dataset)}")
 
     # --- 长度守卫 ---
@@ -123,7 +145,7 @@ def main(
         gradient_accumulation_steps=grad_accum,
         learning_rate=lr,
         max_length=max_length,    # TRL>=0.20 用 max_length（旧名 max_seq_length 已移除）
-        assistant_only_loss=True, # 新增修改
+        completion_only_loss=True,  # prompt 不计 loss，只监督 assistant Action
         max_steps=max_steps,
         logging_steps=10,
         save_steps=100,

--- a/AgenticArxiv/tests/test_training_guards.py
+++ b/AgenticArxiv/tests/test_training_guards.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 
 from rl.precision import precision_flags
 from rl.train_grpo import RewardVarianceGuard
-from rl.train_sft import _check_lengths, _messages_of
+from rl.train_sft import _check_lengths, _messages_of, _to_prompt_completion
 
 
 class _FakeTokenizer:
@@ -37,6 +37,27 @@ class MessagesOfTest(unittest.TestCase):
     def test_messages_format(self):
         row = {"messages": [{"role": "user", "content": "x"}]}
         self.assertEqual(_messages_of(row), row["messages"])
+
+
+class PromptCompletionConversionTest(unittest.TestCase):
+    def test_splits_last_assistant_message_from_prompt(self):
+        row = {
+            "messages": [
+                {"role": "system", "content": "system"},
+                {"role": "user", "content": "task"},
+                {"role": "assistant", "content": '{"tool": "search"}'},
+            ]
+        }
+
+        converted = _to_prompt_completion(row)
+
+        self.assertEqual([m["role"] for m in converted["prompt"]], ["system", "user"])
+        self.assertEqual(converted["completion"], [row["messages"][-1]])
+
+    def test_rejects_sample_without_final_assistant_message(self):
+        row = {"messages": [{"role": "user", "content": "task"}]}
+        with self.assertRaisesRegex(ValueError, "assistant"):
+            _to_prompt_completion(row)
 
 
 class CheckLengthsTest(unittest.TestCase):


### PR DESCRIPTION
## 改动概述

- 在 SFT 训练前，将 conversational `messages` 样本转换为 TRL 的 prompt-completion 格式。
- 显式启用 `completion_only_loss=True`，屏蔽 system 和 user token，只对 assistant 中的 Action 计算损失。
- 校验每条待转换样本必须以 assistant message 结尾，并补充对应单元测试。

## 背景与原因

当前 SFT 样本中的 system prompt 和 user task 是模型生成 Action 时的条件上下文，真正需要学习的目标是 assistant 输出的 Action。如果不设置 assistant-only loss，TRL 会对 chat template 渲染后的整个序列计算语言模型损失，system、user 和 assistant token 都会产生梯度。这不仅会把一部分训练预算用于记忆固定的 system prompt 和复述用户任务，还会削弱模型对“根据上下文生成正确 Action”这一核心目标的关注。因此需要只监督 assistant token：system 和 user token 仍作为输入上下文，但不参与 loss 计算。

从训练语义上看，这正是设置 `assistant_only_loss=True` 的目的。不过，该参数依赖 chat template 通过 `{% generation %}` 标记生成 assistant token mask。项目当前验证使用的 TRL 0.29.1 配合默认 Qwen2.5 chat template 时，该模板不包含这些标记，因此直接增加 `assistant_only_loss=True` 可能因无法得到 assistant mask 而失败。

本次改为 prompt-completion masking：system 和 user message 组成 `prompt`，只包含 Action 的 assistant message 组成 `completion`，再设置 `completion_only_loss=True`。它与 assistant-only loss 的训练目标等价，同时不依赖具体模型模板是否支持 generation mask。

## 验证情况

- 已从 GitHub 重新拉取分支，确认远端文件与本地验证版本一致。
- 远端 `train_sft.py` 和 `test_training_guards.py` 均通过 Python 语法编译检查。
- 已独立验证正常拆分样本和拒绝非 assistant 结尾样本两条逻辑。
- 当前系统 Python 未安装项目的 `datasets` 依赖，因此未在本机运行完整单元测试套件。