### PR TITLE
fix(rl): preserve serializable rollout model metadata

### DIFF
--- a/AgenticArxiv/rl/rollout.py
+++ b/AgenticArxiv/rl/rollout.py
@@ -15,7 +15,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import fire
 
@@ -33,6 +33,18 @@ from rl.env import MockArxivEnv
 from rl.reward import RewardCalculator
 from rl.trajectory import create_trajectory, save_trajectory
 from utils.llm_client import TransformersLLMClient, get_env_llm_client
+
+
+def _get_model_name(llm_client: Optional[Any]) -> str:
+    """Return a JSON-serializable model identifier for trajectory metadata."""
+    if llm_client is None:
+        return ""
+
+    for attribute in ("model_name", "model"):
+        value = getattr(llm_client, attribute, None)
+        if isinstance(value, (str, Path)):
+            return str(value)
+    return ""
 
 
 def _create_agent(
@@ -115,7 +127,7 @@ def rollout_single_task(
     )
 
     # 构造 trajectory
-    model_name = getattr(llm_client, "model", "") if llm_client else ""
+    model_name = _get_model_name(llm_client)
     traj = create_trajectory(
         task_id=task_def["id"],
         task=task_def["task"],
@@ -219,4 +231,3 @@ def main(
 
 if __name__ == "__main__":
     fire.Fire(main)
-

--- a/AgenticArxiv/tests/test_rollout.py
+++ b/AgenticArxiv/tests/test_rollout.py
@@ -1,0 +1,46 @@
+"""Tests for rollout metadata helpers.
+
+These tests do not load a real local model.  A lightweight fake preserves the
+important ``TransformersLLMClient`` contract: ``model_name`` is the identifier
+while ``model`` is the in-memory Hugging Face model object.
+"""
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from rl.rollout import _get_model_name  # noqa: E402
+
+
+class TestModelMetadata(unittest.TestCase):
+    def test_local_client_uses_serializable_model_name(self):
+        class LocalClient:
+            model_name = "outputs/sft/final"
+            model = object()
+
+        model_name = _get_model_name(LocalClient())
+
+        self.assertEqual(model_name, "outputs/sft/final")
+        self.assertEqual(
+            json.loads(json.dumps({"model": model_name})),
+            {"model": "outputs/sft/final"},
+        )
+
+    def test_remote_client_keeps_legacy_string_model(self):
+        class RemoteClient:
+            model = "gpt-4"
+
+        self.assertEqual(_get_model_name(RemoteClient()), "gpt-4")
+
+    def test_non_serializable_model_object_is_not_recorded(self):
+        class UnknownClient:
+            model = object()
+
+        self.assertEqual(_get_model_name(UnknownClient()), "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- import `Any` so `rl.rollout` can evaluate its public type annotations
- record `TransformersLLMClient.model_name` instead of the in-memory Hugging Face model object
- keep compatibility with clients exposing a string `model` field and ignore non-serializable objects
- add focused regression tests without loading a real model

## Why

`rollout_single_task` annotates `llm_client` with `Any`, but `Any` was not imported. The same function also read `TransformersLLMClient.model`, which is the loaded model object, and passed it to JSONL trajectory metadata. This could fail at import time or later during `json.dumps`.

## Testing

- Python 3.9: `python -m unittest AgenticArxiv/tests/test_rollout.py -v`
- Python 3.11: `python -m unittest AgenticArxiv/tests/test_rollout.py AgenticArxiv/tests/test_trajectory.py -v`
- `ruff check AgenticArxiv/rl/rollout.py AgenticArxiv/tests/test_rollout.py --select F821`
- `git diff --check`