### PR TITLE
feat(benchmark): add parameter-boundary infeasible case & wrong_args degenerate baseline policy

### DIFF
--- a/AgenticArxiv/benchmark/baselines.py
+++ b/AgenticArxiv/benchmark/baselines.py
@@ -103,6 +103,30 @@ class RandomToolPolicy(BaselinePolicy):
         return _result([_tool_step(name, args), _finish_step()])
 
 
+class WrongArgsPolicy(BaselinePolicy):
+    """Replay the reference tool names but with deliberately wrong arguments so that triggers the arg_score check."""
+
+    name = "wrong_args"
+
+    _WRONG_ARGS_BY_TOOL = {
+        "get_recently_submitted_cs_papers": {
+            "aspect": "nonexistent_topic", "days": 7, "max_results": 5,
+        },
+        "download_arxiv_pdf": {"ref": -1},
+        "translate_arxiv_pdf": {"ref": -1},
+        "get_paper_cache_status": {"ref": -1},
+    }
+
+    def build_result(self, task: Mapping[str, Any], seed: int) -> Dict[str, Any]:
+        expected_tools = task.get("expected_tools", [])
+        history = [
+            _tool_step(name, self._WRONG_ARGS_BY_TOOL.get(name, {"ref": -1}))
+            for name in expected_tools
+        ]
+        history.append(_finish_step())
+        return _result(history)
+
+
 ALL_POLICIES: Dict[str, BaselinePolicy] = {
     policy.name: policy
     for policy in (
@@ -110,6 +134,7 @@ ALL_POLICIES: Dict[str, BaselinePolicy] = {
         AlwaysFinishPolicy(),
         AlwaysSearchPolicy(),
         RandomToolPolicy(),
+        WrongArgsPolicy(),
     )
 }
 

--- a/AgenticArxiv/benchmark/tasks_expanded.py
+++ b/AgenticArxiv/benchmark/tasks_expanded.py
@@ -569,6 +569,15 @@ _INFEASIBLE: List[TaskSpec] = [
         note='会话里只有 5 篇；正确反应是说明做不到，而不是编一个 ref 去调用',
     ),
     TaskSpec(
+        id='infeasible_zero_index',
+        task='下载第0篇论文',
+        category='infeasible',
+        difficulty='hard',
+        setup=_SEED_AI5,
+        note='ref 从 1 起编号，0 是非法索引；正确反应是说明做不到，'
+             '而不是编一个 ref 去调用（与 infeasible_index_out_of_range 互补：前者测上界越界，这条测下界边界）',
+    ),
+    TaskSpec(
         id='infeasible_unknown_id',
         task='下载 2999.99999v1 这篇论文',
         category='infeasible',

--- a/AgenticArxiv/tests/test_baselines.py
+++ b/AgenticArxiv/tests/test_baselines.py
@@ -125,6 +125,25 @@ class BaselineDiagnosticTest(unittest.TestCase):
             for f in category_gap_failures(results, min_gap=0.3)
         ))
 
+    def test_parameter_boundary_infeasible_case_rejects_tool_calls(self):
+        """zero_index：参数非法时正确行为是不调工具，weak policy 必然掉分。"""
+        task = next(t for t in self.tasks if t["id"] == "infeasible_zero_index")
+        results = evaluate_baselines(
+            [task], resolve_policies(["always_search", "random_tool"]),
+            seed=42, training_step=100,
+        )
+        self.assertTrue(all(r.reward < 1.0 for r in results))
+
+    def test_wrong_args_policy_triggers_arg_score_gate(self):
+        """wrong_args：工具名对、参数出错，arg_score 必须低于 reference。"""
+        summaries = {s.policy: s for s in summarize_baselines(
+            self._results(["reference", "wrong_args"])
+        )}
+        self.assertLess(
+            summaries["wrong_args"].mean_arg_score,
+            summaries["reference"].mean_arg_score,
+        )
+
     def test_markdown_labels_finish_as_a_separate_signal(self):
         results = self._results(["reference", "always_finish"])
         summaries = summarize_baselines(results)


### PR DESCRIPTION
## 改动

### 1. 新增 infeasible case：`infeasible_zero_index`

- 与 `infeasible_index_out_of_range` 互补：上界越界 + 下界非法，覆盖 ref 边界的两端
- 文件：`tasks_expanded.py`
- 任务："下载第0篇论文"，添加参数边界不可行的 infeasible case
- 正确行为：不调任何工具（与现有 4 条 infeasible case 同构，走 `steps=()` 机制）

### 2. 新增退化策略：`WrongArgsPolicy`

- 现有 4 个退化策略基本失败在工具名层面，新增WrongArgsPolicy填充变量 arg_score 闸的盲区
- 文件：`baselines.py`
- 设计：复用参考解的工具名（让 `_tool_score` 放行），但按工具类型分别填错参数
- 注册进 `ALL_POLICIES`，让所有跑全局的策略健康检查自动覆盖它