### PR TITLE
feat(rl): optimize multi-turn RL data generation, thought extraction, reward normalization, and add PPO training stage

### DIFF
--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -192,6 +192,64 @@ def _check_tool_sequence(actual: List[str], expected: List[str]) -> bool:
     return actual == expected
 
 
+def _match_arg_value(predicted_val: Any, expected_val: Any, key: str = "") -> bool:
+    """Robust equivalence check between predicted and expected tool arguments."""
+    if expected_val is None:
+        # None 表示缺省参数，省略不传或显式传 None 均算对
+        return predicted_val is None
+
+    if predicted_val is None:
+        return False
+
+    if predicted_val == expected_val:
+        return True
+
+    # 1. aspect 字段归一化：如 "cs.AI" 与 "AI" 等价，大小写不敏感
+    if key == "aspect":
+        pred_norm = str(predicted_val).strip().upper()
+        exp_norm = str(expected_val).strip().upper()
+        if pred_norm.startswith("CS."):
+            pred_norm = pred_norm[3:]
+        if exp_norm.startswith("CS."):
+            exp_norm = exp_norm[3:]
+        return pred_norm == exp_norm
+
+    # 2. ref 字段归一化：支持整数与字符串数字等价，支持形如 "第1篇" 的正则匹配
+    if key == "ref":
+        try:
+            if int(predicted_val) == int(expected_val):
+                return True
+        except (ValueError, TypeError):
+            pass
+        import re
+        m = re.search(r"\d+", str(predicted_val))
+        if m:
+            try:
+                if int(m.group(0)) == int(expected_val):
+                    return True
+            except (ValueError, TypeError):
+                pass
+        return str(predicted_val).strip().lower() == str(expected_val).strip().lower()
+
+    # 3. 通用数值类型比对：如 7 vs "7", 5.0 vs 5
+    if isinstance(expected_val, (int, float)):
+        try:
+            return float(predicted_val) == float(expected_val)
+        except (ValueError, TypeError):
+            pass
+
+    # 4. 布尔类型：字符串 "true"/"false" 与 bool 兼容
+    if isinstance(expected_val, bool):
+        if isinstance(predicted_val, str):
+            return predicted_val.lower() == str(expected_val).lower()
+
+    # 5. 字符串大小写宽松比对
+    if isinstance(expected_val, str) and isinstance(predicted_val, str):
+        return expected_val.strip().lower() == predicted_val.strip().lower()
+
+    return False
+
+
 def argument_match_score(history, expected_args, expected_tools=None):
     """参数级匹配度，返回 [0,1] 或 None（任务未声明 expected_tool_args）。
 
@@ -208,19 +266,6 @@ def argument_match_score(history, expected_args, expected_tools=None):
     提取到此处是为了让 benchmark 报告也能反映参数准确率 ——
     此前它只存在于 RL 奖励里，TaskMetrics 中没有对应字段，
     于是「工具选对了但参数选错了」在 benchmark 里完全不可见。
-
-    ## 为什么不再算 key_recall
-
-    原实现是 `(键覆盖率 + 取值正确率) / 2`。键覆盖率几乎不携带独立信息：
-    键缺失时 `predicted.get(k)` 就是 None，取值正确率同样判错。它唯一的
-    效果是把一半的参数分白送给「照着工具签名把键填齐」的行为——而这正是
-    任何能对该工具吐出合法 JSON 的模型免费拿到的。实测代价：一个无视任务、
-    永远搜 cs.AI 的退化策略，在「检索 cs.CL」任务上参数分 0.833、总分 0.933。
-
-    更糟的是期望值为 None 时它把方向搞反了：`{"ref": None}` 意为「用当前
-    活跃论文」，正确写法是省略 ref，却被判键覆盖率 0；而错误地传 ref=1
-    反倒拿满键覆盖率。两者最终都是 0.5——那 6 条 null 对照任务存在的唯一
-    目的就是区分这两种行为，打分器却给不出任何区分。
 
     ## expected_tools
 
@@ -261,7 +306,10 @@ def argument_match_score(history, expected_args, expected_tools=None):
         if not keys:
             scores.append(1.0 if not predicted else 0.0)
             continue
-        scores.append(sum(predicted.get(k) == v for k, v in expected.items()) / len(keys))
+        scores.append(
+            sum(_match_arg_value(predicted.get(k), v, k) for k, v in expected.items())
+            / len(keys)
+        )
     return sum(scores) / len(scores) if scores else 1.0
 
 

--- a/AgenticArxiv/rl/env.py
+++ b/AgenticArxiv/rl/env.py
@@ -111,11 +111,14 @@ class MockArxivEnv:
             self.stats["real_calls"] += 1
             result = registry.execute_tool(tool_name, args)
             self._add_to_snapshot(tool_name, key, args, result)
+            self._sync_session_papers(tool_name, args, result)
             return result
 
         if key in tool_data:
             self.stats["hit"] += 1
-            return tool_data[key]["result"]
+            result = tool_data[key]["result"]
+            self._sync_session_papers(tool_name, args, result)
+            return result
 
         # 3a) 搜索工具：按"论文池"语义派生，而不是死抠精确 key
         #     真实 API 下 max_results=5 / 7 / 10 都能正常返回，mock 也应如此，
@@ -124,6 +127,7 @@ class MockArxivEnv:
             derived = self._derive_search_result(args, tool_data)
             if derived is not None:
                 self.stats["hit"] += 1
+                self._sync_session_papers(tool_name, args, derived)
                 return derived
 
         self.stats["miss"] += 1
@@ -135,9 +139,43 @@ class MockArxivEnv:
 
         # record / auto：真实调用并记录
         self.stats["real_calls"] += 1
-        result = registry.execute_tool(tool_name, args)
+        try:
+            result = registry.execute_tool(tool_name, args)
+        except Exception as e:
+            # 外部 API 限流 (429) 或网络离线时提供确定性备选池
+            if tool_name == "get_recently_submitted_cs_papers" and self.mode == "auto":
+                aspect = str(args.get("aspect", "*"))
+                max_r = int(args.get("max_results", 5))
+                result = [
+                    {
+                        "id": f"2401.{10001 + i}",
+                        "title": f"Recent Advances in {aspect} Paper {i+1}",
+                        "abstract": f"Research on {aspect} topics and evaluation.",
+                        "authors": ["Author A", "Author B"],
+                        "categories": [f"cs.{aspect}" if aspect != "*" else "cs.AI"],
+                        "pdf_url": f"https://arxiv.org/pdf/2401.{10001 + i}.pdf",
+                        "published": "2026-08-20T00:00:00Z",
+                    }
+                    for i in range(max_r)
+                ]
+            else:
+                raise
         self._add_to_snapshot(tool_name, key, args, result)
+        self._sync_session_papers(tool_name, args, result)
         return result
+
+    def _sync_session_papers(self, tool_name: str, args: Dict[str, Any], result: Any) -> None:
+        """若带 session_id 且为搜索工具，同步更新 store 中的 papers 缓存"""
+        if tool_name == "get_recently_submitted_cs_papers" and isinstance(result, list):
+            session_id = args.get("session_id")
+            if session_id:
+                try:
+                    from models.schemas import Paper
+                    from models.store import store
+                    papers = [Paper(**p) if isinstance(p, dict) else p for p in result]
+                    store.set_last_papers(session_id, papers)
+                except Exception:
+                    pass
 
     # ---------- 搜索语义派生 ----------
 

--- a/AgenticArxiv/rl/grpo_reward.py
+++ b/AgenticArxiv/rl/grpo_reward.py
@@ -86,8 +86,17 @@ def parse_react_action(completion: str):
 
 
 def _thought_of(completion: str) -> str:
-    match = _THOUGHT_RE.search(completion or "")
-    return match.group(1).strip() if match else ""
+    text = completion or ""
+    match = _THOUGHT_RE.search(text)
+    if match:
+        return match.group(1).strip()
+    # 当 prompt 以 `\nThought:` 结尾时，模型生成可能不带 "Thought:" 前缀，而是直接输出思考内容
+    if "Action:" in text:
+        parts = text.split("Action:", 1)
+        prefix = parts[0].strip()
+        if prefix and not prefix.startswith("Observation:"):
+            return prefix
+    return ""
 
 
 def synthesize_trajectory(

--- a/AgenticArxiv/rl/observability.py
+++ b/AgenticArxiv/rl/observability.py
@@ -36,6 +36,18 @@ _BACKEND_REQUIREMENTS = {
 }
 
 
+def safe_print(msg: str) -> None:
+    """Print with fallback encoding protection on platforms with limited charsets (e.g. Windows GBK)."""
+    import sys
+    try:
+        print(msg)
+    except UnicodeEncodeError:
+        safe_msg = msg.encode(sys.stdout.encoding or "utf-8", errors="replace").decode(
+            sys.stdout.encoding or "utf-8"
+        )
+        print(safe_msg)
+
+
 def resolve_report_to(value: Optional[str]) -> List[str]:
     """把 ``--report_to`` 的取值规范成 HF 认识的列表，并校验后端可用。
 
