### PR TITLE
docs(es): sync benchmark task count with code (7 -> 8) and add search_04

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -227,7 +227,7 @@ AgenticArXiv-RL/
 │  │  └─ cache_status_tool.py      # Consulta de caché
 │  ├─ benchmark/                     # ⭐ Fuente de Verifiable Reward
 │  │  ├─ metrics.py               # TaskMetrics, coincidencia estricta de herramientas y parámetros
-│  │  ├─ tasks.py                 # BENCHMARK_TASKS (7 semillas de tareas)
+│  │  ├─ tasks.py                 # BENCHMARK_TASKS (8 semillas de tareas)
 │  │  ├─ runner.py                 # Ejecutor de benchmarks
 │  │  ├─ run_benchmark.py          # Entrada de benchmark por CLI
 │  │  └─ report.py                 # Informe de métricas
@@ -329,13 +329,14 @@ print(f'Reward: {reward:.2f}')  # Esperado: ~1.5
 
 ## 🧪 Conjunto de Tareas de Prueba
 
-Provenientes de `benchmark/tasks.py`, contienen 7 tareas:
+Provenientes de `benchmark/tasks.py`, contienen 8 tareas:
 
 | ID | Tarea | Tipo | Herramienta Esperada |
 |----|------|------|---------|
 | `search_01` | Buscar papers de IA de los últimos 7 días | Búsqueda | `get_recently_submitted_cs_papers` |
 | `search_02` | Obtener papers de ML de los últimos 3 días | Búsqueda | `get_recently_submitted_cs_papers` |
 | `search_03` | Buscar papers de NLP de los últimos 7 días | Búsqueda | `get_recently_submitted_cs_papers` |
+| `search_04` | Buscar papers de todas las categorías de ciencias de la computación de los últimos 7 días | Búsqueda | `get_recently_submitted_cs_papers` |
 | `download_01` | Descargar PDF del 1er paper | Descarga | `download_arxiv_pdf` |
 | `translate_01` | Traducir el 1er paper | Traducción | `translate_arxiv_pdf` |
 | `cache_01` | Ver estado de caché del 1er paper | Caché | `get_paper_cache_status` |
@@ -475,7 +476,7 @@ Ordenado por prioridad. ¡Las contribuciones son bienvenidas (ver 🤝 Contribui
 
 ### P1 — Medio plazo (datos y evaluación)
 
-- [ ] **Ampliar el conjunto de tareas**: `benchmark/tasks.py` tiene solo 7 tareas; ampliarlo a 50+ y derivar automáticamente `expected_tools` / `expected_tool_args`.
+- [ ] **Ampliar el conjunto de tareas**: `benchmark/tasks.py` tiene solo 8 tareas; ampliarlo a 50+ y derivar automáticamente `expected_tools` / `expected_tool_args`.
 - [ ] **eval/ badcase replay (reproducción de casos malos)**: el directorio `eval/` del árbol no existe aún; implementar `eval_cases.jsonl` + `badcase_replay.py` para cerrar el bucle.
 - [ ] **Investigación de reward hacking**: ampliar `RewardVarianceGuard` / `CanaryCallback` con una biblioteca de casos de reward hacking y ajuste de pesos del currículum.
 


### PR DESCRIPTION
## 变更内容

`README.es-ES.md` 中的 benchmark 冒烟任务数量仍写的是 7，且任务表格漏掉了 `search_04`，与代码 `AgenticArxiv/benchmark/tasks.py`（8 条任务：`search_01-04`、`download_01`、`translate_01`、`cache_01`、`composite_01`）和英文版 README 不一致。英文版在 `c7f498c` 已同步为 8 条并补上 `search_04`，西语版漏更。

本次同步 4 处：
- 目录树注释：`BENCHMARK_TASKS (7 semillas de tareas)` → `(8 semillas de tareas)`
- 任务集表格标题：`contienen 7 tareas` → `contienen 8 tareas`
- 任务表格补充 `search_04` 行（检索全部计算机科学方向论文）
- P1 TODO 数量：`solo 7 tareas` → `solo 8 tareas`

## 为什么改

消除西语文档与代码/英文版的事实漂移：文档声称 7 个任务，实际代码是 8 个，用户按文档可能漏掉 `search_04` 的测试用例。

## 怎么验证的

- `AgenticArxiv/benchmark/tasks.py` 确认 `search_04` 存在（`aspect="*"`），共 8 条 `TaskSpec`
- 修复后西语表格行数与英文版逐行对齐（均 8 行）
- `README.es-ES.md` 中 `search_04` 翻译与英文版描述一致

## 关联

无关联 issue。