### PR TITLE
feat(benchmark): add deterministic degenerate policy baselines

### DIFF
--- a/AgenticArxiv/benchmark/baselines.py
+++ b/AgenticArxiv/benchmark/baselines.py
@@ -1,0 +1,423 @@
+"""Deterministic policies for checking benchmark-score sensitivity.
+
+These policies never call tools. They construct valid ReAct trajectories and
+score them with the same ``RewardCalculator`` used by rollout and training.
+The result is a reproducible diagnostic: if a deliberately weak policy scores
+near the reference trajectory, the task set or reward needs investigation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+import json
+from statistics import mean, pstdev
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+from rl.reward import RewardCalculator
+
+
+_SEARCH_ACTION = (
+    "get_recently_submitted_cs_papers",
+    {"aspect": "AI", "days": 7, "max_results": 5},
+)
+_TOOL_ACTIONS = (
+    _SEARCH_ACTION,
+    ("download_arxiv_pdf", {"ref": 1}),
+    ("translate_arxiv_pdf", {"ref": 1}),
+    ("get_paper_cache_status", {"ref": 1}),
+)
+
+
+def _tool_step(name: str, args: Mapping[str, Any]) -> Dict[str, str]:
+    action = json.dumps({"name": name, "args": dict(args)}, ensure_ascii=False)
+    return {"action": action, "observation": "synthetic baseline action"}
+
+
+def _finish_step() -> Dict[str, str]:
+    return {"action": "FINISH", "observation": "synthetic baseline finish"}
+
+
+def _result(history: List[Dict[str, str]]) -> Dict[str, Any]:
+    return {
+        "history": history,
+        "timing": {},
+        "token_usage": {},
+        "iteration_count": len(history),
+    }
+
+
+class BaselinePolicy:
+    """A deterministic policy that returns a synthetic ReAct trajectory."""
+
+    name = "baseline"
+
+    def build_result(self, task: Mapping[str, Any], seed: int) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+class ReferencePolicy(BaselinePolicy):
+    """Replay each task declaration's reference tool path as a score ceiling."""
+
+    name = "reference"
+
+    def build_result(self, task: Mapping[str, Any], seed: int) -> Dict[str, Any]:
+        expected_tools = task.get("expected_tools", [])
+        expected_args = task.get("expected_tool_args") or []
+        history = []
+        for index, name in enumerate(expected_tools):
+            args = expected_args[index] if index < len(expected_args) else {}
+            history.append(_tool_step(name, args or {}))
+        history.append(_finish_step())
+        return _result(history)
+
+
+class AlwaysFinishPolicy(BaselinePolicy):
+    """Terminate immediately, regardless of the task request."""
+
+    name = "always_finish"
+
+    def build_result(self, task: Mapping[str, Any], seed: int) -> Dict[str, Any]:
+        return _result([_finish_step()])
+
+
+class AlwaysSearchPolicy(BaselinePolicy):
+    """Make the same valid search call for every task, then terminate."""
+
+    name = "always_search"
+
+    def build_result(self, task: Mapping[str, Any], seed: int) -> Dict[str, Any]:
+        name, args = _SEARCH_ACTION
+        return _result([_tool_step(name, args), _finish_step()])
+
+
+class RandomToolPolicy(BaselinePolicy):
+    """Choose one valid tool call per task from a seed-stable pseudo-random draw."""
+
+    name = "random_tool"
+
+    def build_result(self, task: Mapping[str, Any], seed: int) -> Dict[str, Any]:
+        task_id = str(task.get("id", ""))
+        digest = sha256(f"{seed}:{task_id}".encode("utf-8")).digest()
+        name, args = _TOOL_ACTIONS[int.from_bytes(digest[:8], "big") % len(_TOOL_ACTIONS)]
+        return _result([_tool_step(name, args), _finish_step()])
+
+
+ALL_POLICIES: Dict[str, BaselinePolicy] = {
+    policy.name: policy
+    for policy in (
+        ReferencePolicy(),
+        AlwaysFinishPolicy(),
+        AlwaysSearchPolicy(),
+        RandomToolPolicy(),
+    )
+}
+
+
+@dataclass(frozen=True)
+class BaselineResult:
+    """One policy/task score, kept JSON-friendly for reports and CI artifacts."""
+
+    policy: str
+    task_id: str
+    category: str
+    sample_seed: int
+    reward: float
+    finished: bool
+    exact_tool_path: bool
+    exact_reference: bool
+    arg_score: Optional[float]
+    components: Dict[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "policy": self.policy,
+            "task_id": self.task_id,
+            "category": self.category,
+            "sample_seed": self.sample_seed,
+            "reward": self.reward,
+            "finished": self.finished,
+            "exact_tool_path": self.exact_tool_path,
+            "exact_reference": self.exact_reference,
+            "arg_score": self.arg_score,
+            "components": self.components,
+        }
+
+
+@dataclass(frozen=True)
+class PolicySummary:
+    """Aggregate score-sensitivity indicators for one baseline policy."""
+
+    policy: str
+    task_count: int
+    sample_count: int
+    mean_reward: float
+    reward_std: float
+    min_reward: float
+    max_reward: float
+    finish_rate: float
+    exact_tool_path_rate: float
+    mean_arg_score: Optional[float]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "policy": self.policy,
+            "task_count": self.task_count,
+            "sample_count": self.sample_count,
+            "mean_reward": self.mean_reward,
+            "reward_std": self.reward_std,
+            "min_reward": self.min_reward,
+            "max_reward": self.max_reward,
+            "finish_rate": self.finish_rate,
+            "exact_tool_path_rate": self.exact_tool_path_rate,
+            "mean_arg_score": self.mean_arg_score,
+        }
+
+
+@dataclass(frozen=True)
+class TaskScoreSummary:
+    """Per-task aggregate used to surface suspiciously strong weak policies."""
+
+    policy: str
+    task_id: str
+    category: str
+    sample_count: int
+    mean_reward: float
+    max_reward: float
+    exact_tool_path_rate: float
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "policy": self.policy,
+            "task_id": self.task_id,
+            "category": self.category,
+            "sample_count": self.sample_count,
+            "mean_reward": self.mean_reward,
+            "max_reward": self.max_reward,
+            "exact_tool_path_rate": self.exact_tool_path_rate,
+        }
+
+
+def resolve_policies(names: Iterable[str]) -> List[BaselinePolicy]:
+    """Resolve policy names and fail early on typos in a CLI invocation."""
+
+    selected = []
+    for name in names:
+        try:
+            selected.append(ALL_POLICIES[name])
+        except KeyError as exc:
+            choices = ", ".join(ALL_POLICIES)
+            raise ValueError(f"Unknown baseline policy {name!r}; choose from: {choices}") from exc
+    return selected
+
+
+def evaluate_baselines(
+    tasks: Sequence[Mapping[str, Any]],
+    policies: Iterable[BaselinePolicy],
+    *,
+    seed: int = 42,
+    random_samples: int = 20,
+    training_step: int = 100,
+) -> List[BaselineResult]:
+    """Score every policy/task pair without an LLM, network call, or tool execution."""
+
+    if random_samples < 1:
+        raise ValueError("random_samples must be at least 1")
+
+    calculator = RewardCalculator()
+    results = []
+    for policy in policies:
+        sample_seeds = (
+            range(seed, seed + random_samples)
+            if isinstance(policy, RandomToolPolicy)
+            else (seed,)
+        )
+        for sample_seed in sample_seeds:
+            for task in tasks:
+                breakdown, metrics = calculator.compute_reward_breakdown(
+                    dict(task),
+                    policy.build_result(task, sample_seed),
+                    agent_type=f"baseline:{policy.name}",
+                    training_step=training_step,
+                )
+                expected_args = task.get("expected_tool_args")
+                arg_score = metrics.arg_score if expected_args else None
+                results.append(BaselineResult(
+                    policy=policy.name,
+                    task_id=str(task["id"]),
+                    category=str(task.get("category", "uncategorized")),
+                    sample_seed=sample_seed,
+                    reward=breakdown.total,
+                    finished=metrics.task_completed,
+                    exact_tool_path=metrics.tool_call_accurate,
+                    exact_reference=(
+                        metrics.tool_call_accurate
+                        and (arg_score is None or arg_score == 1.0)
+                    ),
+                    arg_score=arg_score,
+                    components=breakdown.to_dict(),
+                ))
+    return results
+
+
+def summarize_baselines(results: Sequence[BaselineResult]) -> List[PolicySummary]:
+    """Summarize score separation while keeping FINISH distinct from success."""
+
+    by_policy: Dict[str, List[BaselineResult]] = {}
+    for result in results:
+        by_policy.setdefault(result.policy, []).append(result)
+
+    summaries = []
+    for policy, rows in by_policy.items():
+        if not rows:
+            continue
+        arg_scores = [row.arg_score for row in rows if row.arg_score is not None]
+        summaries.append(PolicySummary(
+            policy=policy,
+            task_count=len({row.task_id for row in rows}),
+            sample_count=len(rows),
+            mean_reward=round(mean(row.reward for row in rows), 6),
+            reward_std=round(pstdev(row.reward for row in rows), 6),
+            min_reward=round(min(row.reward for row in rows), 6),
+            max_reward=round(max(row.reward for row in rows), 6),
+            finish_rate=round(mean(row.finished for row in rows), 6),
+            exact_tool_path_rate=round(mean(row.exact_tool_path for row in rows), 6),
+            mean_arg_score=round(mean(arg_scores), 6) if arg_scores else None,
+        ))
+    return summaries
+
+
+def highest_scoring_tasks(
+    results: Sequence[BaselineResult], limit_per_policy: int = 5
+) -> List[TaskScoreSummary]:
+    """Return high-scoring tasks whose trajectories do not match the reference."""
+
+    if limit_per_policy < 1:
+        raise ValueError("limit_per_policy must be at least 1")
+
+    grouped: Dict[tuple, List[BaselineResult]] = {}
+    for result in results:
+        if result.policy == "reference" or result.exact_reference:
+            continue
+        key = (result.policy, result.task_id, result.category)
+        grouped.setdefault(key, []).append(result)
+
+    by_policy: Dict[str, List[TaskScoreSummary]] = {}
+    for (policy, task_id, category), rows in grouped.items():
+        by_policy.setdefault(policy, []).append(TaskScoreSummary(
+            policy=policy,
+            task_id=task_id,
+            category=category,
+            sample_count=len(rows),
+            mean_reward=round(mean(row.reward for row in rows), 6),
+            max_reward=round(max(row.reward for row in rows), 6),
+            exact_tool_path_rate=round(mean(row.exact_tool_path for row in rows), 6),
+        ))
+
+    top = []
+    for rows in by_policy.values():
+        rows.sort(key=lambda row: (-row.mean_reward, row.task_id))
+        top.extend(rows[:limit_per_policy])
+    return top
+
+
+def reference_gap_failures(
+    summaries: Sequence[PolicySummary], min_gap: float = 0.3
+) -> List[str]:
+    """Return health-check failures when weak policies approach the reference."""
+
+    if min_gap < 0:
+        raise ValueError("min_gap must be non-negative")
+    by_policy = {summary.policy: summary for summary in summaries}
+    reference = by_policy.get("reference")
+    if reference is None:
+        return ["reference policy is required for the reward-gap health check"]
+
+    failures = []
+    for policy, summary in by_policy.items():
+        if policy == "reference":
+            continue
+        gap = reference.mean_reward - summary.mean_reward
+        if gap < min_gap:
+            failures.append(
+                f"{policy}: reference gap {gap:.3f} is below required {min_gap:.3f}"
+            )
+    return failures
+
+
+def render_markdown(
+    summaries: Sequence[PolicySummary],
+    *,
+    task_set: str,
+    seed: int,
+    training_step: int,
+    top_tasks: Sequence[TaskScoreSummary] = (),
+    min_reference_gap: Optional[float] = None,
+    health_failures: Sequence[str] = (),
+) -> str:
+    """Render a small report suitable for terminal output and saved artifacts."""
+
+    lines = [
+        "# Benchmark Degenerate-policy Baselines",
+        "",
+        f"Task set: `{task_set}` | seed: `{seed}` | training step: `{training_step}`",
+        "",
+        "These synthetic policies never execute tools. `finish_rate` only means the "
+        "trajectory ended in `FINISH`; it is intentionally reported separately from "
+        "tool-path accuracy and reward.",
+        "",
+        "| Policy | Tasks | Samples | Mean reward | Reward std | Reward range | Finish rate | Exact tool path | Mean arg score |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for summary in summaries:
+        arg_score = (
+            f"{summary.mean_arg_score:.3f}"
+            if summary.mean_arg_score is not None
+            else "N/A"
+        )
+        lines.append(
+            "| {policy} | {tasks} | {samples} | {mean:.3f} | {std:.3f} | "
+            "[{low:.3f}, {high:.3f}] | {finish:.1%} | {path:.1%} | {args} |".format(
+                policy=summary.policy,
+                tasks=summary.task_count,
+                samples=summary.sample_count,
+                mean=summary.mean_reward,
+                std=summary.reward_std,
+                low=summary.min_reward,
+                high=summary.max_reward,
+                finish=summary.finish_rate,
+                path=summary.exact_tool_path_rate,
+                args=arg_score,
+            )
+        )
+
+    if min_reference_gap is not None:
+        status = "FAIL" if health_failures else "PASS"
+        lines.extend([
+            "",
+            f"Health check: **{status}** (minimum reference gap: `{min_reference_gap:.3f}`)",
+        ])
+        lines.extend(f"- {failure}" for failure in health_failures)
+
+    if top_tasks:
+        lines.extend([
+            "",
+            "## Highest-scoring non-reference trajectories",
+            "",
+            "| Policy | Task | Category | Samples | Mean reward | Max reward | Exact tool path |",
+            "|---|---|---|---:|---:|---:|---:|",
+        ])
+        for task in top_tasks:
+            lines.append(
+                "| {policy} | {task_id} | {category} | {samples} | {mean:.3f} | "
+                "{maximum:.3f} | {path:.1%} |".format(
+                    policy=task.policy,
+                    task_id=task.task_id,
+                    category=task.category,
+                    samples=task.sample_count,
+                    mean=task.mean_reward,
+                    maximum=task.max_reward,
+                    path=task.exact_tool_path_rate,
+                )
+            )
+    return "\n".join(lines) + "\n"

--- a/AgenticArxiv/benchmark/readme.md
+++ b/AgenticArxiv/benchmark/readme.md
@@ -32,7 +32,32 @@ python -m benchmark.run_benchmark --output /path/to/output
 python -m benchmark.run_benchmark --prefix bench_r1
 ```
 
-默认 7 个任务 x 3 种 Agent x 3 次重复 = 63 次运行。
+默认 8 个任务 x 3 种 Agent x 3 次重复 = 72 次运行。
+
+## 退化策略基线
+
+```bash
+cd AgenticArXiv
+
+# 不调用 LLM、网络或真实工具；用扩展任务集检查评分器能否区分弱策略
+python -m benchmark.run_baselines --task-set expanded
+
+# 保存逐任务 JSON 和 Markdown 报告；random_tool 默认从 seed 起采样 20 次
+python -m benchmark.run_baselines --task-set expanded --seed 42 --random-samples 20 --output /tmp/agentic-arxiv-baselines
+```
+
+该命令会并排评分四种确定性策略：
+
+| 策略 | 用途 |
+|---|---|
+| `reference` | 回放任务声明的标准工具路径，作为评分上限 |
+| `always_finish` | 立即终止，检查“正常 FINISH”会不会被误读为完成 |
+| `always_search` | 无视任务、固定调用一次搜索 |
+| `random_tool` | 对每条任务以固定 seed 选择一次合法工具调用 |
+
+报告单独显示 `finish_rate` 与 `exact_tool_path_rate`：前者只表示轨迹以 `FINISH` 结束，不是业务任务已完成。`random_tool` 汇总多个 seed 并报告标准差；没有参数标准答案的任务不参与平均参数分。报告还会列出每种退化策略中未完整匹配参考工具和参数、但仍获得高分的任务，便于直接定位奖励漏洞。
+
+默认健康门槛要求每种退化策略的平均奖励比 `reference` 至少低 `0.3`；不满足时命令返回非零状态，可直接接入 CI。可用 `--min-reference-gap` 调整门槛，或用 `--top` 调整每种策略展示的高分任务数。
 
 ## 绘图
 
@@ -80,6 +105,7 @@ draw/images/
 | search_01 | search | 检索 cs.AI 论文 | get_recently_submitted_cs_papers |
 | search_02 | search | 检索 cs.LG 论文 | get_recently_submitted_cs_papers |
 | search_03 | search | 检索 cs.CL 论文 | get_recently_submitted_cs_papers |
+| search_04 | search | 检索全部计算机科学论文 | get_recently_submitted_cs_papers |
 | download_01 | download | 下载第 1 篇论文 PDF | download_arxiv_pdf |
 | translate_01 | translate | 翻译第 1 篇论文 | translate_arxiv_pdf |
 | cache_01 | cache | 查看缓存状态 | get_paper_cache_status |
@@ -104,9 +130,9 @@ draw/images/
 
 | 指标 | 说明 |
 |---|---|
-| task_completed | 任务是否正常完成 (FINISH) |
+| task_completed | 轨迹是否以 `FINISH` 正常结束；不验证业务终态 |
 | termination_type | 终止类型: FINISH / FORCE_STOP / ERROR / INCOMPLETE |
-| tool_call_accurate | 实际工具调用是否包含全部预期工具（顺序子序列匹配） |
+| tool_call_accurate | 实际工具调用是否与预期工具序列完全相等（顺序严格、无多余/重复调用） |
 | parse_failures | LLM 响应解析失败次数 |
 | tool_exec_failures | 工具执行失败次数 |
 
@@ -118,6 +144,8 @@ benchmark/
   tasks.py           # 测试任务定义 (BENCHMARK_TASKS)
   runner.py           # BenchmarkRunner：驱动 Agent 执行测试集
   metrics.py          # TaskMetrics：从 run() 结果提取指标
+  baselines.py        # 确定性退化策略与评分敏感性汇总
   report.py           # BenchmarkReport：生成 Markdown/CSV/JSON 报告
   run_benchmark.py    # CLI 入口
+  run_baselines.py    # 离线退化策略诊断 CLI
 ```

--- a/AgenticArxiv/benchmark/run_baselines.py
+++ b/AgenticArxiv/benchmark/run_baselines.py
@@ -1,0 +1,146 @@
+"""CLI for deterministic benchmark-score sensitivity checks.
+
+Run from ``AgenticArxiv/``:
+
+    python -m benchmark.run_baselines --task-set expanded --output /tmp/baselines
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+from benchmark.baselines import (  # noqa: E402
+    ALL_POLICIES,
+    evaluate_baselines,
+    highest_scoring_tasks,
+    reference_gap_failures,
+    render_markdown,
+    resolve_policies,
+    summarize_baselines,
+)
+
+
+def _task_pool(task_set: str):
+    if task_set == "expanded":
+        from benchmark.tasks_expanded import get_expanded_tasks
+        return get_expanded_tasks()
+    from benchmark.tasks import get_all_tasks
+    return get_all_tasks()
+
+
+def _save_report(output_dir: Path, report: dict, markdown: str) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "baseline_report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "baseline_report.md").write_text(markdown, encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Offline diagnostic for benchmark reward sensitivity."
+    )
+    parser.add_argument(
+        "--task-set", choices=["default", "expanded"], default="expanded",
+        help="default=8 seed tasks; expanded=58 tasks including constraints and infeasible requests",
+    )
+    parser.add_argument(
+        "--policies", nargs="+", choices=sorted(ALL_POLICIES),
+        default=list(ALL_POLICIES),
+        help="Synthetic policies to score (default: all, including reference)",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="First stable seed used by random_tool (default: 42)",
+    )
+    parser.add_argument(
+        "--random-samples", type=int, default=20,
+        help="Number of consecutive seeds sampled by random_tool (default: 20)",
+    )
+    parser.add_argument(
+        "--min-reference-gap", type=float, default=0.3,
+        help="Minimum mean-reward gap required for every weak policy (default: 0.3)",
+    )
+    parser.add_argument(
+        "--top", type=int, default=5,
+        help="Highest-scoring tasks shown per weak policy (default: 5)",
+    )
+    parser.add_argument(
+        "--training-step", type=int, default=100,
+        help="Reward curriculum step; 100 uses full correctness weights (default: 100)",
+    )
+    parser.add_argument(
+        "--output", type=Path, default=None,
+        help="Optional directory for baseline_report.json and baseline_report.md",
+    )
+    args = parser.parse_args()
+    if args.random_samples < 1:
+        parser.error("--random-samples must be at least 1")
+    if args.min_reference_gap < 0:
+        parser.error("--min-reference-gap must be non-negative")
+    if args.top < 1:
+        parser.error("--top must be at least 1")
+
+    tasks = _task_pool(args.task_set)
+    results = evaluate_baselines(
+        tasks,
+        resolve_policies(args.policies),
+        seed=args.seed,
+        random_samples=args.random_samples,
+        training_step=args.training_step,
+    )
+    summaries = summarize_baselines(results)
+    top_tasks = highest_scoring_tasks(results, limit_per_policy=args.top)
+    health_failures = reference_gap_failures(
+        summaries, min_gap=args.min_reference_gap
+    )
+    markdown = render_markdown(
+        summaries,
+        task_set=args.task_set,
+        seed=args.seed,
+        training_step=args.training_step,
+        top_tasks=top_tasks,
+        min_reference_gap=args.min_reference_gap,
+        health_failures=health_failures,
+    )
+    print(markdown, end="")
+
+    if args.output is not None:
+        report = {
+            "task_set": args.task_set,
+            "seed": args.seed,
+            "random_samples": args.random_samples,
+            "training_step": args.training_step,
+            "health_check": {
+                "passed": not health_failures,
+                "min_reference_gap": args.min_reference_gap,
+                "failures": health_failures,
+            },
+            "note": (
+                "Synthetic trajectories are a scorer-sensitivity diagnostic; "
+                "they do not execute tools or measure LLM quality."
+            ),
+            "summary": [summary.to_dict() for summary in summaries],
+            "highest_scoring_tasks": [task.to_dict() for task in top_tasks],
+            "results": [result.to_dict() for result in results],
+        }
+        _save_report(args.output, report, markdown)
+        print(f"Saved JSON and Markdown reports to: {args.output}")
+
+    if health_failures:
+        for failure in health_failures:
+            print(f"Health check failed: {failure}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/AgenticArxiv/tests/test_baselines.py
+++ b/AgenticArxiv/tests/test_baselines.py
@@ -1,0 +1,110 @@
+"""Regression tests for the deterministic benchmark-score baselines."""
+
+from dataclasses import replace
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmark.baselines import (  # noqa: E402
+    ALL_POLICIES,
+    evaluate_baselines,
+    highest_scoring_tasks,
+    reference_gap_failures,
+    render_markdown,
+    resolve_policies,
+    summarize_baselines,
+)
+from benchmark.tasks_expanded import get_expanded_tasks  # noqa: E402
+
+
+class BaselineDiagnosticTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tasks = get_expanded_tasks()
+
+    def _results(self, names, random_samples=20):
+        return evaluate_baselines(
+            self.tasks, resolve_policies(names), seed=42,
+            random_samples=random_samples, training_step=100,
+        )
+
+    def test_reference_trajectory_is_the_score_ceiling(self):
+        results = self._results(["reference"])
+        self.assertEqual(len(results), len(self.tasks))
+        self.assertTrue(all(result.reward == 1.0 for result in results))
+        self.assertTrue(all(result.exact_tool_path for result in results))
+
+    def test_always_finish_is_not_mistaken_for_the_reference(self):
+        results = self._results(["reference", "always_finish"])
+        summaries = {item.policy: item for item in summarize_baselines(results)}
+
+        # FINISH is a termination signal, not proof that task work happened.
+        self.assertEqual(summaries["always_finish"].finish_rate, 1.0)
+        self.assertLess(summaries["always_finish"].exact_tool_path_rate, 1.0)
+        self.assertLess(
+            summaries["always_finish"].mean_reward,
+            summaries["reference"].mean_reward,
+        )
+
+    def test_degenerate_policies_keep_the_required_reference_gap(self):
+        results = self._results(list(ALL_POLICIES))
+        summaries = summarize_baselines(results)
+        self.assertEqual(reference_gap_failures(summaries, min_gap=0.3), [])
+
+    def test_health_guard_rejects_a_near_reference_policy(self):
+        summaries = summarize_baselines(self._results(list(ALL_POLICIES)))
+        summaries = [
+            replace(summary, mean_reward=0.95)
+            if summary.policy == "always_search"
+            else summary
+            for summary in summaries
+        ]
+        failures = reference_gap_failures(summaries, min_gap=0.3)
+        self.assertTrue(any("always_search" in failure for failure in failures))
+
+    def test_health_guard_requires_the_reference_policy(self):
+        summaries = summarize_baselines(self._results(["always_finish"]))
+        self.assertIn("reference policy is required", reference_gap_failures(summaries)[0])
+
+    def test_random_tool_is_reproducible_for_a_fixed_seed(self):
+        first = self._results(["random_tool"], random_samples=5)
+        second = self._results(["random_tool"], random_samples=5)
+        self.assertEqual(first, second)
+
+    def test_random_tool_reports_multiple_samples_and_variance(self):
+        results = self._results(["random_tool"], random_samples=5)
+        summary = summarize_baselines(results)[0]
+        self.assertEqual(summary.task_count, len(self.tasks))
+        self.assertEqual(summary.sample_count, len(self.tasks) * 5)
+        self.assertGreater(summary.reward_std, 0.0)
+
+    def test_missing_argument_oracles_are_excluded_from_the_mean(self):
+        from benchmark.tasks import get_all_tasks
+
+        results = evaluate_baselines(
+            get_all_tasks(), resolve_policies(["always_finish"]), training_step=100
+        )
+        self.assertEqual(summarize_baselines(results)[0].mean_arg_score, 0.0)
+
+    def test_markdown_labels_finish_as_a_separate_signal(self):
+        results = self._results(["reference", "always_finish"])
+        summaries = summarize_baselines(results)
+        top_tasks = highest_scoring_tasks(results, limit_per_policy=3)
+        markdown = render_markdown(
+            summaries, task_set="expanded", seed=42, training_step=100,
+            top_tasks=top_tasks, min_reference_gap=0.3,
+        )
+        self.assertIn("Finish rate", markdown)
+        self.assertIn("Exact tool path", markdown)
+        self.assertIn("Highest-scoring non-reference trajectories", markdown)
+        self.assertIn("Health check: **PASS**", markdown)
+        always_finish_tasks = {
+            task.task_id for task in top_tasks if task.policy == "always_finish"
+        }
+        self.assertNotIn("infeasible_index_out_of_range", always_finish_tasks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 改动内容

- 新增 `reference`、`always_finish`、`always_search` 和 `random_tool` 四种确定性基线策略。
- 新增完全离线的评分敏感性检查 CLI，无需调用 LLM、网络或真实工具。
- 为随机工具策略增加多 seed 采样、奖励标准差和可复现报告。
- 增加最小参考奖励分差检查；退化策略过于接近参考策略时返回非零状态。
- 输出未完整匹配参考轨迹但仍获得高分的任务，便于排查奖励漏洞。
- 区分 `FINISH` 结束率、严格工具路径准确率和业务任务完成情况。
- 补充单元测试和 benchmark 使用文档。

## 背景

关联 #17。

当前 benchmark 中，轨迹以 `FINISH` 结束并不代表业务任务真正完成。为了检查奖励函数和任务集是否能有效区分正常策略与退化策略，本 PR 增加一组确定性基线，并使用现有 `RewardCalculator` 进行统一评分。

如果退化策略的平均奖励过于接近参考轨迹，命令会明确失败，从而把 benchmark 区分度问题变成可重复、可接入 CI 的健康检查。

## 验证

- `PYTHONPATH=. python3 -m unittest -v tests.test_baselines`
- `PYTHONPATH=. python3 -m benchmark.run_baselines --task-set expanded --seed 42 --random-samples 20`
- 相关 benchmark 与 reward 测试通过
- `python3 -m compileall`
- `git diff --check`

## 说明

这些基线使用合成轨迹检查评分器敏感性，不执行真实工具，也不用于衡量实际 LLM 能力。