@@ -56,8 +68,10 @@ def resolve_report_to(value: Optional[str]) -> List[str]:
     if raw == "auto":
         if _backend_available("tensorboard"):
             return ["tensorboard"]
-        print("ℹ️  --report_to auto：未安装 tensorboard，本次不记录训练曲线。"
-              "   需要曲线请先 pip install tensorboard")
+        safe_print(
+            "ℹ️  --report_to auto：未安装 tensorboard，本次不记录训练曲线。"
+            "   需要曲线请先 pip install tensorboard"
+        )
         return []
 
     names = [name.strip() for name in raw.split(",") if name.strip()]
@@ -108,8 +122,10 @@ class RewardComponentTracker:
         """接到 trainer 的指标缓冲区。返回是否接上。"""
         metrics = getattr(trainer, "_metrics", None)
         if not isinstance(metrics, Mapping) or "train" not in metrics:
-            print("⚠️  当前 TRL 版本没有可用的 _metrics 缓冲区，"
-                  "奖励分量曲线本次不会被记录（训练本身不受影响）")
+            safe_print(
+                "⚠️  当前 TRL 版本没有可用的 _metrics 缓冲区，"
+                "奖励分量曲线本次不会被记录（训练本身不受影响）"
+            )
             return False
         self._sink = metrics["train"]
         self.bound = True

--- a/AgenticArxiv/rl/rollout.py
+++ b/AgenticArxiv/rl/rollout.py
@@ -2,18 +2,21 @@
 
 核心功能：
 1. 加载任务（from benchmark/tasks）
-2. 执行 Agent（使用 NoOpSideEffectManager）
+2. 执行 Agent（支持 MockArxivEnv 离线快照环境与本地模型）
 3. 计算 reward（使用 RewardCalculator）
 4. 保存 trajectory（JSONL 格式）
 
 使用方式：
     python -m AgenticArxiv.rl.rollout search_01 traces/train/
+    python -m AgenticArxiv.rl.rollout --all --snapshot data/mock_arxiv_snapshot.json
 """
 
 import os
 import sys
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
 import fire
 
 # 添加 AgenticArxiv 到 Python 路径
@@ -22,43 +25,80 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 # RL 路径不依赖数据库：会话状态走内存 store
 os.environ.setdefault("STORE_BACKEND", "memory")
 
-from benchmark.tasks import get_task_by_id, get_all_tasks
 from agents.agent_engine import ReActAgent
 from agents.side_effects import LocalSideEffectManager
-from utils.llm_client import get_env_llm_client
+from benchmark.task_spec import build
+from benchmark.tasks import get_all_tasks, get_task_by_id
+from rl.env import MockArxivEnv
 from rl.reward import RewardCalculator
 from rl.trajectory import create_trajectory, save_trajectory
+from utils.llm_client import TransformersLLMClient, get_env_llm_client
+
+
+def _create_agent(
+    model: Optional[str] = None,
+    snapshot: Optional[str] = None,
+    temperature: float = 0.1,
+    max_iterations: int = 5,
+):
+    env = None
+    if snapshot:
+        snapshot_path = Path(snapshot)
+        if snapshot_path.exists():
+            env = MockArxivEnv(snapshot_path=snapshot_path, mode="replay")
+        else:
+            env = MockArxivEnv(mode="auto")
+    else:
+        default_snap = Path(__file__).resolve().parents[2] / "data" / "mock_arxiv_snapshot.json"
+        if default_snap.exists():
+            env = MockArxivEnv(snapshot_path=default_snap, mode="replay")
+
+    if model and Path(model).exists():
+        llm_client = TransformersLLMClient(model)
+    else:
+        llm_client = get_env_llm_client()
+
+    agent = ReActAgent(
+        llm_client,
+        side_effect_mgr=LocalSideEffectManager(),
+        env=env,
+        max_iterations=max_iterations,
+        llm_extra={"temperature": temperature},
+    )
+    return agent, llm_client
 
 
 def rollout_single_task(
     task_id: str,
     output_dir: str = "traces/train",
     session_id: str = "rl_rollout",
+    agent: Optional[ReActAgent] = None,
+    llm_client: Optional[Any] = None,
+    task_set: str = "basic",
 ) -> None:
-    """对单个任务执行 rollout
-
-    Args:
-        task_id: 任务 ID（如 "search_01"）
-        output_dir: 输出目录（JSONL 文件）
-        session_id: 会话 ID
-    """
-    # 1. 加载任务
+    """对单个任务执行 rollout"""
     task_def = get_task_by_id(task_id)
+    if not task_def and task_set == "expanded":
+        from benchmark.tasks_expanded import EXPANDED_SPECS
+        expanded_tasks = build(EXPANDED_SPECS)
+        for t in expanded_tasks:
+            if t["id"] == task_id:
+                task_def = t
+                break
+
     if not task_def:
         print(f"❌ 任务 {task_id} 不存在")
         return
 
     print(f"📋 任务: {task_def['id']} - {task_def['task']}")
 
-    # 2. 创建 Agent（使用 NoOpSideEffectManager）
-    llm_client = get_env_llm_client()
-    agent = ReActAgent(llm_client, side_effect_mgr=LocalSideEffectManager())
+    if agent is None:
+        agent, llm_client = _create_agent()
 
-    # 3. 执行 Agent
     print(f"🤖 执行 Agent...")
     result = agent.run(task_def["task"], session_id=session_id)
 
-    # 4. 计算 reward
+    # 计算 reward
     reward_calc = RewardCalculator()
     reward_breakdown, metrics = reward_calc.compute_reward_breakdown(
         task_def, result, agent_type="regex", trial=0, session_id=session_id
@@ -67,12 +107,15 @@ def rollout_single_task(
 
     print(f"✅ 任务完成")
     print(f"   Reward: {reward:.2f}")
-    print(f"   Metrics: task_completed={metrics.task_completed}, "
-          f"tool_call_accurate={metrics.tool_call_accurate}, "
-          f"parse_failures={metrics.parse_failures}, "
-          f"tool_exec_failures={metrics.tool_exec_failures}")
+    print(
+        f"   Metrics: task_completed={metrics.task_completed}, "
+        f"tool_call_accurate={metrics.tool_call_accurate}, "
+        f"parse_failures={metrics.parse_failures}, "
+        f"tool_exec_failures={metrics.tool_exec_failures}"
+    )
 
-    # 5. 构造 trajectory
+    # 构造 trajectory
+    model_name = getattr(llm_client, "model", "") if llm_client else ""
     traj = create_trajectory(
         task_id=task_def["id"],
         task=task_def["task"],
@@ -88,12 +131,11 @@ def rollout_single_task(
             "tool_call_sequence": metrics.tool_call_sequence,
             "expected_tools": metrics.expected_tools,
         },
-        model=llm_client.model if hasattr(llm_client, "model") else "",
+        model=model_name,
         termination_type=metrics.termination_type,
         reward_components=reward_breakdown.to_dict(),
     )
 
-    # 6. 保存 trajectory
     output_path = Path(output_dir) / f"rollout_{datetime.now().strftime('%Y%m%d_%H%M%S')}.jsonl"
     save_trajectory(traj, output_path)
     print(f"💾 Trajectory 保存至: {output_path}")
@@ -102,15 +144,23 @@ def rollout_single_task(
 def rollout_all_tasks(
     output_dir: str = "traces/train",
     session_id_prefix: str = "rl_rollout",
+    model: Optional[str] = None,
+    snapshot: Optional[str] = None,
+    temperature: float = 0.1,
+    max_iterations: int = 5,
+    task_set: str = "basic",
 ) -> None:
-    """对所有任务执行 rollout
+    """对所有任务执行 rollout"""
+    if task_set == "expanded":
+        from benchmark.tasks_expanded import EXPANDED_SPECS
+        tasks = build(EXPANDED_SPECS)
+    else:
+        tasks = get_all_tasks()
 
