### PR TITLE
docs(benchmark): fix plot command working directory

### DIFF
--- a/AgenticArxiv/benchmark/readme.md
+++ b/AgenticArxiv/benchmark/readme.md
@@ -64,7 +64,7 @@ python -m benchmark.run_baselines --task-set expanded --seed 42 --random-samples
 ## 绘图
 
 ```bash
-cd AgenticArXiv  # 项目根目录
+cd ..  # 回到仓库根目录（draw/ 与 data/ 位于根目录，不在 AgenticArxiv/ 内；已在根目录时可跳过）
 
 # 使用默认路径（读 data/raw_data.csv，输出到 draw/images/）
 python draw/plot.py


### PR DESCRIPTION
## 变更内容

`AgenticArxiv/benchmark/readme.md` 中「绘图」代码块先 `cd AgenticArxiv` 再执行 `python draw/plot.py`，但 `draw/` 与 `data/` 实际位于**仓库根目录**（不在 `AgenticArxiv/` 包内），因此该命令必然失败（`No such file or directory`）。本改动将工作目录改回仓库根目录，并注明原因。

## 为什么改

文档命令与真实目录结构不符：从 `AgenticArxiv/` 下运行 `python draw/plot.py` 会找不到 `draw/plot.py` 和 `data/raw_data.csv`，照文档执行必然报错。

## 怎么验证的

- `draw/plot.py` 与 `data/raw_data.csv` 仅在仓库根目录存在（`AgenticArxiv/draw/plot.py`、`AgenticArxiv/data/raw_data.csv` 均不存在）
- 修复后命令从仓库根目录执行即可读到默认路径

## 关联

无关联 issue。