### PR TITLE
fix(reward): make argument scoring discriminate, and gate outcome on it

### DIFF
--- a/AgenticArxiv/benchmark/baselines.py
+++ b/AgenticArxiv/benchmark/baselines.py
@@ -345,6 +345,48 @@ def reference_gap_failures(
     return failures
 
 
+def category_gap_failures(
+    results: Sequence[BaselineResult], min_gap: float = 0.3
+) -> List[str]:
+    """Per-category health check: an aggregate mean hides single-category holes.
+
+    ``reference_gap_failures`` compares whole-task-set means, so one leaky
+    category is diluted by the rest. Search tasks once left ``always_search``
+    only 0.167 below the reference while the aggregate check still passed.
+
+    Rows where a policy reproduced the reference trajectory are excluded: a
+    degenerate policy that happens to emit the reference solution has earned
+    the reference score, and on ``infeasible`` tasks ``always_finish`` *is*
+    the reference. A policy with no other rows in that category is skipped.
+    """
+
+    if min_gap < 0:
+        raise ValueError("min_gap must be non-negative")
+
+    reference: Dict[str, List[float]] = {}
+    others: Dict[tuple, List[float]] = {}
+    for result in results:
+        if result.policy == "reference":
+            reference.setdefault(result.category, []).append(result.reward)
+        elif not result.exact_reference:
+            others.setdefault((result.category, result.policy), []).append(result.reward)
+
+    if not reference:
+        return ["reference policy is required for the reward-gap health check"]
+
+    failures = []
+    for (category, policy), rewards in sorted(others.items()):
+        if category not in reference:
+            continue
+        gap = mean(reference[category]) - mean(rewards)
+        if gap < min_gap:
+            failures.append(
+                f"{category}/{policy}: reference gap {gap:.3f} is below "
+                f"required {min_gap:.3f}"
+            )
+    return failures
+
+
 def render_markdown(
     summaries: Sequence[PolicySummary],
     *,
@@ -354,6 +396,8 @@ def render_markdown(
     top_tasks: Sequence[TaskScoreSummary] = (),
     min_reference_gap: Optional[float] = None,
     health_failures: Sequence[str] = (),
+    min_category_gap: Optional[float] = None,
+    category_failures: Sequence[str] = (),
 ) -> str:
     """Render a small report suitable for terminal output and saved artifacts."""
 
@@ -398,6 +442,16 @@ def render_markdown(
             f"Health check: **{status}** (minimum reference gap: `{min_reference_gap:.3f}`)",
         ])
         lines.extend(f"- {failure}" for failure in health_failures)
+
+    if min_category_gap is not None:
+        status = "FAIL" if category_failures else "PASS"
+        lines.extend([
+            "",
+            f"Per-category check: **{status}** (minimum gap: `{min_category_gap:.3f}`). "
+            "The aggregate check above averages over the whole task set, so a "
+            "single leaky category is diluted by the rest.",
+        ])
+        lines.extend(f"- {failure}" for failure in category_failures)
 
     if top_tasks:
         lines.extend([

--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -87,7 +87,9 @@ def extract_metrics(
     parse_failures = _count_parse_failures(history)
     tool_exec_failures = _count_tool_failures(history)
 
-    arg_score = argument_match_score(history, task_def.get("expected_tool_args"))
+    arg_score = argument_match_score(
+        history, task_def.get("expected_tool_args"), expected_tools
+    )
     if arg_score is None:
         arg_score = 1.0
 
@@ -190,16 +192,43 @@ def _check_tool_sequence(actual: List[str], expected: List[str]) -> bool:
     return actual == expected
 
 
-def argument_match_score(history, expected_args):
+def argument_match_score(history, expected_args, expected_tools=None):
     """参数级匹配度，返回 [0,1] 或 None（任务未声明 expected_tool_args）。
 
-    从 rl/reward.py 的 _argument_score 提取，语义保持一致：
-    每一步取 (键覆盖率 + 取值正确率) / 2，再对各步取平均。
-    expected_args 中为 None 的项表示该步不校验参数。
+    每一步按「期望键里被答对的比例」打分，再对各步取平均。约定：
+
+    - `expected_args is None`：任务没有参数标准答案，返回 None，
+      `RewardCalculator` 会把 argument 这一档整个踢出加权分母。
+    - `expected_args == []`：正确行为是**一次工具都不调**（category="infeasible"）。
+      这与上一条不是一回事，必须能区分，否则乱调工具反而白拿满分。
+    - 某一项为 `None`：该步存在但不校验参数。
+    - 某个键的期望值为 `None`：该键应当缺省——省略不传、或显式传 None 都算对，
+      工具会退回当前活跃论文。
 
     提取到此处是为了让 benchmark 报告也能反映参数准确率 ——
     此前它只存在于 RL 奖励里，TaskMetrics 中没有对应字段，
     于是「工具选对了但参数选错了」在 benchmark 里完全不可见。
+
+    ## 为什么不再算 key_recall
+
+    原实现是 `(键覆盖率 + 取值正确率) / 2`。键覆盖率几乎不携带独立信息：
+    键缺失时 `predicted.get(k)` 就是 None，取值正确率同样判错。它唯一的
+    效果是把一半的参数分白送给「照着工具签名把键填齐」的行为——而这正是
+    任何能对该工具吐出合法 JSON 的模型免费拿到的。实测代价：一个无视任务、
+    永远搜 cs.AI 的退化策略，在「检索 cs.CL」任务上参数分 0.833、总分 0.933。
+
+    更糟的是期望值为 None 时它把方向搞反了：`{"ref": None}` 意为「用当前
+    活跃论文」，正确写法是省略 ref，却被判键覆盖率 0；而错误地传 ref=1
+    反倒拿满键覆盖率。两者最终都是 0.5——那 6 条 null 对照任务存在的唯一
+    目的就是区分这两种行为，打分器却给不出任何区分。
+
+    ## expected_tools
+
+    传入后，第 i 步只有在**工具名也对**时才算参数分，否则该步 0 分；
+    不传则退化为原来的纯按位比对（保持既有调用点兼容）。
+    没有这道闸时参数分与工具名脱钩：`download_01` 期望
+    `download_arxiv_pdf(ref=1)`，而 `get_paper_cache_status(ref=1)`
+    照样拿满参数分——等于替调错的工具背书，权重 2 白送出去。
     """
     if expected_args is None:
         return None
@@ -208,20 +237,31 @@ def argument_match_score(history, expected_args):
     for step in history or []:
         parsed = _parse_tool_action(step.get("action", ""))
         if parsed is not None:
-            actual.append(parsed.get("parameters", parsed.get("args", {})) or {})
+            actual.append((
+                parsed.get("name"),
+                parsed.get("parameters", parsed.get("args", {})) or {},
+            ))
+
+    if not expected_args:
+        return 1.0 if not actual else 0.0
 
     scores = []
     for index, expected in enumerate(expected_args):
         if expected is None:
             continue
-        predicted = actual[index] if index < len(actual) else {}
+        name, predicted = actual[index] if index < len(actual) else (None, {})
+        if (
+            expected_tools is not None
+            and index < len(expected_tools)
+            and name != expected_tools[index]
+        ):
+            scores.append(0.0)
+            continue
         keys = set(expected)
         if not keys:
             scores.append(1.0 if not predicted else 0.0)
             continue
-        key_recall = len(keys & set(predicted)) / len(keys)
-        value_accuracy = sum(predicted.get(k) == v for k, v in expected.items()) / len(keys)
-        scores.append((key_recall + value_accuracy) / 2)
+        scores.append(sum(predicted.get(k) == v for k, v in expected.items()) / len(keys))
     return sum(scores) / len(scores) if scores else 1.0
 
 

--- a/AgenticArxiv/benchmark/readme.md
+++ b/AgenticArxiv/benchmark/readme.md
@@ -59,6 +59,8 @@ python -m benchmark.run_baselines --task-set expanded --seed 42 --random-samples
 
 默认健康门槛要求每种退化策略的平均奖励比 `reference` 至少低 `0.3`；不满足时命令返回非零状态，可直接接入 CI。可用 `--min-reference-gap` 调整门槛，或用 `--top` 调整每种策略展示的高分任务数。
 
+此外还有一道**逐类目**门槛 `--min-category-gap`（默认同为 `0.3`）。总体均值会把单个类目的漏洞摊平：`always_search` 曾经在 search 类目上距参考仅 `0.167`（无视任务、永远发同一个 cs.AI 查询，在「检索 cs.CL」任务上拿 `0.933`），而总体均值差有 `0.832`，总体闸照样 PASS。逐类目闸会剔除「策略恰好复现了参考解法」的那些行——infeasible 任务上 `always_finish` **就是**参考解法（正确行为是一次工具都不调），那不是漏洞。
+
 ## 绘图
 
 ```bash
@@ -132,7 +134,8 @@ draw/images/
 |---|---|
 | task_completed | 轨迹是否以 `FINISH` 正常结束；不验证业务终态 |
 | termination_type | 终止类型: FINISH / FORCE_STOP / ERROR / INCOMPLETE |
-| tool_call_accurate | 实际工具调用是否与预期工具序列完全相等（顺序严格、无多余/重复调用） |
+| tool_call_accurate | 实际工具调用是否与预期工具序列完全相等（顺序严格、无多余/重复调用），只比工具名 |
+| arg_score | 参数级匹配度 `[0,1]`：逐步比对期望键的**取值**；未声明 `expected_tool_args` 时为 1.0 |
 | parse_failures | LLM 响应解析失败次数 |
 | tool_exec_failures | 工具执行失败次数 |
 
@@ -141,7 +144,9 @@ draw/images/
 ```
 benchmark/
   __init__.py
-  tasks.py           # 测试任务定义 (BENCHMARK_TASKS)
+  task_spec.py        # TaskSpec/Step：expected_tools 与 expected_tool_args 同源派生
+  tasks.py           # 8 条冒烟任务 (BENCHMARK_TASKS)
+  tasks_expanded.py   # 58 条完整基准集 (--task-set expanded)
   runner.py           # BenchmarkRunner：驱动 Agent 执行测试集
   metrics.py          # TaskMetrics：从 run() 结果提取指标
   baselines.py        # 确定性退化策略与评分敏感性汇总

--- a/AgenticArxiv/benchmark/run_baselines.py
+++ b/AgenticArxiv/benchmark/run_baselines.py
@@ -19,6 +19,7 @@ if PROJECT_ROOT not in sys.path:
 
 from benchmark.baselines import (  # noqa: E402
     ALL_POLICIES,
+    category_gap_failures,
     evaluate_baselines,
     highest_scoring_tasks,
     reference_gap_failures,
@@ -71,6 +72,11 @@ def main() -> None:
         help="Minimum mean-reward gap required for every weak policy (default: 0.3)",
     )
     parser.add_argument(
+        "--min-category-gap", type=float, default=0.3,
+        help="Minimum mean-reward gap required per task category (default: 0.3). "
+             "The aggregate check dilutes a single leaky category.",
+    )
+    parser.add_argument(
         "--top", type=int, default=5,
         help="Highest-scoring tasks shown per weak policy (default: 5)",
     )
@@ -87,6 +93,8 @@ def main() -> None:
         parser.error("--random-samples must be at least 1")
     if args.min_reference_gap < 0:
         parser.error("--min-reference-gap must be non-negative")
+    if args.min_category_gap < 0:
+        parser.error("--min-category-gap must be non-negative")
     if args.top < 1:
         parser.error("--top must be at least 1")
 
@@ -103,6 +111,9 @@ def main() -> None:
     health_failures = reference_gap_failures(
         summaries, min_gap=args.min_reference_gap
     )
+    category_failures = category_gap_failures(
+        results, min_gap=args.min_category_gap
+    )
     markdown = render_markdown(
         summaries,
         task_set=args.task_set,
@@ -111,6 +122,8 @@ def main() -> None:
         top_tasks=top_tasks,
         min_reference_gap=args.min_reference_gap,
         health_failures=health_failures,
+        min_category_gap=args.min_category_gap,
+        category_failures=category_failures,
     )
     print(markdown, end="")
 
@@ -125,6 +138,11 @@ def main() -> None:
                 "min_reference_gap": args.min_reference_gap,
                 "failures": health_failures,
             },
+            "category_check": {
+                "passed": not category_failures,
+                "min_category_gap": args.min_category_gap,
+                "failures": category_failures,
+            },
             "note": (
                 "Synthetic trajectories are a scorer-sensitivity diagnostic; "
                 "they do not execute tools or measure LLM quality."
@@ -136,9 +154,11 @@ def main() -> None:
         _save_report(args.output, report, markdown)
         print(f"Saved JSON and Markdown reports to: {args.output}")
 
-    if health_failures:
-        for failure in health_failures:
-            print(f"Health check failed: {failure}", file=sys.stderr)
+    for failure in health_failures:
+        print(f"Health check failed: {failure}", file=sys.stderr)
+    for failure in category_failures:
+        print(f"Per-category check failed: {failure}", file=sys.stderr)
+    if health_failures or category_failures:
         raise SystemExit(1)
 
 

--- a/AgenticArxiv/benchmark/task_spec.py
+++ b/AgenticArxiv/benchmark/task_spec.py
@@ -51,6 +51,8 @@ class TaskSpec:
         max_iterations: 该任务允许的 ReAct 轮数上限。Agent 默认 5 轮，也就是
             最多 4 次工具调用 + 一次 FINISH；更长的链必须显式抬高，否则会被
             判成 FORCE_STOP 而非能力不足。
+        depends_on: 前置任务 id。同一会话里按依赖顺序跑，供
+            `tasks.get_dependency_chain` 使用。
     """
 
     id: str
@@ -64,6 +66,7 @@ class TaskSpec:
     note: str = ""
     termination: str = "FINISH"
     max_iterations: Optional[int] = None
+    depends_on: Optional[str] = None
 
     def to_task(self) -> Dict[str, Any]:
         """展开成 benchmark / RL 两侧共用的任务字典。"""
@@ -87,6 +90,8 @@ class TaskSpec:
             task["note"] = self.note
         if self.max_iterations is not None:
             task["max_iterations"] = self.max_iterations
+        if self.depends_on:
+            task["depends_on"] = self.depends_on
         return task
 
 

--- a/AgenticArxiv/benchmark/tasks.py
+++ b/AgenticArxiv/benchmark/tasks.py
@@ -1,95 +1,100 @@
 # AgenticArxiv/benchmark/tasks.py
-"""标准化测试任务集，用于对比三种 Agent 模式的性能和准确性。"""
+"""标准化测试任务集，用于对比三种 Agent 模式的性能和准确性。
+
+这里是 8 条冒烟任务；完整的 58 条基准集在 `benchmark/tasks_expanded.py`
+（`--task-set expanded`）。两边共用 `task_spec.TaskSpec`：`expected_tools`
+与 `expected_tool_args` 由同一份 `steps` 派生，不再手写两份平行列表。
+
+改成派生不是为了少敲字。原来 `download_01` / `translate_01` / `cache_01`
+三条只写了 `expected_tools`，`expected_tool_args` 缺省为 None，于是
+`argument_match_score` 返回 None、`RewardCalculator` 把 argument 档整个
+踢出加权分母——任务照跑、分照打，参数从此不再被检查。代价是可以量出来的：
+`benchmark/run_baselines.py` 里那个纯随机挑一个工具的退化策略，只要蒙对
+工具名就能在这三条上拿到满分 1.000，因为没有任何参数标准答案能拆穿它。
+"""
 
 from typing import List, Dict, Any, Optional
 
+from benchmark.task_spec import Step, TaskSpec, build
 
-BENCHMARK_TASKS: List[Dict[str, Any]] = [
+
+BENCHMARK_SPECS: List[TaskSpec] = [
     # === 类型 1: 简单搜索（单工具） ===
-    {
-        "id": "search_01",
-        "task": "检索最近7天内人工智能(cs.AI)方向的论文，最多5篇",
-        "expected_tools": ["get_recently_submitted_cs_papers"],
-        "expected_tool_args": [
-            {"aspect": "AI", "days": 7, "max_results": 5}
-        ],
-        "expected_termination": "FINISH",
-        "category": "search",
-    },
-    {
-        "id": "search_02",
-        "task": "获取最近3天机器学习(cs.LG)方向的最新论文，最多10篇",
-        "expected_tools": ["get_recently_submitted_cs_papers"],
-        "expected_tool_args": [
-            {"aspect": "LG", "days": 3, "max_results": 10}
-        ],
-        "expected_termination": "FINISH",
-        "category": "search",
-    },
-    {
-        "id": "search_03",
-        "task": "搜索最近7天自然语言处理(cs.CL)方向的论文，最多5篇",
-        "expected_tools": ["get_recently_submitted_cs_papers"],
-        "expected_tool_args": [
-            {"aspect": "CL", "days": 7, "max_results": 5}
-        ],
-        "expected_termination": "FINISH",
-        "category": "search",
-    },
-    {
-        "id": "search_04",
-        "task": "检索最近7天计算机科学全部方向的论文，最多10篇",
-        "expected_tools": ["get_recently_submitted_cs_papers"],
-        "expected_tool_args": [
-            {"aspect": "*", "days": 7, "max_results": 10}
-        ],
-        "expected_termination": "FINISH",
-        "category": "search",
-    },
+    # 四条的措辞刻意不统一（检索 / 获取 / 搜索），用来看模型对表述的鲁棒性，
+    # 因此不套 family() 模板——模板会把描述抹平成一个句式。
+    TaskSpec(
+        id="search_01",
+        task="检索最近7天内人工智能(cs.AI)方向的论文，最多5篇",
+        steps=(Step("get_recently_submitted_cs_papers",
+                    {"aspect": "AI", "days": 7, "max_results": 5}),),
+        category="search",
+    ),
+    TaskSpec(
+        id="search_02",
+        task="获取最近3天机器学习(cs.LG)方向的最新论文，最多10篇",
+        steps=(Step("get_recently_submitted_cs_papers",
+                    {"aspect": "LG", "days": 3, "max_results": 10}),),
+        category="search",
+    ),
+    TaskSpec(
+        id="search_03",
+        task="搜索最近7天自然语言处理(cs.CL)方向的论文，最多5篇",
+        steps=(Step("get_recently_submitted_cs_papers",
+                    {"aspect": "CL", "days": 7, "max_results": 5}),),
+        category="search",
+    ),
+    TaskSpec(
+        id="search_04",
+        task="检索最近7天计算机科学全部方向的论文，最多10篇",
+        steps=(Step("get_recently_submitted_cs_papers",
+                    {"aspect": "*", "days": 7, "max_results": 10}),),
+        category="search",
+    ),
 
     # === 类型 2: 下载 PDF（依赖搜索） ===
-    {
-        "id": "download_01",
-        "task": "下载第1篇论文的PDF",
-        "expected_tools": ["download_arxiv_pdf"],
-        "expected_termination": "FINISH",
-        "category": "download",
-        "depends_on": "search_01",
-    },
+    TaskSpec(
+        id="download_01",
+        task="下载第1篇论文的PDF",
+        steps=(Step("download_arxiv_pdf", {"ref": 1}),),
+        category="download",
+        depends_on="search_01",
+    ),
 
     # === 类型 3: 翻译 PDF（异步任务，依赖下载） ===
-    {
-        "id": "translate_01",
-        "task": "翻译第1篇论文",
-        "expected_tools": ["translate_arxiv_pdf"],
-        "expected_termination": "FINISH",
-        "category": "translate",
-        "depends_on": "download_01",
-    },
+    TaskSpec(
+        id="translate_01",
+        task="翻译第1篇论文",
+        steps=(Step("translate_arxiv_pdf", {"ref": 1}),),
+        category="translate",
+        depends_on="download_01",
+    ),
 
     # === 类型 4: 缓存查询（依赖搜索） ===
-    {
-        "id": "cache_01",
-        "task": "查看第1篇论文的缓存状态",
-        "expected_tools": ["get_paper_cache_status"],
-        "expected_termination": "FINISH",
-        "category": "cache",
-        "depends_on": "search_01",
-    },
+    TaskSpec(
+        id="cache_01",
+        task="查看第1篇论文的缓存状态",
+        steps=(Step("get_paper_cache_status", {"ref": 1}),),
+        category="cache",
+        depends_on="search_01",
+    ),
 
     # === 类型 5: 多步骤复合任务 ===
-    {
-        "id": "composite_01",
-        "task": "搜索最近7天计算机视觉(cs.CV)的论文(最多3篇)，然后下载第1篇",
-        "expected_tools": ["get_recently_submitted_cs_papers", "download_arxiv_pdf"],
-        "expected_tool_args": [
-            {"aspect": "CV", "days": 7, "max_results": 3},
-            None,
-        ],
-        "expected_termination": "FINISH",
-        "category": "composite",
-    },
+    TaskSpec(
+        id="composite_01",
+        task="搜索最近7天计算机视觉(cs.CV)的论文(最多3篇)，然后下载第1篇",
+        steps=(
+            Step("get_recently_submitted_cs_papers",
+                 {"aspect": "CV", "days": 7, "max_results": 3}),
+            # 原来这一步写的是 None（不校验参数）。任务明说了「第1篇」，
+            # 有标准答案就该校验，否则第二步的参数是免检的。
+            Step("download_arxiv_pdf", {"ref": 1}),
+        ),
+        category="composite",
+    ),
 ]
+
+
+BENCHMARK_TASKS: List[Dict[str, Any]] = build(BENCHMARK_SPECS)
 
 
 def get_tasks_by_category(category: str) -> List[Dict[str, Any]]:

--- a/AgenticArxiv/rl/reward.py
+++ b/AgenticArxiv/rl/reward.py
@@ -112,7 +112,11 @@ class RewardCalculator:
         components = {
             "format": self._format_score(history),
             "tool": self._tool_score(metrics.tool_call_sequence, metrics.expected_tools),
-            "argument": self._argument_score(history, task_def.get("expected_tool_args")),
+            "argument": self._argument_score(
+                history,
+                task_def.get("expected_tool_args"),
+                task_def.get("expected_tools"),
+            ),
             "process": self._process_score(history, metrics),
             "outcome": self._outcome_score(metrics),
         }
@@ -180,10 +184,11 @@ class RewardCalculator:
     def _argument_score(
         history: Sequence[Dict[str, Any]],
         expected_args: Optional[Sequence[Optional[Mapping[str, Any]]]],
+        expected_tools: Optional[Sequence[str]] = None,
     ) -> Optional[float]:
-        # 比对逻辑已提取到 benchmark/metrics.py，供 benchmark 报告共用；
-        # 这里只做 [0,1] → [-1,1] 的缩放，语义与原实现一致。
-        score = argument_match_score(history, expected_args)
+        # 比对逻辑在 benchmark/metrics.py，供 benchmark 报告共用；
+        # 这里只做 [0,1] → [-1,1] 的缩放。
+        score = argument_match_score(history, expected_args, expected_tools)
         return None if score is None else 2 * score - 1
 
     @staticmethod
@@ -209,7 +214,14 @@ class RewardCalculator:
         if metrics.termination_type == "FORCE_STOP":
             return -0.5
         if metrics.task_completed and metrics.tool_call_accurate:
-            return 1.0
+            # 工具名对了不等于任务完成。`tool_call_accurate` 只比较工具序列，
+            # 问 cs.CL 却搜了 cs.AI 在这里完全相等——要的东西根本没拿到，
+            # outcome 却给满分。这样 outcome 就成了 tool 档的复制品，权重 3
+            # 白送给「照着签名瞎填参数」的策略（issue #17 第 2 条）。
+            # 下限保持 0.25，与「FINISH 了但工具序列错」持平：参数全错不该
+            # 罚得比工具全错还狠。任务未声明参数标准答案时 arg_score 恒为 1.0，
+            # 该分支行为与原实现一致。
+            return max(0.25, 2 * metrics.arg_score - 1)
         if metrics.task_completed:
             return 0.25
         return -0.25

--- a/AgenticArxiv/tests/test_baselines.py
+++ b/AgenticArxiv/tests/test_baselines.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from benchmark.baselines import (  # noqa: E402
     ALL_POLICIES,
+    category_gap_failures,
     evaluate_baselines,
     highest_scoring_tasks,
     reference_gap_failures,
@@ -87,6 +88,42 @@ class BaselineDiagnosticTest(unittest.TestCase):
             get_all_tasks(), resolve_policies(["always_finish"]), training_step=100
         )
         self.assertEqual(summarize_baselines(results)[0].mean_arg_score, 0.0)
+
+    def test_per_category_check_catches_what_the_aggregate_mean_dilutes(self):
+        """总体均值把单类目的洞摊平了。
+
+        实测过的例子：`always_search` 在 search 类目上距参考仅 0.167，
+        而总体均值差 0.832 —— 总体闸 PASS，逐类目闸 FAIL。
+        """
+        results = self._results(list(ALL_POLICIES))
+        self.assertEqual(category_gap_failures(results, min_gap=0.3), [])
+
+        leaky = [
+            replace(row, reward=0.95)
+            if (row.category == "search" and row.policy == "always_search")
+            else row
+            for row in results
+        ]
+        summaries = summarize_baselines(leaky)
+        self.assertEqual(reference_gap_failures(summaries, min_gap=0.3), [])
+        failures = category_gap_failures(leaky, min_gap=0.3)
+        self.assertTrue(any("search/always_search" in f for f in failures), failures)
+
+    def test_per_category_check_ignores_rows_that_are_the_reference(self):
+        """infeasible 上 always_finish 就是参考解法：正确行为是一次都不调。
+
+        这不是漏洞，逐类目闸不能因此报警。
+        """
+        results = self._results(["reference", "always_finish"])
+        infeasible = [r for r in results if r.category == "infeasible"]
+        self.assertTrue(infeasible)
+        self.assertTrue(all(
+            r.exact_reference for r in infeasible if r.policy == "always_finish"
+        ))
+        self.assertFalse(any(
+            "infeasible/always_finish" in f
+            for f in category_gap_failures(results, min_gap=0.3)
+        ))
 
     def test_markdown_labels_finish_as_a_separate_signal(self):
         results = self._results(["reference", "always_finish"])

--- a/AgenticArxiv/tests/test_benchmark_offline.py
+++ b/AgenticArxiv/tests/test_benchmark_offline.py
@@ -40,7 +40,7 @@ class _FakeSideEffects:
 
 
 class ArgumentMatchScoreTest(unittest.TestCase):
-    """语义须与提取前的 rl/reward.py::_argument_score 一致。"""
+    """参数级打分：只认取值，认工具身份，区分「不该调」与「不校验」。"""
 
     def test_returns_none_when_task_declares_no_expected_args(self):
         self.assertIsNone(argument_match_score([_step("t", {"a": 1})], None))
@@ -49,9 +49,10 @@ class ArgumentMatchScoreTest(unittest.TestCase):
         history = [_step("download_arxiv_pdf", {"ref": 2})]
         self.assertEqual(argument_match_score(history, [{"ref": 2}]), 1.0)
 
-    def test_right_key_wrong_value_scores_half(self):
+    def test_right_key_wrong_value_scores_zero(self):
+        # 曾经是 0.5：键覆盖率占一半分，而把键填齐是免费的。
         history = [_step("download_arxiv_pdf", {"ref": 9})]
-        self.assertEqual(argument_match_score(history, [{"ref": 2}]), 0.5)
+        self.assertEqual(argument_match_score(history, [{"ref": 2}]), 0.0)
 
     def test_missing_step_scores_zero(self):
         self.assertEqual(argument_match_score([], [{"ref": 2}]), 0.0)
@@ -64,6 +65,43 @@ class ArgumentMatchScoreTest(unittest.TestCase):
         # session_id 由框架注入，不该算模型的错
         history = [_step("download_arxiv_pdf", {"ref": 2, "session_id": "s"})]
         self.assertEqual(argument_match_score(history, [{"ref": 2}]), 1.0)
+
+    def test_empty_expected_args_means_call_nothing(self):
+        """[] 是「正确行为是一次都不调」，不是「没写标准答案」。
+
+        后者是 None。两者曾经都走到末尾的 `else 1.0`，于是 infeasible
+        任务上乱调一个工具反而白拿满参数分（+1.0 × 权重 2），把
+        `_tool_score` 给的 -1.0 抵掉大半。
+        """
+        self.assertEqual(argument_match_score([], []), 1.0)
+        self.assertEqual(argument_match_score([_step("search", {"aspect": "AI"})], []), 0.0)
+
+    def test_expected_none_value_means_the_key_should_be_omitted(self):
+        """`{"ref": None}` = 用当前活跃论文；省略 ref 才是正确写法。
+
+        旧口径下「省略」被判键覆盖率 0、「错传 ref=1」反倒键覆盖率满分，
+        两者都落在 0.5——而 ref_form / state 里那些 null 对照任务存在的
+        唯一目的就是区分这两种行为。
+        """
+        expected = [{"ref": None}]
+        self.assertEqual(argument_match_score([_step("translate_arxiv_pdf", {})], expected), 1.0)
+        self.assertEqual(
+            argument_match_score([_step("translate_arxiv_pdf", {"ref": None})], expected), 1.0
+        )
+        self.assertEqual(
+            argument_match_score([_step("translate_arxiv_pdf", {"ref": 1})], expected), 0.0
+        )
+
+    def test_arguments_only_count_when_the_tool_itself_is_right(self):
+        """参数分不能与工具名脱钩，否则等于替调错的工具背书。"""
+        history = [_step("get_paper_cache_status", {"ref": 1})]
+        self.assertEqual(argument_match_score(history, [{"ref": 1}]), 1.0)  # 不传 expected_tools
+        self.assertEqual(
+            argument_match_score(history, [{"ref": 1}], ["download_arxiv_pdf"]), 0.0
+        )
+        self.assertEqual(
+            argument_match_score(history, [{"ref": 1}], ["get_paper_cache_status"]), 1.0
+        )
 
 
 class ApplySetupTest(unittest.TestCase):

--- a/AgenticArxiv/tests/test_multigranular_reward.py
+++ b/AgenticArxiv/tests/test_multigranular_reward.py
@@ -1,5 +1,6 @@
 """Unit tests for hierarchical reward shaping."""
 
+import json
 import unittest
 from types import ModuleType
 from unittest.mock import Mock, patch
@@ -45,7 +46,15 @@ class MultiGranularRewardTest(unittest.TestCase):
         self.assertLess(reward.tool, 1.0)
         self.assertLess(reward.outcome, 1.0)
 
-    def test_argument_layer_scores_keys_and_values(self):
+    def test_argument_layer_scores_values_not_key_presence(self):
+        """键填齐不算分，只有值对了才算。
+
+        原实现是 (键覆盖率 + 取值正确率) / 2，这里 days 填错、键齐全，
+        旧口径给 0.75 → 分量 0.5。键覆盖率几乎不携带独立信息（键缺失时
+        取值同样判错），它唯一的作用是把一半参数分白送给「照着工具签名
+        把键填齐」，而那是任何能吐出合法 JSON 的模型免费拿到的。
+        现在 2 个键对 1 个 → 0.5 → 分量 0.0。
+        """
         task = {
             "id": "search",
             "expected_tools": ["search"],
@@ -56,7 +65,7 @@ class MultiGranularRewardTest(unittest.TestCase):
             {"action": "FINISH", "observation": "done"},
         ]
         reward, _ = self.calculator.compute_reward_breakdown(task, _result(history))
-        self.assertEqual(reward.argument, 0.5)
+        self.assertEqual(reward.argument, 0.0)
 
     def test_complete_args_receive_maximum_argument_score(self):
         task = {
@@ -94,7 +103,9 @@ class MultiGranularRewardTest(unittest.TestCase):
             {"action": "FINISH", "observation": "done"},
         ]
         reward, _ = self.calculator.compute_reward_breakdown(task, _result(history))
-        self.assertEqual(reward.argument, 0.0)
+        # 三个值全错 → 取值正确率 0 → 分量 -1.0。
+        # 旧口径因为键齐全还能拿 0.0（不罚），等于「搜错了方向」零成本。
+        self.assertEqual(reward.argument, -1.0)
 
     def test_missing_arguments_receive_lower_score(self):
         task = {
@@ -127,27 +138,40 @@ class MultiGranularRewardTest(unittest.TestCase):
         self.assertEqual(reward.argument, 0.0)
         self.assertEqual(reward.total, 1.0)
 
-    def test_composite_task_skips_dynamic_download_arguments(self):
+    def test_composite_download_step_has_a_static_argument_oracle(self):
+        """composite_01 第二步曾经写成 None（免检），前提是错的。
+
+        任务原文是「然后下载第1篇」，而 download_arxiv_pdf 的 ref 就是
+        1-based 序号（tools/pdf_download_tool.py: ref: Union[str,int,None] = 1），
+        「第1篇」= ref 1 是静态可判的，不存在动态性。免检的代价是这一步
+        随便填什么都拿满参数分。
+        """
         task = get_task_by_id("composite_01")
         self.assertEqual(
             task["expected_tool_args"],
-            [{"aspect": "CV", "days": 7, "max_results": 3}, None],
+            [{"aspect": "CV", "days": 7, "max_results": 3}, {"ref": 1}],
         )
-        history = [
-            {
-                "action": '{"name":"get_recently_submitted_cs_papers",'
-                '"args":{"aspect":"CV","days":7,"max_results":3}}',
+        head = {
+            "action": '{"name":"get_recently_submitted_cs_papers",'
+            '"args":{"aspect":"CV","days":7,"max_results":3}}',
+            "observation": "ok",
+        }
+        finish = {"action": "FINISH", "observation": "done"}
+
+        def download(ref):
+            return {
+                "action": '{"name":"download_arxiv_pdf","args":{"ref":%s}}' % json.dumps(ref),
                 "observation": "ok",
-            },
-            {
-                "action": '{"name":"download_arxiv_pdf",'
-                '"args":{"ref":"dynamic-search-result"}}',
-                "observation": "ok",
-            },
-            {"action": "FINISH", "observation": "done"},
-        ]
-        reward, _ = self.calculator.compute_reward_breakdown(task, _result(history))
-        self.assertEqual(reward.argument, 1.0)
+            }
+
+        right, _ = self.calculator.compute_reward_breakdown(
+            task, _result([head, download(1), finish])
+        )
+        wrong, _ = self.calculator.compute_reward_breakdown(
+            task, _result([head, download("dynamic-search-result"), finish])
+        )
+        self.assertEqual(right.argument, 1.0)
+        self.assertEqual(wrong.argument, 0.0)
 
     def test_benchmark_search_tasks_define_static_argument_oracles(self):
         expected = {

--- a/AgenticArxiv/tests/test_reward_discrimination.py
+++ b/AgenticArxiv/tests/test_reward_discrimination.py
@@ -1,0 +1,125 @@
+"""奖励区分度的回归护栏。
+
+README TODO P1 的落点是「……奖励才有区分度」。这个文件把「有区分度」
+变成可执行的断言：借 `benchmark/run_baselines.py` 的确定性退化策略，
+逐类目卡住「参考解法」与「退化策略」之间的分差。
+
+这些数字曾经不成立。修之前实测（training_step=100，full weights）：
+
+    类目        参考   always_search  最小分差
+    search     1.000      0.833        0.167   <- 无视任务永远搜 cs.AI，
+                                                  在「检索 cs.CL」上拿 0.933
+    infeasible 1.000      0.165       (负分才对) <- 正确答案是一次都别调，
+                                                  乱调一个反而拿正分
+
+根因有四处，都在参数档：
+
+1. `argument_match_score` 把一半分给键覆盖率，而把键填齐是免费的；
+2. 期望值为 None（「该键应缺省」）时键覆盖率把方向判反了，
+   正确的省略与错误的传值同为 0.5，null 对照任务毫无区分；
+3. `expected_tool_args == []`（一次都不该调）落到了「没有标准答案」
+   那条分支，返回 1.0；
+4. 参数分不看是哪个工具调的，`get_paper_cache_status(ref=1)` 能顶替
+   `download_arxiv_pdf(ref=1)` 拿满分。
+
+外加 `_outcome_score` 只看工具名，参数全错也给满分，权重 3。
+"""
+
+import sys
+import unittest
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmark.baselines import (  # noqa: E402
+    ALL_POLICIES,
+    category_gap_failures,
+    evaluate_baselines,
+    resolve_policies,
+)
+from benchmark.tasks import get_all_tasks  # noqa: E402
+from benchmark.tasks_expanded import get_expanded_tasks  # noqa: E402
+
+# 与 run_baselines.py 的 --min-reference-gap 默认值保持一致
+MIN_GAP = 0.3
+
+
+def _score(tasks):
+    return evaluate_baselines(
+        tasks, resolve_policies(list(ALL_POLICIES)),
+        seed=42, random_samples=20, training_step=100,
+    )
+
+
+def _by_category(results):
+    """{category: {policy: mean_reward}}"""
+    grouped = defaultdict(lambda: defaultdict(list))
+    for r in results:
+        grouped[r.category][r.policy].append(r.reward)
+    return {
+        cat: {policy: mean(vals) for policy, vals in rows.items()}
+        for cat, rows in grouped.items()
+    }
+
+
+class PerCategoryRewardGapTest(unittest.TestCase):
+    """总体均值差看不见单类目的洞：search 曾经只有 0.167，总体却 PASS。"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.expanded_rows = _score(get_expanded_tasks())
+        cls.default_rows = _score(get_all_tasks())
+        cls.expanded = _by_category(cls.expanded_rows)
+
+    def test_expanded_set_separates_every_category(self):
+        # infeasible 上 always_finish **就是**参考解法（正确行为是一次工具
+        # 都不调），category_gap_failures 已按 exact_reference 把这类行剔除。
+        self.assertEqual(category_gap_failures(self.expanded_rows, min_gap=MIN_GAP), [])
+
+    def test_default_set_separates_every_category(self):
+        self.assertEqual(category_gap_failures(self.default_rows, min_gap=MIN_GAP), [])
+
+    def test_calling_a_tool_on_an_infeasible_task_is_punished(self):
+        """正确答案是「什么都别做」，动了手必须是负分而不只是低分。"""
+        rewards = self.expanded["infeasible"]
+        self.assertEqual(rewards["reference"], 1.0)
+        self.assertEqual(rewards["always_finish"], 1.0)
+        for policy in ("always_search", "random_tool"):
+            with self.subTest(policy=policy):
+                self.assertLess(rewards[policy], 0.0)
+
+    def test_ignoring_the_task_costs_more_than_a_third_of_the_score(self):
+        """always_search 无视任务、永远发同一个 cs.AI 查询。
+
+        修前它在 search 类目上平均 0.833；这里只钉一个上界，不钉具体值，
+        免得以后调权重时变成需要同步维护的魔数。
+        """
+        self.assertLess(self.expanded["search"]["always_search"], 0.7)
+
+
+class DefaultTaskSetDerivationTest(unittest.TestCase):
+    """benchmark/tasks.py 迁到 TaskSpec 之后不该再有免检步骤。"""
+
+    def test_every_task_declares_argument_oracles(self):
+        for task in get_all_tasks():
+            with self.subTest(task_id=task["id"]):
+                args = task["expected_tool_args"]
+                self.assertIsNotNone(
+                    args, "expected_tool_args 为 None 会让 argument 档整个退出加权"
+                )
+                self.assertEqual(len(args), len(task["expected_tools"]))
+                self.assertNotIn(None, args, "不该再有免检步骤")
+
+    def test_dependency_chain_survives_the_migration(self):
+        from benchmark.tasks import get_dependency_chain
+
+        self.assertEqual(
+            get_dependency_chain("translate_01"),
+            ["search_01", "download_01", "translate_01"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ PPO 更适合生产级大模型训练（7B+），本项目作为学习 demo 不�
 
 ### P1 — 中期（数据与评测）
 
-- [ ] **任务集扩充**：`benchmark/tasks.py` 仅 7 个任务，扩充到 50+，并支持自动派生 `expected_tools` / `expected_tool_args`，奖励才有区分度。
+- [x] **任务集扩充**：基准集扩到 58 条（`benchmark/tasks_expanded.py`，`--task-set expanded`），涵盖 search / ref_form / composite / state / optional / constraint / long_chain / infeasible 八类；`benchmark/tasks.py` 保留为 8 条冒烟子集。两边统一走 `benchmark/task_spec.py` 的 `TaskSpec`：`expected_tools` 与 `expected_tool_args` 由同一份 `steps` 派生，不再手写两份平行列表漂移。区分度用 `benchmark/run_baselines.py` 的确定性退化策略量化并逐类目卡门槛（`tests/test_reward_discrimination.py`）——修掉参数档的四处漏分后，「无视任务永远搜 cs.AI」在检索类任务上从 0.833 降到 0.446，「本该什么都不做却调了工具」从 +0.165 变成 −0.235。
 - [ ] **eval/ badcase replay**：目录树中的 `eval/`（`eval_cases.jsonl`、`badcase_replay.py`）实际尚不存在，需实现坏例回放闭环。
 - [ ] **Reward hacking 排查**：在现有 `RewardVarianceGuard` / `CanaryCallback` 基础上补 reward-hacking 案例库与多粒度权重课程调优。
 


### PR DESCRIPTION
Closes the last clause of the README TODO under **P1**:

> **任务集扩充**：`benchmark/tasks.py` 仅 7 个任务，扩充到 50+，并支持自动派生
> `expected_tools` / `expected_tool_args`，**奖励才有区分度**。

The count and the auto-derivation landed in #36 and #39. This PR is about the
clause those two left unfinished — whether the reward can actually tell a
task-solving policy apart from one that ignores the task.

It cannot. #39 gave us the instrument to measure that, and the first
measurement fails.

## The measurement

`benchmark/run_baselines.py` scores deterministic degenerate policies offline.
Broken out per category on the 58-task expanded set (`training_step=100`,
full correctness weights):

| Category | reference | `always_search` | gap |
|---|---:|---:|---:|
| search | 1.000 | **0.833** | 0.167 |
| infeasible | 1.000 | **+0.165** | should be negative |
| composite | 1.000 | 0.238 | 0.762 |
| ref_form | 1.000 | −0.185 | 0.812 |
| state | 1.000 | −0.150 | 0.875 |

`always_search` never reads the task. It emits the same
`get_recently_submitted_cs_papers(aspect="AI", days=7, max_results=5)` every
time. On `search_CL_7d_5` — "检索最近7天内自然语言处理(cs.CL)方向的论文" —
it scores **0.933**, with `outcome` at a full **1.0**. That is issue #17's
second complaint, quantified.

On `infeasible` tasks, where the correct behaviour is to call nothing at all,
calling a tool anyway earns a **positive** reward.

The existing `--min-reference-gap` health check passes throughout: it compares
whole-task-set means, so one leaky category is diluted by the other seven.

## Four leaks, all in the argument component

### 1. `key_recall` is half the score and it is free

`argument_match_score` was `(key_recall + value_accuracy) / 2`. `key_recall`
carries almost no independent information — when a key is missing,
`predicted.get(k)` is `None` and `value_accuracy` fails it too. Its only real
effect is to hand half the argument score to "reproduce the tool's signature",
which any model that can emit valid JSON for that tool gets for free.

Concretely, on `search_CL_7d_5`: `key_recall = 3/3`, `value_accuracy = 2/3`,
so getting `aspect` wrong — the parameter that *defines* the task — costs 1/6.

Now only value correctness counts.

### 2. With an expected value of `None`, `key_recall` had the sign backwards

`{"ref": None}` means "use the currently active paper"
(`tools/pdf_download_tool.py:33`, `ref: Union[str, int, None]`). The natural
correct call omits `ref` entirely. Before:

```
omit ref      (correct) -> 0.5
pass ref=1    (wrong)   -> 0.5
```

Omitting scored `key_recall = 0`; passing a wrong value scored `key_recall = 1`.
The two cancelled out to the same number. The six `ref_form` / `state`
null-control tasks exist for the sole purpose of separating these two
behaviours, and the scorer separated them by exactly zero.

After: `1.0` vs `0.0`.

### 3. `expected_tool_args == []` fell through to "no ground truth"

`[]` means *the correct behaviour is to call nothing* (`category="infeasible"`).
`None` means *this task declares no argument oracle*. Both reached the trailing
`else 1.0`, so a hallucinated call on an infeasible task banked `+1.0 ×
weight 2`, cancelling most of the `-1.0` that `_tool_score` correctly assigned.

This is the same hole #36 fixed in `_tool_score` and did not follow through to
the argument component.

### 4. Argument credit was decoupled from tool identity

`get_paper_cache_status(ref=1)` scored full marks against an oracle of
`download_arxiv_pdf(ref=1)` — argument credit for a call to the wrong tool.
`argument_match_score` takes an optional `expected_tools`; a step whose tool
name is wrong scores 0. The parameter is optional, so existing call sites keep
working.

This one only surfaced after the first three: `default/download`'s
`random_tool` mean went *up*, from 0.227 to 0.321, because three of the four
tool actions it draws from carry `{"ref": 1}`.

## `_outcome_score` was a copy of the tool component

```python
if metrics.task_completed and metrics.tool_call_accurate:
    return 1.0
```

`tool_call_accurate` compares tool *names* only. Searching cs.AI when asked for
cs.CL is name-identical, so the trajectory collected a full-weight-3 outcome
for not retrieving what was asked.

```python
return max(0.25, 2 * metrics.arg_score - 1)
```

The floor matches "FINISHed but the tool sequence was wrong" — wrong arguments
should not be punished harder than wrong tools. Tasks with no argument oracle
have `arg_score == 1.0`, so this branch is unchanged for them.

**On the choice not to make it binary.** Strict binary outcome is closer to
RLVR, but on a 1.5B policy it pushes rewards to the floor and collapses
group variance — the `frac_reward_zero_std` failure mode. Graded with a floor
keeps the gradient.

## `benchmark/tasks.py` migrated to `TaskSpec`

The file the TODO names by hand-maintained two ground-truth lists until now.
`download_01` / `translate_01` / `cache_01` declared only `expected_tools`,
which meant `argument_match_score` returned `None` and the argument component
dropped out of the weighted denominator entirely — tasks ran, scores came out,
arguments went unchecked.

That was measurable: `random_tool` scored a **perfect 1.000** on those three
whenever it happened to draw the right tool name, because no argument oracle
existed to catch it.

`composite_01`'s second step was `None` ("skip argument checking, the ref is
dynamic"). The premise was wrong: the task says "然后下载第1篇", and `ref` is a
1-based ordinal, so `{"ref": 1}` is static and checkable.

`TaskSpec` gains a `depends_on` field to carry the existing dependency chain.

## Per-category health gate

`--min-category-gap` (default `0.3`) alongside the existing aggregate gate.
Rows where a policy reproduced the reference trajectory are excluded — on
`infeasible` tasks `always_finish` **is** the reference solution, and that is
not a leak.

Verified against the pre-fix scorer:

```
old code · aggregate gate    : PASS
old code · per-category gate : FAIL
   - search/always_search: reference gap 0.167 is below required 0.300
```

## Results

58-task expanded set, seed 42, 20 random samples:

| Policy | mean before | mean after |
|---|---:|---:|
| `reference` | 1.000 | 1.000 |
| `always_finish` | −0.122 | −0.141 |
| `always_search` | 0.168 | **0.021** |
| `random_tool` | 0.086 | **−0.053** |

Per category, the two that were leaking:

| Category | `always_search` before | after |
|---|---:|---:|
| search | 0.833 | **0.446** |
| infeasible | +0.165 | **−0.235** |

Every category now clears the 0.3 gate on both task sets.

**Residual.** `always_search` still averages 0.446 on search tasks. Format,
tool and process are legitimately earned there, and only one of three
parameters is wrong. Pushing it lower would require weighting semantically
central parameters like `aspect` above `days` / `max_results`, which
introduces per-task tuning. Left alone deliberately.

## Tests

`173 → 184 passed`. The remaining `3 failed / 3 error` are a missing local
`trl` install and network-dependent tests; identical on `main`.

- `tests/test_reward_discrimination.py` (new) — per-category gap guard over
  both task sets, reusing `category_gap_failures` so the CLI and the test
  share one implementation; `tasks.py` derivation invariants.
- `tests/test_baselines.py` — the per-category gate catches what the aggregate
  mean dilutes; it does not fire on `infeasible`/`always_finish`.
- `tests/test_benchmark_offline.py` — `[]` vs `None`, expected-`None` values,
  tool-identity gating.
- `tests/test_multigranular_reward.py` — three tests pinned the old semantics
  and were rewritten, including
  `test_composite_task_skips_dynamic_download_arguments`, whose premise the
  tool signature contradicts.