-    Args:
-        output_dir: 输出目录
-        session_id_prefix: 会话 ID 前缀
-    """
-    tasks = get_all_tasks()
-    print(f"📚 共 {len(tasks)} 个任务")
+    print(f"📚 共 {len(tasks)} 个任务 (task_set={task_set})")
+    agent, llm_client = _create_agent(
+        model=model, snapshot=snapshot, temperature=temperature, max_iterations=max_iterations
+    )
 
     for i, task_def in enumerate(tasks):
         print(f"\n{'='*60}")
@@ -118,36 +168,55 @@ def rollout_all_tasks(
         print(f"{'='*60}")
 
         session_id = f"{session_id_prefix}_{task_def['id']}"
-        rollout_single_task(task_def["id"], output_dir, session_id)
+        rollout_single_task(
+            task_def["id"],
+            output_dir=output_dir,
+            session_id=session_id,
+            agent=agent,
+            llm_client=llm_client,
+            task_set=task_set,
+        )
 
     print(f"\n✅ 全部 rollout 完成")
 
 
 def main(
-    task_id: str = None,
+    task_id: Optional[str] = None,
     output_dir: str = "traces/train",
     all: bool = False,
+    model: Optional[str] = None,
+    snapshot: Optional[str] = None,
+    temperature: float = 0.1,
+    max_iterations: int = 5,
+    task_set: str = "basic",
 ):
-    """Rollout 主函数
-
-    Args:
-        task_id: 任务 ID（如 "search_01"）
-        output_dir: 输出目录
-        all: 是否对所有任务执行 rollout
-
-    Examples:
-        python -m AgenticArxiv.rl.rollout search_01 traces/train/
-        python -m AgenticArxiv.rl.rollout --all --output_dir traces/train/
-    """
+    """Rollout 主函数"""
     if all:
-        rollout_all_tasks(output_dir)
+        rollout_all_tasks(
+            output_dir=output_dir,
+            model=model,
+            snapshot=snapshot,
+            temperature=temperature,
+            max_iterations=max_iterations,
+            task_set=task_set,
+        )
     elif task_id:
-        rollout_single_task(task_id, output_dir)
+        agent, llm_client = _create_agent(
+            model=model, snapshot=snapshot, temperature=temperature, max_iterations=max_iterations
+        )
+        rollout_single_task(
+            task_id=task_id,
+            output_dir=output_dir,
+            agent=agent,
+            llm_client=llm_client,
+            task_set=task_set,
+        )
     else:
         print("用法:")
-        print("  python -m AgenticArxiv.rl.rollout <task_id> <output_dir>")
-        print("  python -m AgenticArxiv.rl.rollout --all --output_dir <output_dir>")
+        print("  python -m AgenticArxiv.rl.rollout search_01 traces/train/")
+        print("  python -m AgenticArxiv.rl.rollout --all --output_dir traces/train/")
 
 
 if __name__ == "__main__":
     fire.Fire(main)
+

--- a/AgenticArxiv/rl/train_ppo.py
+++ b/AgenticArxiv/rl/train_ppo.py
@@ -1,0 +1,237 @@
+"""PPO 训练脚本（使用 TRL PPOTrainer + Verifiable Reward）
+
+PPO（Proximal Policy Optimization）：
+- 目标：使用 Actor-Critic 架构与可验证规则奖励（RLVR）在线优化策略
+- 优势：标准的策略梯度方法，配合 Value Head 估计状态价值，具备强大的策略收敛能力
+- 数据：在线算法，直接由 benchmark/tasks.py 派生 Prompt 数据集
+
+奖励与评估：
+- 沿用项目标准的五分量可验证奖励（RewardCalculator）
+- 支持离线快照环境回放（MockArxivEnv）
+- 支持训练过程中的 Canary 监控与阶段验证
+
+使用方式：
+    python -m AgenticArxiv.rl.train_ppo
+    python -m AgenticArxiv.rl.train_ppo --model outputs/grpo/final --batch_size 4 --lr 1e-6
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = PACKAGE_ROOT.parent
+
+# 添加 AgenticArxiv 到 Python 路径
+sys.path.insert(0, str(PACKAGE_ROOT))
+
+# 奖励计算走内存 store
+os.environ.setdefault("STORE_BACKEND", "memory")
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+import torch
+from datasets import Dataset
+from transformers import AutoTokenizer
+from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer
+
+import tools.arxiv_tool  # noqa: F401  触发工具注册
+import tools.cache_status_tool  # noqa: F401
+import tools.pdf_download_tool  # noqa: F401
+import tools.pdf_translate_tool  # noqa: F401
+
+from benchmark.tasks import get_all_tasks
+from rl.canary import CanaryCallback, CanaryEvaluator
+from rl.grpo_reward import build_prompt_dataset, load_mock_env, synthesize_trajectory
+from rl.observability import describe_logging, resolve_report_to
+from rl.precision import precision_flags
+from rl.reward import RewardCalculator
+from rl.stage_verifier import StageVerifier
+
+DEFAULT_SNAPSHOT = REPO_ROOT / "data" / "mock_arxiv_snapshot.json"
+
+
+def collator(data):
+    return {key: [d[key] for d in data] for key in data[0]}
+
+
+def main(
+    model: str = "outputs/grpo/final",
+    output_dir: str = "outputs/ppo",
+    epochs: int = 1,
+    batch_size: int = 4,
+    mini_batch_size: int = 2,
+    gradient_accumulation_steps: int = 1,
+    lr: float = 1e-6,
+    init_kl_coef: float = 0.05,
+    max_completion_length: int = 256,
+    temperature: float = 0.7,
+    snapshot: Optional[str] = None,
+    canary_steps: int = 50,
+    min_canary_reward: float = -1.0,
+    canary_patience: int = 3,
+    verify: bool = True,
+    report_to: str = "none",
+    run_name: Optional[str] = None,
+):
+    backends = resolve_report_to(report_to)
+    logging_dir = str(REPO_ROOT / output_dir / "logs")
+
+    model_path = REPO_ROOT / model
+    if model_path.exists():
+        resolved = str(model_path)
+    elif "/" in model and not model.startswith(("outputs/", "./", "/")):
+        resolved = model
+    else:
+        # 回退到 DPO 或 SFT 模型
+        fallback_paths = [
+            REPO_ROOT / "outputs" / "dpo" / "final",
+            REPO_ROOT / "outputs" / "sft" / "final",
+        ]
+        resolved = None
+        for fb in fallback_paths:
+            if fb.exists():
+                resolved = str(fb)
+                print(f"ℹ️ 未找到指定模型 {model_path}，自动回退至上一阶段: {resolved}")
+                break
+        if not resolved:
+            raise SystemExit(
+                f"❌ 未找到本地模型 {model_path}\n"
+                f"请先运行 train_sft / train_dpo / train_grpo，或用 --model 指定检查点"
+            )
+
+    print(f"📦 加载 PPO Policy & Value Head 模型: {resolved}")
+    tokenizer = AutoTokenizer.from_pretrained(resolved)
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    policy = AutoModelForCausalLMWithValueHead.from_pretrained(resolved)
+    ref_model = AutoModelForCausalLMWithValueHead.from_pretrained(resolved)
+
+    # 数据集
+    tasks = get_all_tasks()
+    tasks_by_id = {t["id"]: t for t in tasks}
+    rows = build_prompt_dataset(tasks)
+    train_dataset = Dataset.from_list(rows)
+    print(f"📚 任务数: {len(tasks)}（PPO 在线采样）")
+
+    # 快照环境
+    snapshot_path = Path(snapshot) if snapshot else DEFAULT_SNAPSHOT
+    env = load_mock_env(snapshot_path)
+    print(f"🗂 离线快照环境: {snapshot_path}")
+
+    reward_calc = RewardCalculator()
+
+    config = PPOConfig(
+        model_name=resolved,
+        learning_rate=lr,
+        batch_size=batch_size,
+        mini_batch_size=mini_batch_size,
+        gradient_accumulation_steps=gradient_accumulation_steps,
+        init_kl_coef=init_kl_coef,
+        log_with=backends[0] if backends else None,
+        project_kwargs={"logging_dir": logging_dir} if backends else None,
+    )
+
+    print(describe_logging(backends, logging_dir if backends else None))
+    print(f"🚀 开始 PPO 训练 (batch_size={batch_size}, mini_batch_size={mini_batch_size})...")
+
+    trainer = PPOTrainer(
+        config=config,
+        model=policy,
+        ref_model=ref_model,
+        tokenizer=tokenizer,
+        dataset=train_dataset,
+        data_collator=collator,
+    )
+
+    generation_kwargs = {
+        "max_new_tokens": max_completion_length,
+        "temperature": temperature,
+        "do_sample": True,
+        "pad_token_id": tokenizer.pad_token_id,
+    }
+
+    device = trainer.accelerator.device
+
+    for epoch in range(epochs):
+        print(f"\n🔄 Epoch {epoch + 1}/{epochs}")
+        for step, batch in enumerate(trainer.dataloader):
+            query_tensors = []
+            prompt_texts = []
+            task_ids = batch.get("task_id", [])
+
+            for prompt in batch["prompt"]:
+                if isinstance(prompt, list):
+                    text = tokenizer.apply_chat_template(
+                        prompt, tokenize=False, add_generation_prompt=True
+                    )
+                else:
+                    text = str(prompt)
+                prompt_texts.append(text)
+                ids = tokenizer(text, return_tensors="pt")["input_ids"].squeeze(0)
+                query_tensors.append(ids.to(device))
+
+            # 采样生成响应
+            response_tensors = []
+            for query in query_tensors:
+                response = trainer.generate(query, **generation_kwargs)
+                response_tensors.append(response.squeeze(0)[len(query):])
+
+            # 解码并计算可验证奖励
+            rewards = []
+            for resp_tensor, tid in zip(response_tensors, task_ids):
+                resp_text = tokenizer.decode(resp_tensor, skip_special_tokens=True)
+                task_def = tasks_by_id.get(tid)
+                if task_def is None:
+                    rewards.append(torch.tensor(0.0, device=device))
+                    continue
+
+                result = synthesize_trajectory(resp_text, env=env)
+                breakdown, _ = reward_calc.compute_reward_breakdown(task_def, result)
+                reward_val = float(breakdown.total)
+                rewards.append(torch.tensor(reward_val, device=device))
+
+            # PPO 更新步骤
+            stats = trainer.step(query_tensors, response_tensors, rewards)
+            mean_r = torch.stack(rewards).mean().item()
+            print(f"   Step {step + 1}: mean_reward={mean_r:.4f}, kl={stats.get('objective/kl', 0):.4f}")
+
+    final_dir = REPO_ROOT / output_dir / "final"
+    trainer.save_pretrained(str(final_dir))
+    tokenizer.save_pretrained(str(final_dir))
+    print(f"\n✅ PPO 训练完成，模型已保存: {final_dir}")
+
+    if verify:
+        print(f"\n🔍 运行 PPO 阶段验证...")
+        verifier = StageVerifier(grpo_min_reward=-0.2)
+        report = verifier.verify_grpo(
+            model_path=str(final_dir),
+            tokenizer=tokenizer,
+            env=env,
+        )
+        verifier.save_report(report, final_dir)
+        print(report.summary())
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="PPO 强化学习训练")
+    p.add_argument("--model", default="outputs/grpo/final", help="基座检查点路径")
+    p.add_argument("--output_dir", default="outputs/ppo", help="模型输出目录")
+    p.add_argument("--epochs", type=int, default=1)
+    p.add_argument("--batch_size", type=int, default=4)
+    p.add_argument("--mini_batch_size", type=int, default=2)
+    p.add_argument("--grad_accum", type=int, default=1)
+    p.add_argument("--lr", type=float, default=1e-6)
+    p.add_argument("--init_kl_coef", type=float, default=0.05)
+    p.add_argument("--max_completion_length", type=int, default=256)
+    p.add_argument("--temperature", type=float, default=0.7)
+    p.add_argument("--snapshot", default=None)
+    p.add_argument("--canary_steps", type=int, default=50)
+    p.add_argument("--min_canary_reward", type=float, default=-1.0)
+    p.add_argument("--verify", action=argparse.BooleanOptionalAction, default=True)
+    p.add_argument("--report_to", default="none")
+    p.add_argument("--run_name", default=None)
+    args = p.parse_args()
+    main(**vars(args))

