### PR TITLE
 q qfeat(benchmark): add negative-constraint arXiv cases

### DIFF
--- a/AgenticArxiv/benchmark/run_benchmark.py
+++ b/AgenticArxiv/benchmark/run_benchmark.py
@@ -43,8 +43,9 @@ def main():
     parser.add_argument(
         "--tasks", type=str, default=None,
         choices=["search", "download", "translate", "cache", "composite",
-                 "ref_form", "optional", "state", "long_chain", "infeasible"],
-        help="按类别筛选测试任务。后五个类别只存在于 --task-set expanded",
+                 "ref_form", "optional", "state", "long_chain", "constraint",
+                 "infeasible"],
+        help="按类别筛选测试任务。扩展类别只存在于 --task-set expanded",
     )
     parser.add_argument(
         "--task-ids", nargs="+", default=None,
@@ -78,8 +79,8 @@ def main():
     parser.add_argument("--snapshot", default=None, help="指定快照路径（默认 data/mock_arxiv_snapshot.json）")
     parser.add_argument(
         "--task-set", choices=["default", "expanded"], default="default",
-        help="default=benchmark/tasks.py 的 8 条；expanded=扩充后的 52 条"
-             "（指代形态、可选参数、跨步状态、多跳链路、不可行请求）",
+        help="default=benchmark/tasks.py 的 8 条；expanded=扩充后的 58 条"
+             "（指代形态、可选参数、跨步状态、多跳链路、负向约束、不可行请求）",
     )
     args = parser.parse_args()
 

--- a/AgenticArxiv/benchmark/tasks_expanded.py
+++ b/AgenticArxiv/benchmark/tasks_expanded.py
@@ -6,6 +6,7 @@
   - **可选参数**（optional）：force / service / threads / keep_dual
   - **跨步状态**（state）：「刚下载的那篇」这类必须靠会话状态才能解析的指代
   - **多跳链路**（composite / long_chain）：2~5 步的工具链
+  - **负向约束**（constraint）：完成指定操作，同时抑制下载、翻译等多余调用
   - **不可行请求**（infeasible）：正确行为是**不调用任何工具**
 
 `expected_tools` 与 `expected_tool_args` 都从 `steps` 派生（见
@@ -468,6 +469,88 @@ _OTHERS: List[TaskSpec] = [
 
 
 # ============================================================================
+# 负向约束：完成可行任务，但不要执行用户明确排除的操作
+# ============================================================================
+# infeasible 覆盖的是「一次工具都不该调」；这一组覆盖更常见、也更难判定的情况：
+# 任务本身需要调用工具，但模型必须在完成目标后及时停止，不能因为“看起来有帮助”
+# 就继续下载、翻译或查缓存。严格工具序列评分会把任何多余调用判错。
+#
+# constraint_search_no_file 还覆盖搜索工具中此前未测试的副作用开关：
+# save_to_file 默认是 True，用户明确要求不落盘时必须传 False。
+_CONSTRAINTS: List[TaskSpec] = [
+    TaskSpec(
+        id='constraint_search_no_file',
+        task='检索最近7天所有计算机科学方向的新论文，最多5篇；只返回结果，不要保存到文件，也不要下载论文',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {
+                'aspect': '*', 'days': 7, 'max_results': 5, 'save_to_file': False,
+            }),
+        ),
+        category='constraint',
+        difficulty='hard',
+        note='覆盖 aspect=* 与 save_to_file=False；额外下载也会被严格序列评分判错',
+    ),
+    TaskSpec(
+        id='constraint_search_only',
+        task='搜索最近3天机器人学(cs.RO)论文，最多3篇；只列出检索结果，不要下载或翻译',
+        steps=(
+            Step('get_recently_submitted_cs_papers', {
+                'aspect': 'RO', 'days': 3, 'max_results': 3,
+            }),
+        ),
+        category='constraint',
+        difficulty='medium',
+    ),
+    TaskSpec(
+        id='constraint_cache_only',
+        task='只查看第2篇论文的缓存状态，不要下载，也不要翻译',
+        steps=(
+            Step('get_paper_cache_status', {'ref': 2}),
+        ),
+        category='constraint',
+        difficulty='hard',
+        setup=_SEED_AI5,
+    ),
+    TaskSpec(
+        id='constraint_download_only',
+        task='只下载第1篇论文，不要翻译，也不要额外检查缓存状态',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 1}),
+        ),
+        category='constraint',
+        difficulty='hard',
+        setup=_SEED_AI5,
+    ),
+    TaskSpec(
+        id='constraint_translate_only',
+        task='只把刚下载的那篇论文翻译成双语版本，不要重新搜索，也不要检查缓存状态',
+        steps=(
+            Step('translate_arxiv_pdf', {'ref': None, 'keep_dual': True}),
+        ),
+        category='constraint',
+        difficulty='hard',
+        setup=(
+            Step('get_recently_submitted_cs_papers', {
+                'aspect': 'AI', 'days': 7, 'max_results': 5,
+            }),
+            Step('download_arxiv_pdf', {'ref': 1}),
+        ),
+    ),
+    TaskSpec(
+        id='constraint_two_downloads_only',
+        task='下载第1篇和第3篇论文；除此之外不要检查缓存或翻译',
+        steps=(
+            Step('download_arxiv_pdf', {'ref': 1}),
+            Step('download_arxiv_pdf', {'ref': 3}),
+        ),
+        category='constraint',
+        difficulty='hard',
+        setup=_SEED_AI5,
+    ),
+]
+
+
+# ============================================================================
 # 不可行请求：正确行为是**不调用任何工具**
 # ============================================================================
 # 现有任务全都在奖励「做对了什么」，没有一条惩罚「做了不该做的事」。