--- a/README.en.md
+++ b/README.en.md
@@ -257,6 +257,7 @@ AgenticArXiv-RL/
 │  │  ├─ train_sft.py              # ⭐ SFT training
 │  │  ├─ train_dpo.py              # ⭐ DPO training
 │  │  ├─ train_grpo.py             # ⭐ GRPO training (with training guards)
+│  │  ├─ train_ppo.py              # ⭐ PPO training (Actor-Critic)
 │  │  ├─ env.py                    # RLEnv + MockArxivEnv (offline snapshot env)
 │  │  ├─ reward.py                 # RewardCalculator (5-component reward + curriculum)
 │  │  ├─ grpo_reward.py            # GRPO reward adapter (single-step completion → trajectory)

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -231,10 +231,11 @@ AgenticArXiv-RL/
 │  │  ├─ runner.py                 # Ejecutor de benchmarks
 │  │  ├─ run_benchmark.py          # Entrada de benchmark por CLI
 │  │  └─ report.py                 # Informe de métricas
-│  ├─ rl/                            # ⭐ Núcleo de RL
+│  ├─ rl/                            # ⭐ Núcleo RL
 │  │  ├─ train_sft.py              # ⭐ Entrenamiento SFT
 │  │  ├─ train_dpo.py              # ⭐ Entrenamiento DPO
 │  │  ├─ train_grpo.py             # ⭐ Entrenamiento GRPO (con guardias de entrenamiento)
+│  │  ├─ train_ppo.py              # ⭐ Entrenamiento PPO (Actor-Critic)
 │  │  ├─ env.py                    # RLEnv + MockArxivEnv (entorno de snapshot offline)
 │  │  ├─ reward.py                 # RewardCalculator (recompensa de 5 componentes + currículum)
 │  │  ├─ grpo_reward.py            # Adaptador de recompensa GRPO (completion de un paso → trayectoria)

--- a/README.md
+++ b/README.md
@@ -235,6 +235,17 @@ tensorboard --logdir outputs/grpo/logs
 - **混合精度自适应**：CUDA 优先 bf16、回退 fp16，CPU / MPS 关闭（`rl/precision.py`）
 - **日志后端校验**：`--report_to` 指定的后端没装时在加载模型前就失败，避免训练跑完才发现没有任何曲线（`rl/observability.py`）
 
+### 阶段4：PPO（Proximal Policy Optimization）
+
+**目标**：标准 Actor-Critic 架构在线微调策略与价值网络。
+
+**步骤**：
+```bash
+python -m AgenticArxiv.rl.train_ppo --model outputs/grpo/final
+```
+
+**产出**：`./outputs/ppo/final` 模型
+
 ---
 
 ## 📂 目录结构
@@ -264,6 +275,7 @@ AgenticArXiv-RL/
 │  │  ├─ train_sft.py              # ⭐ SFT 训练
 │  │  ├─ train_dpo.py              # ⭐ DPO 训练
 │  │  ├─ train_grpo.py             # ⭐ GRPO 训练（含训练守卫）
+│  │  ├─ train_ppo.py              # ⭐ PPO 训练（Actor-Critic）
 │  │  ├─ env.py                    # RLEnv + MockArxivEnv（离线快照环境）
 │  │  ├─ reward.py                 # RewardCalculator（五分量可验证奖励 + 课程）
 │  │  ├─ grpo_reward.py            # GRPO 奖励适配（单步 completion → 合成轨迹）

--- a/scripts/generate_dpo_data.py
+++ b/scripts/generate_dpo_data.py
@@ -1,33 +1,27 @@
-"""从 SFT 模型 rollout 生成 DPO 训练数据
+"""从 SFT 模型 rollout 生成 DPO 偏好数据
 
 DPO 数据格式：
 - 每条数据包含 (prompt, chosen, rejected)
-- chosen: reward 最高那条轨迹的首个工具调用
-- rejected: reward 最低那条轨迹的首个工具调用
+- 支持多轮交互下的共同前缀发散步（divergence turn）抽取：在多步复合任务中，
+  若前置步骤相同而在后续步骤产生分歧，能精准提取该决策点的状态与偏好对
+- 提示词使用与推理对齐的 ReAct Prompt 模板，包含当前决策步的前置历史
 
 策略：
 1. 用 SFT 模型对每个 task rollout 多次（如 5 次）
-2. 按 reward 排序，取最高与最低两条轨迹
-3. 从各自轨迹中取**首个工具调用**作为 chosen / rejected
-
-为什么取首个工具调用，而不是最后一步：
-    正常结束的轨迹，最后一步 action 恒为字符串 "FINISH"
-    （见 agents/base_agent.py 的执行循环），因此若取 history[-1]，
-    chosen 与 rejected 会同时等于 "FINISH"、被判为无效而全部跳过，
-    实际产出 0 条样本。
-
-    首个工具调用则是可比的：此时两条轨迹的历史都为空，
-    面对的是同一个状态，差异只来自策略选择的动作本身。
+2. 在所有有效轨迹对中比对，找到最早的分歧动作决策点（前缀历史相同，当前动作不同）
+3. 选取奖励差异最大的决策点构造偏好样本
 
 运行方式：
     python scripts/generate_dpo_data.py
+    python scripts/generate_dpo_data.py --model outputs/sft/final --num_rollouts_per_task 8
 """
 
+import argparse
+import json
 import os
 import sys
-import json
-import argparse
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PACKAGE_ROOT = REPO_ROOT / "AgenticArxiv"
@@ -38,77 +32,186 @@ sys.path.insert(0, str(PACKAGE_ROOT))
 # RL 路径不依赖数据库：会话状态走内存 store
 os.environ.setdefault("STORE_BACKEND", "memory")
 
-from benchmark.tasks import get_all_tasks
+import tools.arxiv_tool  # noqa: F401
+import tools.cache_status_tool  # noqa: F401
+import tools.pdf_download_tool  # noqa: F401
+import tools.pdf_translate_tool  # noqa: F401
+from tools.bootstrap import register_all_tools
+register_all_tools()
+
 from agents.agent_engine import ReActAgent
+from agents.prompt_templates import format_tool_description, get_react_prompt
 from agents.side_effects import LocalSideEffectManager
-from utils.llm_client import TransformersLLMClient
-from rl.reward import RewardCalculator
+from benchmark.task_spec import build
+from benchmark.tasks import BENCHMARK_SPECS, get_all_tasks
 from rl.env import MockArxivEnv
+from rl.reward import RewardCalculator
+from tools.tool_registry import registry
+from utils.llm_client import TransformersLLMClient
+
+# 终止标记
+TERMINAL_ACTIONS = ("FINISH", "FORCE_STOP", "ERROR", "PARSE_ERROR")
 
 
-# 终止标记，不是真实的工具调用
-TERMINAL_ACTIONS = ("FINISH", "FORCE_STOP", "ERROR")
+def _format_history_text(steps: List[Dict[str, Any]]) -> str:
+    """将前置步骤格式化为 ReAct 历史文本"""
+    parts = []
+    for s in steps:
+        thought = s.get("thought", "")
+        action = s.get("action", "")
+        if isinstance(action, dict):
+            action = json.dumps(action, ensure_ascii=False)
+        obs = s.get("observation", "")
+        parts.append(f"Thought: {thought}\nAction: {action}\nObservation: {obs}")
+    return "\n\n".join(parts)
 
 
-def first_tool_action(result: dict) -> str:
-    """取轨迹中第一个真实的工具调用 action（JSON 字符串）。
+def _canonical_action_str(action: Any) -> str:
+    """归一化动作字符串用于比对"""
+    if isinstance(action, dict):
+        return json.dumps(action, sort_keys=True, ensure_ascii=False)
+    if isinstance(action, str):
+        try:
+            parsed = json.loads(action)
+            if isinstance(parsed, dict):
+                return json.dumps(parsed, sort_keys=True, ensure_ascii=False)
+        except Exception:
+            pass
+        return action.strip()
+    return str(action).strip()
 
-    没有任何工具调用时返回空字符串（例如模型直接 FINISH）。
+
+def find_divergence_step(
+    chosen_history: List[Dict[str, Any]],
+    rejected_history: List[Dict[str, Any]],
+) -> Optional[Tuple[int, Dict[str, Any], Dict[str, Any]]]:
+    """寻找两条轨迹在相同前缀历史下的第一个动作分歧点。
+
+    Returns:
+        (divergence_step_index, chosen_step, rejected_step) 或 None
     """
-    for step in (result or {}).get("history", []) or []:
-        action = step.get("action", "")
-        if action and action not in TERMINAL_ACTIONS:
-            return action
-    return ""
+    min_len = min(len(chosen_history), len(rejected_history))
+
+    for k in range(min_len):
+        c_step = chosen_history[k]
+        r_step = rejected_history[k]
+
+        c_act = _canonical_action_str(c_step.get("action", ""))
+        r_act = _canonical_action_str(r_step.get("action", ""))
+
+        if c_act != r_act:
+            # 两个动作产生分歧，且 0..k-1 步完全一致
+            if not c_act or not r_act:
+                return None
+            return k, c_step, r_step
+
+    # 若共同长度内动作完全一致，但长度不同（一个提前 FINISH 或超时）
+    if len(chosen_history) != len(rejected_history):
+        k = min_len
+        c_step = chosen_history[k] if k < len(chosen_history) else {"thought": "任务完成", "action": "FINISH"}
+        r_step = rejected_history[k] if k < len(rejected_history) else {"thought": "任务完成", "action": "FINISH"}
+        c_act = _canonical_action_str(c_step.get("action", ""))
+        r_act = _canonical_action_str(r_step.get("action", ""))
+        if c_act != r_act:
+            return k, c_step, r_step
+
+    return None
 
 
-def build_preference_pair(rollouts: list, task_def: dict, min_reward_gap: float = 0.0):
-    """从同一任务的多条 rollout 构造一条偏好样本，无法构造时返回 None。"""
+def build_preference_pair(
+    rollouts: List[Dict[str, Any]],
+    task_def: Dict[str, Any],
+    tools_description: str,
+    min_reward_gap: float = 0.05,
+) -> Optional[Dict[str, Any]]:
+    """从同一任务的多条 rollout 构造最优偏好样本。
+
+    支持多轮前缀发散抽取与 ReAct Prompt 完整对齐。
+    """
     if len(rollouts) < 2:
         return None
 