@@ -591,7 +674,9 @@ _LONG_CHAIN: List[TaskSpec] = [
 ]
 
 
-EXPANDED_TASKS: List[Dict[str, Any]] = build(_SEARCH + _OTHERS + _INFEASIBLE + _LONG_CHAIN)
+EXPANDED_TASKS: List[Dict[str, Any]] = build(
+    _SEARCH + _OTHERS + _CONSTRAINTS + _INFEASIBLE + _LONG_CHAIN
+)
 
 
 def get_expanded_tasks() -> List[Dict[str, Any]]:

--- a/AgenticArxiv/tests/test_constraint_tasks.py
+++ b/AgenticArxiv/tests/test_constraint_tasks.py
@@ -1,0 +1,71 @@
+"""负向约束 benchmark case 的回归测试。"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmark.metrics import _check_tool_sequence, argument_match_score  # noqa: E402
+from benchmark.tasks_expanded import EXPANDED_TASKS  # noqa: E402
+
+
+class ConstraintTaskTest(unittest.TestCase):
+    def setUp(self):
+        self.tasks = {
+            task["id"]: task
+            for task in EXPANDED_TASKS
+            if task["category"] == "constraint"
+        }
+
+    def test_six_constraint_cases_are_registered(self):
+        self.assertEqual(len(self.tasks), 6)
+
+    def test_cases_do_not_expand_the_tool_space(self):
+        existing_tools = {
+            "get_recently_submitted_cs_papers",
+            "download_arxiv_pdf",
+            "translate_arxiv_pdf",
+            "get_paper_cache_status",
+        }
+        used_tools = {
+            name
+            for task in self.tasks.values()
+            for name in task["expected_tools"]
+        }
+        self.assertLessEqual(used_tools, existing_tools)
+
+    def test_no_file_case_declares_the_side_effect_switch(self):
+        task = self.tasks["constraint_search_no_file"]
+        self.assertEqual(task["expected_tool_args"], [{
+            "aspect": "*",
+            "days": 7,
+            "max_results": 5,
+            "save_to_file": False,
+        }])
+
+        history = [{
+            "action": {
+                "name": "get_recently_submitted_cs_papers",
+                "args": task["expected_tool_args"][0],
+            }
+        }]
+        self.assertEqual(argument_match_score(history, task["expected_tool_args"]), 1.0)
+
+    def test_extra_helpful_call_is_rejected(self):
+        task = self.tasks["constraint_download_only"]
+        expected = task["expected_tools"]
+
+        self.assertTrue(_check_tool_sequence(["download_arxiv_pdf"], expected))
+        self.assertFalse(_check_tool_sequence([
+            "get_paper_cache_status",
+            "download_arxiv_pdf",
+        ], expected))
+        self.assertFalse(_check_tool_sequence([
+            "download_arxiv_pdf",
+            "translate_arxiv_pdf",
+        ], expected))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

感谢维护者之前对工具扩展 PR 的反馈。本次调整不再引入 GitHub/Gitee 等新任务域，也不增加任何工具，而是在现有 arXiv action space 内补充 benchmark 场景。

现有 expanded benchmark 主要覆盖“应该调用什么工具”，但对“完成任务的同时，不执行用户明确排除的操作”覆盖较少。本 PR 因此增加了一组负向约束任务，用于评估 Agent 是否会产生多余下载、翻译、缓存检查等调用。

## 改动内容

新增 6 条 `constraint` 类 arXiv benchmark case，覆盖：

- 只检索，不下载或翻译
- 只返回搜索结果，不写入文件
- 只检查缓存，不下载或翻译
- 只下载，不翻译或额外检查缓存
- 只翻译当前论文，不重新检索
- 下载指定的两篇论文，不执行其他操作
- `aspect="*"` 全计算机科学类别检索
- `save_to_file=False` 搜索副作用控制

同时：

- expanded benchmark 从 52 条增加到 58 条
- CLI 支持通过 `--tasks constraint` 单独运行该类别
- 增加回归测试，验证新增任务没有扩大现有工具空间
- 验证严格工具序列评分能够拒绝额外的“帮助性”调用

## Scope

本 PR 不包含：

- 新工具
- 新任务域
- 工具实现修改
- 环境或 MDP action space 修改
- 训练流程修改
- 原 GitHub/Gitee 仓库工具相关代码

新增任务仍只使用以下现有工具：

- `get_recently_submitted_cs_papers`
- `download_arxiv_pdf`
- `translate_arxiv_pdf`
- `get_paper_cache_status`

## Tests

```bash
python -m unittest \
  tests.test_constraint_tasks \
  tests.test_task_spec \
  tests.test_tool_sequence_strict