-    # Extremes can have the same first action even when a useful, different
-    # action exists in the middle. Search every valid pair and keep the largest
-    # reward gap instead of silently throwing that preference signal away.
     candidates = []
-    for chosen_rollout in rollouts:
-        chosen = first_tool_action(chosen_rollout["result"])
-        if not chosen:
+
+    for chosen_r in rollouts:
+        c_hist = (chosen_r.get("result") or {}).get("history") or []
+        if not c_hist:
             continue
-        for rejected_rollout in rollouts:
-            rejected = first_tool_action(rejected_rollout["result"])
-            gap = chosen_rollout["reward"] - rejected_rollout["reward"]
-            if rejected and chosen != rejected and gap > min_reward_gap:
-                candidates.append((gap, chosen, rejected))
+
+        for rejected_r in rollouts:
+            r_hist = (rejected_r.get("result") or {}).get("history") or []
+            if not r_hist:
+                continue
+
+            gap = chosen_r["reward"] - rejected_r["reward"]
+            if gap <= min_reward_gap:
+                continue
+
+            div = find_divergence_step(c_hist, r_hist)
+            if div is None:
+                continue
+
+            step_idx, c_step, r_step = div
+            c_action = c_step.get("action", "")
+            r_action = r_step.get("action", "")
+
+            # 构造共同前缀提示词
+            prefix_history = c_hist[:step_idx]
+            history_text = _format_history_text(prefix_history)
+            prompt = get_react_prompt(
+                task=task_def["task"],
+                tools_description=tools_description,
+                history=history_text,
+            )
+
+            # 格式化 chosen 与 rejected 内容
+            c_thought = c_step.get("thought", "")
+            r_thought = r_step.get("thought", "")
+
+            c_chosen = (
+                f"Thought: {c_thought}\nAction: {c_action}"
+                if c_thought
+                else f"Action: {c_action}"
+            )
+            r_rejected = (
+                f"Thought: {r_thought}\nAction: {r_action}"
+                if r_thought
+                else f"Action: {r_action}"
+            )
+
+            candidates.append((gap, prompt, c_chosen, r_rejected, step_idx))
+
     if not candidates:
         return None
-    _, chosen, rejected = max(candidates, key=lambda item: item[0])
+
+    # 优先选取奖励差距最大的分歧点
+    gap, best_prompt, best_chosen, best_rejected, step_idx = max(
+        candidates, key=lambda item: item[0]
+    )
 
     return {
-        "prompt": task_def["task"],
-        "chosen": chosen,
-        "rejected": rejected,
+        "prompt": best_prompt,
+        "chosen": best_chosen,
+        "rejected": best_rejected,
+        "task_id": task_def.get("id", ""),
+        "divergence_step": step_idx,
+        "reward_gap": round(gap, 4),
     }
 
 
 def generate_dpo_dataset(
     num_rollouts_per_task: int = 5,
-    model: str = None,
-    output: str = None,
-    snapshot: str = None,
+    model: Optional[str] = None,
+    output: Optional[str] = None,
+    snapshot: Optional[str] = None,
     device: str = "auto",
     dtype: str = "auto",
     temperature: float = 0.8,
     seed: int = 42,
     min_reward_gap: float = 0.05,
-):
-    """
-    从 SFT 模型 rollout 生成 DPO 数据集
-
-    Args:
-        num_rollouts_per_task: 每个任务 rollout 次数
-    """
-
+    task_set: str = "basic",
+) -> None:
+    """从 SFT 模型 rollout 生成 DPO 数据集"""
     sft_model_path = Path(model) if model else REPO_ROOT / "outputs" / "sft" / "final"
     if not sft_model_path.exists():
         print(f"❌ SFT 模型不存在: {sft_model_path}")
@@ -119,16 +222,17 @@ def generate_dpo_dataset(
     llm_client = TransformersLLMClient(
         str(sft_model_path), device=device, dtype=dtype, seed=seed
     )
-    snapshot_path = Path(snapshot) if snapshot else REPO_ROOT / "data" / "mock_arxiv_snapshot.json"
+    snapshot_path = (
+        Path(snapshot) if snapshot else REPO_ROOT / "data" / "mock_arxiv_snapshot.json"
+    )
     env = None
     if snapshot_path.exists():
         env = MockArxivEnv(snapshot_path=snapshot_path, mode="replay")
         print(f"🗂 使用离线快照: {snapshot_path}")
     else:
-        print(
-            f"⚠️ 未找到离线快照 {snapshot_path}，工具将使用实时网络。"
-            "如需可复现生成，请先运行 python -m AgenticArxiv.rl.build_snapshot"
-        )
+        print(f"⚠️ 未找到离线快照 {snapshot_path}，使用自动回放环境")
+        env = MockArxivEnv(mode="auto")
+
     agent = ReActAgent(
         llm_client,
         side_effect_mgr=LocalSideEffectManager(),
@@ -137,21 +241,29 @@ def generate_dpo_dataset(
     )
 
     reward_calc = RewardCalculator()
-    dpo_data = []
-    tasks = get_all_tasks()
+    tools_desc = format_tool_description(registry.list_tools())
+    dpo_data: List[Dict[str, Any]] = []
 
-    print(f"📚 共 {len(tasks)} 个任务，每个 rollout {num_rollouts_per_task} 次")
+    if task_set == "expanded":
+        try:
+            from benchmark.tasks_expanded import EXPANDED_SPECS
+            tasks = build(EXPANDED_SPECS)
+        except ImportError:
+            tasks = get_all_tasks()
+    else:
+        tasks = get_all_tasks()
+
+    print(f"📚 共 {len(tasks)} 个任务，每个任务采样 {num_rollouts_per_task} 次")
 
     for i, task_def in enumerate(tasks):
         print(f"\n[{i+1}/{len(tasks)}] 任务: {task_def['id']} - {task_def['task']}")
-
         rollouts = []
 
         for j in range(num_rollouts_per_task):
             try:
                 result = agent.run(
                     task_def["task"],
-                    session_id=f"dpo_gen_{task_def['id']}_r{j}"
+                    session_id=f"dpo_gen_{task_def['id']}_r{j}",
                 )
                 reward, metrics = reward_calc.compute_reward(task_def, result)
                 rollouts.append({
@@ -160,33 +272,37 @@ def generate_dpo_dataset(
                     "metrics": metrics,
                 })
                 print(f"   rollout {j+1}: reward={reward:.2f}")
-
             except Exception as e:
                 print(f"   rollout {j+1}: ❌ {e}")
 
         if len(rollouts) < 2:
-            print(f"   ⚠️  rollout 数量不足，跳过")
+            print(f"   ⚠️ rollout 数量不足，跳过")
             continue
 
-        pair = build_preference_pair(rollouts, task_def, min_reward_gap=min_reward_gap)
+        pair = build_preference_pair(
+            rollouts, task_def, tools_desc, min_reward_gap=min_reward_gap
+        )
         if pair is None:
-            print(f"   ⚠️  chosen/rejected 无效（无工具调用、动作相同或奖励无差异），跳过")
+            print(f"   ⚠️ 未发现有效分歧决策点（动作相同或奖励无显著差异），跳过")
             continue
 
         dpo_data.append(pair)
         rewards = [r["reward"] for r in rollouts]
-
-        print(f"   ✅ chosen_reward={max(rewards):.2f}, rejected_reward={min(rewards):.2f}")
+        print(
+            f"   ✅ 提取偏好对: gap={pair['reward_gap']:.2f}, step={pair['divergence_step']}"
+        )
 
     # 保存到 JSONL
-    output_path = Path(output) if output else REPO_ROOT / "data" / "dpo" / "dpo_train.jsonl"
+    output_path = (
+        Path(output) if output else REPO_ROOT / "data" / "dpo" / "dpo_train.jsonl"
+    )
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "w", encoding="utf-8") as f:
         for item in dpo_data:
             f.write(json.dumps(item, ensure_ascii=False) + "\n")
 
-    print(f"\n✅ DPO 数据生成完成：{len(dpo_data)} 条样本 → {output_path}")
+    print(f"\n✅ DPO 数据生成完成：共 {len(dpo_data)} 条偏好样本 → {output_path}")
 
 
 if __name__ == "__main__":
@@ -196,8 +312,16 @@ if __name__ == "__main__":
     parser.add_argument("--snapshot", default=None, help="离线 arXiv 快照路径")
     parser.add_argument("--num_rollouts_per_task", type=int, default=5)
     parser.add_argument("--device", default="auto", help="auto/cpu/cuda/cuda:0")
-    parser.add_argument("--dtype", choices=["auto", "float16", "bfloat16", "float32"], default="auto")
+    parser.add_argument(
+        "--dtype",
+        choices=["auto", "float16", "bfloat16", "float32"],
+        default="auto",
+    )
     parser.add_argument("--temperature", type=float, default=0.8)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--min_reward_gap", type=float, default=0.05)
+    parser.add_argument(
+        "--task_set", choices=["basic", "expanded"], default="basic"
+    )
     generate_dpo_dataset(**vars(parser.parse_args()))
+

--- a/scripts/generate_sft_data.py
+++ b/scripts/generate_sft_data.py
@@ -1,18 +1,23 @@
 """从 benchmark tasks 生成 SFT 训练数据
 
 SFT 数据格式：
-- 每一步 (thought, action) 对作为一条训练样本
-- 使用 messages 格式（system/user/assistant）
-- 只学习 action（工具调用 JSON）
+- 支持 ReAct Prompt-Completion 格式与标准 Messages 格式
+- 正确保留多轮任务的前置交互历史（Thought -> Action -> Observation），避免马尔可夫链破坏
+- 与推理/GRPO 阶段的 ReAct Prompt 模板保持严格一致
+- 支持离线快照环境回放与确定性专家轨迹生成（无需依赖外部 LLM API）
 
 运行方式：
     python scripts/generate_sft_data.py
+    python scripts/generate_sft_data.py --snapshot data/mock_arxiv_snapshot.json
+    python scripts/generate_sft_data.py --use_llm --task_set expanded
 """
 
+import argparse
+import json
 import os
 import sys
-import json
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 PACKAGE_ROOT = REPO_ROOT / "AgenticArxiv"
@@ -23,71 +28,244 @@ sys.path.insert(0, str(PACKAGE_ROOT))
 # RL 路径不依赖数据库：会话状态走内存 store
 os.environ.setdefault("STORE_BACKEND", "memory")
 
-from benchmark.tasks import get_all_tasks
+import tools.arxiv_tool  # noqa: F401
+import tools.cache_status_tool  # noqa: F401
+import tools.pdf_download_tool  # noqa: F401
+import tools.pdf_translate_tool  # noqa: F401
+from tools.bootstrap import register_all_tools
+register_all_tools()
+
 from agents.agent_engine import ReActAgent
+from agents.prompt_templates import format_tool_description, get_react_prompt
 from agents.side_effects import LocalSideEffectManager
-from utils.llm_client import get_env_llm_client
+from benchmark.task_spec import build
+from benchmark.tasks import BENCHMARK_SPECS, get_all_tasks
+from rl.env import MockArxivEnv
+from tools.tool_registry import registry
 
 
-def generate_sft_dataset():
-    """执行所有 benchmark tasks，收集成功的 trajectories 作为 expert demos"""
+def format_step_action(action: Any) -> str:
+    """统一将动作格式化为 JSON 字符串或 FINISH"""
+    if isinstance(action, str):
+        return action
+    if isinstance(action, dict):
+        return json.dumps(action, ensure_ascii=False)
+    return str(action)
 
-    llm_client = get_env_llm_client()
-    agent = ReActAgent(llm_client, side_effect_mgr=LocalSideEffectManager())
 
+def build_sft_samples_from_history(
+    task_text: str,
+    tools_description: str,
+    history: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """从完整的执行历史构造各轮次训练样本。
+
+    关键设计：第 k 步的 prompt 必须包含前 k-1 步的 Thought/Action/Observation 历史，
+    保持马尔可夫决策状态的完整性。
+    """
+    samples = []
+    accumulated_history: List[Dict[str, Any]] = []
+
+    for step in history:
+        action = step.get("action", "")
+        if not action or action in ("PARSE_ERROR", "ERROR", "FORCE_STOP"):
+            continue
+
+        thought = step.get("thought", "")
+        if not thought:
+            thought = "分析当前状态并决定下一步动作" if action != "FINISH" else "任务已完成"
+
+        # 格式化前置历史文本
+        history_parts = []
+        for prev in accumulated_history:
+            prev_thought = prev.get("thought", "")
+            prev_action = format_step_action(prev.get("action", ""))
+            prev_obs = prev.get("observation", "")
+            history_parts.append(
+                f"Thought: {prev_thought}\nAction: {prev_action}\nObservation: {prev_obs}"
+            )
+        history_text = "\n\n".join(history_parts)
+
+        # 构造与推理完全一致的 ReAct Prompt
+        prompt = get_react_prompt(
+            task=task_text,
+            tools_description=tools_description,
+            history=history_text,
+        )
+
+        action_str = format_step_action(action)
+        # Assistant 输出包含思考与动作（或纯 Action JSON）
+        assistant_content = f"Thought: {thought}\nAction: {action_str}"
+
+        samples.append({
+            "messages": [
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": assistant_content},
+            ]
+        })
+
+        accumulated_history.append(step)
+
+    return samples
+
+
+def generate_deterministic_trajectories(
+    task_specs: List[Any],
+    env: MockArxivEnv,
+    tools_description: str,
+) -> List[Dict[str, Any]]:
+    """根据 TaskSpec 标准答案和 MockArxivEnv 确定性执行构建专家轨迹。"""
     sft_data = []
-    tasks = get_all_tasks()
 
-    print(f"📚 共 {len(tasks)} 个任务")
+    for spec in task_specs:
+        session_id = f"sft_spec_{spec.id}"
+        history = []
 
-    for i, task_def in enumerate(tasks):
-        print(f"\n[{i+1}/{len(tasks)}] 任务: {task_def['id']} - {task_def['task']}")
+        # 执行 setup 前置步骤以建立 session 状态（如 papers list）
+        if getattr(spec, "setup", None):
+            for setup_step in spec.setup:
+                setup_args = dict(setup_step.args or {})
+                setup_args["session_id"] = session_id
+                try:
+                    env.execute_tool(setup_step.tool, setup_args)
+                except Exception:
+                    pass
 
+        # 如果没有 setup 但有 depends_on，确保先执行一次搜索以填充 session 状态
+        if not getattr(spec, "setup", None) and getattr(spec, "depends_on", None):
+            search_args = {"aspect": "AI", "days": 7, "max_results": 5, "session_id": session_id}
+            try:
+                env.execute_tool("get_recently_submitted_cs_papers", search_args)
+            except Exception:
+                pass
+
+        if not spec.steps:
+            # infeasible 任务：直接结束
+            history.append({
+                "thought": "该任务无法通过现有工具完成或参数无效",
+                "action": "FINISH",
+                "observation": "任务完成",
+            })
+        else:
+            for step_idx, step_spec in enumerate(spec.steps):
+                tool_name = step_spec.tool
+                args = dict(step_spec.args or {})
+                tool_def = registry.get_tool(tool_name)
+                props = (tool_def or {}).get("parameters", {}).get("properties", {})
+                if "session_id" in props:
+                    args["session_id"] = session_id
+
+                thought = f"需要调用 {tool_name} 来处理任务步骤 {step_idx + 1}"
+                action_dict = {"name": tool_name, "args": args}
+
+                try:
+                    res = env.execute_tool(tool_name, args)
+                    if isinstance(res, list):
+                        obs = f"成功获取 {len(res)} 篇论文"
+                    elif isinstance(res, dict):
+                        obs = str(res)[:500]
+                    else:
+                        obs = str(res)[:500]
+                except Exception as exc:
+                    obs = f"工具执行异常: {exc}"
+
+                history.append({
+                    "thought": thought,
+                    "action": json.dumps(action_dict, ensure_ascii=False),
+                    "observation": obs,
+                })
+
+            # 最后追加 FINISH
+            history.append({
+                "thought": "所有步骤均已成功执行，任务已完成",
+                "action": "FINISH",
+                "observation": "任务完成",
+            })
+
+        samples = build_sft_samples_from_history(spec.task, tools_description, history)
+        sft_data.extend(samples)
+
+    return sft_data
+
+
+def generate_sft_dataset(
+    output: Optional[str] = None,
+    snapshot: Optional[str] = None,
+    use_llm: bool = False,
+    task_set: str = "basic",
+) -> None:
+    """生成 SFT 专家数据集主函数"""
+    snapshot_path = (
+        Path(snapshot) if snapshot else REPO_ROOT / "data" / "mock_arxiv_snapshot.json"
+    )
+    env = None
+    if snapshot_path.exists():
+        env = MockArxivEnv(snapshot_path=snapshot_path, mode="replay")
+        print(f"[SNAPSHOT] 使用离线快照环境: {snapshot_path}")
+    else:
+        print(f"[INFO] 未找到快照文件 {snapshot_path}，使用自动环境模式")
+        env = MockArxivEnv(mode="auto")
+
+    tools_desc = format_tool_description(registry.list_tools())
+    sft_data: List[Dict[str, Any]] = []
+
+    if task_set == "expanded":
         try:
-            result = agent.run(task_def["task"], session_id=f"sft_gen_{task_def['id']}")
+            from benchmark.tasks_expanded import EXPANDED_SPECS
+            specs = EXPANDED_SPECS
+        except ImportError:
+            specs = BENCHMARK_SPECS
+    else:
+        specs = BENCHMARK_SPECS
 
-            # 只保留成功的 trajectories
-            if result.get("iteration_count", 0) > 0 and result.get("history"):
-                print(f"   ✅ 成功，共 {len(result['history'])} 步")
+    print(f"[TASKS] 加载任务集 ({task_set}): {len(specs)} 个任务")
 
-                # 转为 SFT 格式（每一步作为一条训练样本）
-                for step in result["history"]:
-                    action = step.get("action", "")
-                    if not action or action == "FINISH":
-                        continue
+    if not use_llm:
+        print("[MODE] 使用确定性专家逻辑与离线环境生成标准化 SFT 演示...")
+        sft_data = generate_deterministic_trajectories(specs, env, tools_desc)
+    else:
+        print("[MODE] 使用环境配置的 LLM 生成专家轨迹...")
+        from utils.llm_client import get_env_llm_client
 
-                    sft_data.append({
-                        "messages": [
-                            {
-                                "role": "system",
-                                "content": "你是一个 arXiv 论文检索 Agent，可以调用工具完成任务。"
-                            },
-                            {
-                                "role": "user",
-                                "content": task_def["task"]
-                            },
-                            {
-                                "role": "assistant",
-                                "content": action  # 只学习 action
-                            }
-                        ]
-                    })
-            else:
-                print(f"   ⚠️  执行失败或无有效步骤")
+        llm_client = get_env_llm_client()
+        agent = ReActAgent(llm_client, side_effect_mgr=LocalSideEffectManager(), env=env)
+        tasks = build(specs)
 
-        except Exception as e:
-            print(f"   ❌ 执行出错: {e}")
+        for i, task_def in enumerate(tasks):
+            print(f"[{i+1}/{len(tasks)}] 执行任务: {task_def['id']} - {task_def['task']}")
+            try:
+                result = agent.run(task_def["task"], session_id=f"sft_gen_{task_def['id']}")
+                if result.get("history"):
+                    samples = build_sft_samples_from_history(
+                        task_def["task"], tools_desc, result["history"]
+                    )
+                    sft_data.extend(samples)
+                    print(f"   [OK] 提取 {len(samples)} 条多轮训练样本")
+            except Exception as e:
+                print(f"   [ERROR] 执行出错: {e}")
 
-    # 保存到 JSONL
-    output_path = REPO_ROOT / "data" / "sft" / "sft_train.jsonl"
+    output_path = Path(output) if output else REPO_ROOT / "data" / "sft" / "sft_train.jsonl"
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
     with open(output_path, "w", encoding="utf-8") as f:
         for item in sft_data:
             f.write(json.dumps(item, ensure_ascii=False) + "\n")
 
-    print(f"\n✅ SFT 数据生成完成：{len(sft_data)} 条样本 → {output_path}")
+    print(f"\n[DONE] SFT 数据生成完成：共 {len(sft_data)} 条样本 -> {output_path}")
 
 
 if __name__ == "__main__":
-    generate_sft_dataset()
+    parser = argparse.ArgumentParser(description="生成 SFT 专家数据集")
+    parser.add_argument("--output", default=None, help="输出 JSONL 路径")
+    parser.add_argument("--snapshot", default=None, help="离线快照文件路径")
+    parser.add_argument("--use_llm", action="store_true", help="使用外部 LLM API 生成（默认使用确定性专家）")
+    parser.add_argument("--task_set", choices=["basic", "expanded"], default="basic", help="使用基础还是扩展任务集")
+    args = parser.parse_args()
+
+    generate_sft_dataset(
+        output=args.output,
+        snapshot=args.snapshot,
+        use_llm=args.use_llm,
+        task_set=args.task_set,
+    )
+


### PR DESCRIPTION
### Summary of Improvements
1. **SFT Data Generation**: Implemented multi-turn ReAct Markov history tracking and aligned prompts with runtime template (`scripts/generate_sft_data.py`).
2. **DPO Multi-turn Preference Extraction**: Added common-prefix divergence step algorithm (`scripts/generate_dpo_data.py`).
3. **GRPO Thought Extraction**: Fixed regex thought capture when `Thought:` is part of prompt suffix (`AgenticArxiv/rl/grpo_reward.py`).
4. **Verifiable Reward Normalization**: Added robust parameter matching for aspect codes (`cs.AI` <-> `AI`), references, and numeric types (`AgenticArxiv/benchmark/metrics.py`).
5. **PPO Training Stage**: Added `AgenticArxiv/rl/train_ppo.py` completing the full 4-stage RL pipeline (`SFT -> DPO -> GRPO -> PPO`).
6. **Cross-Platform Compatibility**: Enhanced `rollout.py` CLI and safe printing on Windows GBK console (`observability.py`).