### PR TITLE
fix(benchmark): stop scoring ref=-1 as ref=1, and repair the DPO test import

### DIFF
--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -2,6 +2,7 @@
 """从 Agent run() 结果中提取性能和准确性指标。"""
 
 import json
+import re
 from dataclasses import dataclass, field, asdict
 from typing import List, Dict, Any, Optional
 
@@ -217,12 +218,14 @@ def _match_arg_value(predicted_val: Any, expected_val: Any, key: str = "") -> bo
     # 2. ref 字段归一化：支持整数与字符串数字等价，支持形如 "第1篇" 的正则匹配
     if key == "ref":
         try:
-            if int(predicted_val) == int(expected_val):
-                return True
+            # 两边都能转成整数时，这一步就是定论，不该再往下抠数字。
+            return int(predicted_val) == int(expected_val)
         except (ValueError, TypeError):
             pass
-        import re
-        m = re.search(r"\d+", str(predicted_val))
+        # 只有取值不是纯数字（"第1篇"）时才退回正则。`-?` 不能省：str(-1) 里的
+        # 减号不属于 \d+，写成 \d+ 会从 "-1" 里抠出 "1" 判成对。ref 是 1-based
+        # 序号，-1 是越界值，正是 wrong_args 基线用来制造错误参数的取值。
+        m = re.search(r"-?\d+", str(predicted_val))
         if m:
             try:
                 if int(m.group(0)) == int(expected_val):

--- a/AgenticArxiv/benchmark/readme.md
+++ b/AgenticArxiv/benchmark/readme.md
@@ -146,7 +146,7 @@ benchmark/
   __init__.py
   task_spec.py        # TaskSpec/Step：expected_tools 与 expected_tool_args 同源派生
   tasks.py           # 8 条冒烟任务 (BENCHMARK_TASKS)
-  tasks_expanded.py   # 58 条完整基准集 (--task-set expanded)
+  tasks_expanded.py   # 59 条完整基准集 (--task-set expanded)
   runner.py           # BenchmarkRunner：驱动 Agent 执行测试集
   metrics.py          # TaskMetrics：从 run() 结果提取指标
   baselines.py        # 确定性退化策略与评分敏感性汇总

--- a/AgenticArxiv/benchmark/run_baselines.py
+++ b/AgenticArxiv/benchmark/run_baselines.py
@@ -52,7 +52,11 @@ def main() -> None:
     )
     parser.add_argument(
         "--task-set", choices=["default", "expanded"], default="expanded",
-        help="default=8 seed tasks; expanded=58 tasks including constraints and infeasible requests",
+        help=(
+            f"default={len(_task_pool('default'))} seed tasks; "
+            f"expanded={len(_task_pool('expanded'))} tasks including constraints "
+            "and infeasible requests"
+        ),
     )
     parser.add_argument(
         "--policies", nargs="+", choices=sorted(ALL_POLICIES),

--- a/AgenticArxiv/benchmark/run_benchmark.py
+++ b/AgenticArxiv/benchmark/run_benchmark.py
@@ -23,6 +23,7 @@ if PROJECT_ROOT not in sys.path:
 
 from tools.bootstrap import require_all_tools
 from benchmark.tasks import get_all_tasks
+from benchmark.tasks_expanded import get_expanded_tasks
 from benchmark.runner import BenchmarkRunner
 from benchmark.report import BenchmarkReport
 from config import settings
@@ -79,8 +80,11 @@ def main():
     parser.add_argument("--snapshot", default=None, help="指定快照路径（默认 data/mock_arxiv_snapshot.json）")
     parser.add_argument(
         "--task-set", choices=["default", "expanded"], default="default",
-        help="default=benchmark/tasks.py 的 8 条；expanded=扩充后的 58 条"
-             "（指代形态、可选参数、跨步状态、多跳链路、负向约束、不可行请求）",
+        help=(
+            f"default=benchmark/tasks.py 的 {len(get_all_tasks())} 条；"
+            f"expanded=扩充后的 {len(get_expanded_tasks())} 条"
+            "（指代形态、可选参数、跨步状态、多跳链路、负向约束、不可行请求）"
+        ),
     )
     args = parser.parse_args()
 
@@ -94,7 +98,7 @@ def main():
 
     # 任务池
     if args.task_set == "expanded":
-        from benchmark.tasks_expanded import get_expanded_tasks, offline_only_ids
+        from benchmark.tasks_expanded import offline_only_ids
         pool = get_expanded_tasks()
         if not args.offline:
             # 这些任务的标准答案绑定 data/mock_arxiv_snapshot.json（例如标题子串

--- a/AgenticArxiv/benchmark/tasks.py
+++ b/AgenticArxiv/benchmark/tasks.py
@@ -1,7 +1,7 @@
 # AgenticArxiv/benchmark/tasks.py
 """标准化测试任务集，用于对比三种 Agent 模式的性能和准确性。
 
-这里是 8 条冒烟任务；完整的 58 条基准集在 `benchmark/tasks_expanded.py`
+这里是 8 条冒烟任务；完整的 59 条基准集在 `benchmark/tasks_expanded.py`
 （`--task-set expanded`）。两边共用 `task_spec.TaskSpec`：`expected_tools`
 与 `expected_tool_args` 由同一份 `steps` 派生，不再手写两份平行列表。
 

--- a/AgenticArxiv/tests/test_benchmark_offline.py
+++ b/AgenticArxiv/tests/test_benchmark_offline.py
@@ -3,7 +3,7 @@
 import json
 import unittest
 
-from benchmark.metrics import argument_match_score
+from benchmark.metrics import _match_arg_value, argument_match_score
 from benchmark.runner import BenchmarkRunner
 
 
@@ -101,6 +101,56 @@ class ArgumentMatchScoreTest(unittest.TestCase):
         )
         self.assertEqual(
             argument_match_score(history, [{"ref": 1}], ["get_paper_cache_status"]), 1.0
+        )
+
+
+class ArgValueEquivalenceTest(unittest.TestCase):
+    """取值等价判定：允许写法差异，不允许语义差异。
+
+    `_match_arg_value` 让 "cs.AI"/"AI"、"1"/1、"第1篇"/1 这类同义写法不被
+    误判为错，这是对的——模型换个写法不该扣分。但它的宽松度必须止步于写法：
+    一旦放行了语义不同的取值，参数档就重新变成「照签名填齐就有分」，
+    也就是 issue #17 第 2 条描述的那个洞。
+    """
+
+    def test_aspect_accepts_the_cs_prefix_and_case_variants(self):
+        for predicted in ("cs.AI", "AI", "cs.ai", " CS.AI "):
+            self.assertTrue(_match_arg_value(predicted, "cs.AI", "aspect"), predicted)
+
+    def test_aspect_still_rejects_a_different_category(self):
+        self.assertFalse(_match_arg_value("cs.AI", "cs.CL", "aspect"))
+
+    def test_ref_accepts_string_and_ordinal_spellings(self):
+        for predicted in (1, "1", "1.0", "第1篇", "第 1 篇"):
+            self.assertTrue(_match_arg_value(predicted, 1, "ref"), predicted)
+
+    def test_ref_does_not_drop_the_minus_sign(self):
+        r"""回归：`\d+` 从 "-1" 里只抠得到 "1"，于是 ref=-1 被判成 ref=1。
+
+        ref 是 1-based 序号（tools/pdf_download_tool.py），-1 是越界值，
+        也正是 wrong_args 基线用来制造错误参数的取值——这个洞让它在
+        composite 类目上白拿 0.226 分，离参考轨迹只剩 0.335 的差距。
+        """
+        self.assertFalse(_match_arg_value(-1, 1, "ref"))
+        self.assertFalse(_match_arg_value("-1", 1, "ref"))
+        self.assertFalse(_match_arg_value(-3, 3, "ref"))
+        self.assertFalse(_match_arg_value("ref=-1", 1, "ref"))
+
+    def test_numeric_and_string_forms_agree_outside_the_named_keys(self):
+        self.assertTrue(_match_arg_value("7", 7, "days"))
+        self.assertTrue(_match_arg_value(5.0, 5, "max_results"))
+        self.assertFalse(_match_arg_value(7, 30, "days"))
+
+    def test_expected_none_means_the_key_should_be_omitted(self):
+        self.assertTrue(_match_arg_value(None, None, "ref"))
+        self.assertFalse(_match_arg_value(1, None, "ref"))
+        self.assertFalse(_match_arg_value(None, 1, "ref"))
+
+    def test_wrong_args_baseline_earns_nothing_on_a_ref_oracle(self):
+        """端到端确认：wrong_args 的 ref=-1 在参数档上应当颗粒无收。"""
+        history = [_step("download_arxiv_pdf", {"ref": -1})]
+        self.assertEqual(
+            argument_match_score(history, [{"ref": 1}], ["download_arxiv_pdf"]), 0.0
         )
 
 

--- a/AgenticArxiv/tests/test_dpo_pairs.py
+++ b/AgenticArxiv/tests/test_dpo_pairs.py
@@ -3,6 +3,12 @@
 
 不需要 LLM API、不需要网络、不需要 TRL —— 用合成轨迹直接验证配对逻辑。
 
+配对口径在「多轮 RL 数据生成」那次重写里换过一次：原来是各取轨迹的首个工具
+调用（`first_tool_action`）配成一对，现在是找两条轨迹在**相同前缀**下的第一个
+分歧动作（`find_divergence_step`），prompt 也随之对齐到那一步之前的历史。
+换句话说偏好信号从「整条轨迹谁好」收紧成了「同一状态下这一步该怎么走」，
+复合任务里前几步相同、后面才走岔的情形因此才有对可配。
+
 运行：
     cd AgenticArxiv && python tests/test_dpo_pairs.py
 """
@@ -14,84 +20,180 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
-from generate_dpo_data import build_preference_pair, first_tool_action  # noqa: E402
+from generate_dpo_data import (  # noqa: E402
+    _canonical_action_str,
+    build_preference_pair,
+    find_divergence_step,
+)
 
 SEARCH = '{"name": "get_recently_submitted_cs_papers", "args": {"aspect": "AI"}}'
 DOWNLOAD = '{"name": "download_arxiv_pdf", "args": {"ref": 1}}'
+TRANSLATE = '{"name": "translate_arxiv_pdf", "args": {"ref": 1}}'
 TASK = {"id": "search_01", "task": "检索最近7天内人工智能(cs.AI)方向的论文"}
+TOOLS = "TOOLS_DESCRIPTION_PLACEHOLDER"
+
+
+def step(action, thought=""):
+    return {"thought": thought, "action": action, "observation": "obs"}
 
 
 def traj(*actions):
     """把动作序列包成 agent.run() 的返回结构。"""
-    return {"history": [{"thought": "", "action": a, "observation": ""} for a in actions]}
+    return {"history": [step(a) for a in actions]}
 
 
 def rollout(reward, *actions):
     return {"reward": reward, "result": traj(*actions)}
 
 
-class TestFirstToolAction(unittest.TestCase):
-    def test_skips_terminal_markers(self):
-        self.assertEqual(first_tool_action(traj(SEARCH, "FINISH")), SEARCH)
-
-    def test_returns_first_of_several(self):
-        self.assertEqual(first_tool_action(traj(SEARCH, DOWNLOAD, "FINISH")), SEARCH)
-
-    def test_empty_when_no_tool_call(self):
-        self.assertEqual(first_tool_action(traj("FINISH")), "")
-        self.assertEqual(first_tool_action(traj("FORCE_STOP")), "")
-        self.assertEqual(first_tool_action(traj("ERROR")), "")
-        self.assertEqual(first_tool_action({"history": []}), "")
+def pair(rollouts, **kwargs):
+    return build_preference_pair(rollouts, TASK, TOOLS, **kwargs)
 
 
-class TestBuildPreferencePair(unittest.TestCase):
+class CanonicalActionTest(unittest.TestCase):
+    """动作归一化决定了「两步算不算同一步」，也就决定了分歧点落在哪。"""
+
+    def test_dict_and_json_string_are_the_same_action(self):
+        self.assertEqual(
+            _canonical_action_str({"name": "download_arxiv_pdf", "args": {"ref": 1}}),
+            _canonical_action_str(DOWNLOAD),
+        )
+
+    def test_key_order_does_not_make_two_actions_differ(self):
+        self.assertEqual(
+            _canonical_action_str('{"args": {"ref": 1}, "name": "download_arxiv_pdf"}'),
+            _canonical_action_str(DOWNLOAD),
+        )
+
+    def test_terminal_markers_pass_through(self):
+        self.assertEqual(_canonical_action_str("  FINISH  "), "FINISH")
+
+
+class FindDivergenceStepTest(unittest.TestCase):
+    """分歧点：前缀相同、当前动作不同的第一步。"""
+
+    def test_first_step_divergence(self):
+        found = find_divergence_step([step(SEARCH), step("FINISH")],
+                                     [step(DOWNLOAD), step("FINISH")])
+        self.assertIsNotNone(found)
+        index, chosen, rejected = found
+        self.assertEqual(index, 0)
+        self.assertEqual(chosen["action"], SEARCH)
+        self.assertEqual(rejected["action"], DOWNLOAD)
+
+    def test_divergence_after_a_shared_prefix(self):
+        """复合任务的核心场景：都先搜索，第二步才走岔。
+
+        旧口径各取首个工具调用，两边都是 SEARCH，判为相同、丢弃；
+        真正有信息量的第 2 步决策拿不到任何监督信号。
+        """
+        found = find_divergence_step([step(SEARCH), step(DOWNLOAD)],
+                                     [step(SEARCH), step(TRANSLATE)])
+        self.assertIsNotNone(found)
+        index, chosen, rejected = found
+        self.assertEqual(index, 1)
+        self.assertEqual(chosen["action"], DOWNLOAD)
+        self.assertEqual(rejected["action"], TRANSLATE)
+
+    def test_identical_trajectories_have_no_divergence(self):
+        self.assertIsNone(find_divergence_step([step(SEARCH)], [step(SEARCH)]))
+
+    def test_one_trajectory_being_a_prefix_diverges_against_finish(self):
+        """短的那条等价于「到此为止」，拿 FINISH 补齐再比。"""
+        found = find_divergence_step([step(SEARCH), step(DOWNLOAD)], [step(SEARCH)])
+        self.assertIsNotNone(found)
+        index, chosen, rejected = found
+        self.assertEqual(index, 1)
+        self.assertEqual(chosen["action"], DOWNLOAD)
+        self.assertEqual(rejected["action"], "FINISH")
+
+    def test_an_empty_action_is_not_a_usable_divergence(self):
+        self.assertIsNone(find_divergence_step([step(SEARCH)], [step("")]))
+
+
+class BuildPreferencePairTest(unittest.TestCase):
     def test_regression_last_step_is_always_finish(self):
-        """回归：两条轨迹末步都是 FINISH，旧实现会因 chosen==rejected 全部跳过。"""
+        """回归：两条轨迹末步都是 FINISH，取 history[-1] 的实现会全部跳过。"""
         rollouts = [rollout(1.5, SEARCH, "FINISH"), rollout(0.5, DOWNLOAD, "FINISH")]
 
-        # 旧实现取 history[-1]，两边都是 "FINISH"
         last_actions = {r["result"]["history"][-1]["action"] for r in rollouts}
         self.assertEqual(last_actions, {"FINISH"})
 
-        # 新实现取首个工具调用，能构造出有效偏好对
-        pair = build_preference_pair(rollouts, TASK)
-        self.assertIsNotNone(pair)
-        self.assertEqual(pair["chosen"], SEARCH)
-        self.assertEqual(pair["rejected"], DOWNLOAD)
-        self.assertEqual(pair["prompt"], TASK["task"])
+        result = pair(rollouts)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["divergence_step"], 0)
+        self.assertIn(SEARCH, result["chosen"])
+        self.assertIn(DOWNLOAD, result["rejected"])
 
-    def test_picks_extremes_not_adjacent(self):
+    def test_picks_the_widest_reward_gap(self):
         rollouts = [rollout(0.5, DOWNLOAD, "FINISH"),
                     rollout(2.0, SEARCH, "FINISH"),
                     rollout(1.0, SEARCH, DOWNLOAD, "FINISH")]
-        pair = build_preference_pair(rollouts, TASK)
-        self.assertEqual(pair["chosen"], SEARCH)
-        self.assertEqual(pair["rejected"], DOWNLOAD)
+        result = pair(rollouts)
+        self.assertEqual(result["reward_gap"], 1.5)
+        self.assertIn(SEARCH, result["chosen"])
+        self.assertIn(DOWNLOAD, result["rejected"])
 
-    def test_finds_distinct_middle_action_when_extremes_match(self):
+    def test_finds_a_distinct_action_when_the_extremes_match(self):
         rollouts = [rollout(2.0, SEARCH), rollout(1.0, DOWNLOAD), rollout(0.0, SEARCH)]
-        pair = build_preference_pair(rollouts, TASK)
-        self.assertEqual(pair["chosen"], SEARCH)
-        self.assertEqual(pair["rejected"], DOWNLOAD)
+        result = pair(rollouts)
+        self.assertIn(SEARCH, result["chosen"])
+        self.assertIn(DOWNLOAD, result["rejected"])
+
+    def test_prompt_is_aligned_to_the_shared_prefix(self):
+        """prompt 必须停在分歧点之前：既要带上共同历史，又不能剧透该走哪步。"""
+        rollouts = [rollout(2.0, SEARCH, DOWNLOAD), rollout(0.5, SEARCH, TRANSLATE)]
+        result = pair(rollouts)
+
+        self.assertEqual(result["divergence_step"], 1)
+        self.assertIn(SEARCH, result["prompt"])          # 共同前缀在
+        self.assertNotIn(DOWNLOAD, result["prompt"])     # 答案不在
+        self.assertIn(TOOLS, result["prompt"])           # 与推理期同一套工具说明
+        self.assertIn(TASK["task"], result["prompt"])
+
+    def test_thought_travels_with_the_action(self):
+        rollouts = [
+            {"reward": 2.0, "result": {"history": [step(SEARCH, "先搜一下")]}},
+            {"reward": 0.0, "result": {"history": [step(DOWNLOAD, "直接下载")]}},
+        ]
+        result = pair(rollouts)
+        self.assertTrue(result["chosen"].startswith("Thought: 先搜一下\nAction: "))
+        self.assertTrue(result["rejected"].startswith("Thought: 直接下载\nAction: "))
+
+    def test_task_id_is_carried_through(self):
+        result = pair([rollout(1.5, SEARCH, "FINISH"), rollout(0.5, DOWNLOAD, "FINISH")])
+        self.assertEqual(result["task_id"], TASK["id"])
 
     def test_respects_minimum_reward_gap(self):
         rollouts = [rollout(1.01, SEARCH), rollout(1.0, DOWNLOAD)]
-        self.assertIsNone(build_preference_pair(rollouts, TASK, min_reward_gap=0.05))
+        self.assertIsNone(pair(rollouts, min_reward_gap=0.05))
+        self.assertIsNotNone(pair(rollouts, min_reward_gap=0.0))
 
     def test_none_when_actions_identical(self):
-        rollouts = [rollout(1.5, SEARCH, "FINISH"), rollout(0.5, SEARCH, "FINISH")]
-        self.assertIsNone(build_preference_pair(rollouts, TASK))
+        self.assertIsNone(pair([rollout(1.5, SEARCH, "FINISH"),
+                                rollout(0.5, SEARCH, "FINISH")]))
 
     def test_none_when_rewards_tie(self):
-        rollouts = [rollout(1.0, SEARCH, "FINISH"), rollout(1.0, DOWNLOAD, "FINISH")]
-        self.assertIsNone(build_preference_pair(rollouts, TASK))
+        self.assertIsNone(pair([rollout(1.0, SEARCH, "FINISH"),
+                                rollout(1.0, DOWNLOAD, "FINISH")]))
 
-    def test_none_when_a_trajectory_has_no_tool_call(self):
-        rollouts = [rollout(1.5, SEARCH, "FINISH"), rollout(0.0, "FINISH")]
-        self.assertIsNone(build_preference_pair(rollouts, TASK))
+    def test_giving_up_immediately_is_a_valid_rejected_sample(self):
+        """口径变更：一条只有 FINISH 的轨迹现在会配成对，而不是被丢掉。
+
+        旧实现要求两边都有工具调用，「该动手却直接收工」这种典型失败因此
+        进不了偏好数据。分歧点口径下它就是第 0 步 SEARCH vs FINISH。
+        """
+        result = pair([rollout(1.5, SEARCH, "FINISH"), rollout(0.0, "FINISH")])
+        self.assertIsNotNone(result)
+        self.assertIn(SEARCH, result["chosen"])
+        self.assertEqual(result["rejected"], "Action: FINISH")
+
+    def test_none_when_a_trajectory_has_no_history(self):
+        self.assertIsNone(pair([rollout(1.5, SEARCH, "FINISH"),
+                                {"reward": 0.0, "result": {"history": []}}]))
 
     def test_none_when_fewer_than_two_rollouts(self):
-        self.assertIsNone(build_preference_pair([rollout(1.5, SEARCH, "FINISH")], TASK))
+        self.assertIsNone(pair([rollout(1.5, SEARCH, "FINISH")]))
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -515,7 +515,7 @@ PPO 更适合生产级大模型训练（7B+），本项目作为学习 demo 不�
 
 ### P1 — 中期（数据与评测）
 
-- [x] **任务集扩充**：基准集扩到 58 条（`benchmark/tasks_expanded.py`，`--task-set expanded`），涵盖 search / ref_form / composite / state / optional / constraint / long_chain / infeasible 八类；`benchmark/tasks.py` 保留为 8 条冒烟子集。两边统一走 `benchmark/task_spec.py` 的 `TaskSpec`：`expected_tools` 与 `expected_tool_args` 由同一份 `steps` 派生，不再手写两份平行列表漂移。区分度用 `benchmark/run_baselines.py` 的确定性退化策略量化并逐类目卡门槛（`tests/test_reward_discrimination.py`）——修掉参数档的四处漏分后，「无视任务永远搜 cs.AI」在检索类任务上从 0.833 降到 0.446，「本该什么都不做却调了工具」从 +0.165 变成 −0.235。
+- [x] **任务集扩充**：基准集扩到 59 条（`benchmark/tasks_expanded.py`，`--task-set expanded`），涵盖 search / ref_form / composite / state / optional / constraint / long_chain / infeasible 八类；`benchmark/tasks.py` 保留为 8 条冒烟子集。两边统一走 `benchmark/task_spec.py` 的 `TaskSpec`：`expected_tools` 与 `expected_tool_args` 由同一份 `steps` 派生，不再手写两份平行列表漂移。区分度用 `benchmark/run_baselines.py` 的确定性退化策略量化并逐类目卡门槛（`tests/test_reward_discrimination.py`）——修掉参数档的四处漏分后，「无视任务永远搜 cs.AI」在检索类任务上从 0.833 降到 0.446，「本该什么都不做却调了工具」从 +0.165 变成 −0.235。
 - [ ] **eval/ badcase replay**：目录树中的 `eval/`（`eval_cases.jsonl`、`badcase_replay.py`）实际尚不存在，需实现坏例回放闭环。
 - [ ] **Reward hacking 排查**：在现有 `RewardVarianceGuard` / `CanaryCallback` 基础上补 reward-hacking 案例库与多粒度权重课程调优。
 


### PR DESCRIPTION
Two defects that landed on `main` after #40, plus a doc-count sync.

Neither is visible from the test suite as it stands: one of them **is** the
test suite failing to load, and the other silently hands reward to the very
baseline that exists to catch it.

## 1. `ref=-1` scores as `ref=1`

`_match_arg_value` (added in "optimize multi-turn RL data generation") falls
back to scraping digits out of the predicted value when the integer comparison
fails. The intent is to accept ordinal spellings like `"第1篇"`, which is a
reasonable thing to accept:

```python
m = re.search(r"\d+", str(predicted_val))
if m and int(m.group(0)) == int(expected_val):
    return True
```

`\d+` does not include the minus sign. `str(-1)` is `"-1"`, the scrape yields
`"1"`, and `ref=-1` is scored as a correct `ref=1`. Same for `-3` against `3`.

`ref` is a 1-based ordinal (`tools/pdf_download_tool.py:28`), so `-1` is an
out-of-range value — and it is exactly the value `WrongArgsPolicy` uses to
manufacture wrong arguments:

```python
"download_arxiv_pdf":     {"ref": -1},
"translate_arxiv_pdf":    {"ref": -1},
"get_paper_cache_status": {"ref": -1},
```

So the baseline whose whole purpose is to fail the argument component was
being paid for its wrong arguments.

### Fix

Two changes. When both sides convert to an integer, that comparison is the
answer — don't fall through to scraping. When scraping a genuinely
non-numeric string, keep the sign with `-?\d+`.

```python
try:
    return int(predicted_val) == int(expected_val)
except (ValueError, TypeError):
    pass
m = re.search(r"-?\d+", str(predicted_val))
```

`"第1篇"`, `"第 2 篇"`, `"1.0"`, `"1"` all still resolve to `1`. `_match_arg_value`
had no test coverage at all; this PR adds seven cases covering both the
normalisation it is meant to allow and the sign regression.

### Measured effect

`--task-set expanded --seed 42 --random-samples 20 --training-step 100`

| | before | after |
|---|---:|---:|
| `wrong_args` mean reward | 0.542 | **0.454** |
| `wrong_args` mean arg score | 0.255 | **0.069** |
| `wrong_args` on `composite` | 0.665 | **0.439** |
| `wrong_args` best single task | 0.933 | **0.667** |

Per-category gaps to the reference, tightest first:

| category | before | after |
|---|---:|---:|
| composite | 0.335 | **0.561** |
| long_chain | 0.433 | **0.574** |
| optional | 0.425 | **0.625** |

The per-category gate passed at `0.30` before this fix, but failed at `0.40`.
It now passes at `0.50`. No other policy moves by any amount:
`reference` 1.000, `always_finish` −0.121, `always_search` 0.017,
`random_tool` −0.056 — identical before and after.

## 2. `tests/test_dpo_pairs.py` does not load

```
ImportError: cannot import name 'first_tool_action' from 'generate_dpo_data'
```

The multi-turn rewrite of `scripts/generate_dpo_data.py` removed
`first_tool_action`, and the test module still imports it. Because this is a
collection error, `pytest tests/` aborts the entire run — the other 205 tests
never execute either.

`first_tool_action` was not renamed, it was superseded. Pairing changed from
"take each trajectory's first tool call" to "find the first action where two
trajectories diverge under a shared prefix" (`find_divergence_step`), and the
prompt is now aligned to the history before that step. The preference signal
went from "which whole trajectory is better" to "at this state, which next
step is better" — which is what makes multi-step tasks pairable at all.

So restoring the old function would be wrong. The tests are rewritten against
the current API, keeping the intent of every existing assertion and adding
three behaviours that had no coverage:

- **divergence after a shared prefix** — both trajectories search first and
  split on step 2. This is the case the rewrite exists for, and nothing tested
  it. Under the old pairing both sides were `SEARCH`, judged identical, and
  discarded.
- **prompt alignment** — the prompt carries the shared prefix and the tools
  description, and does *not* contain the diverging action itself.
- **thought travels with the action** into `chosen` / `rejected`.

One assertion flips, with the reason recorded in the test: a trajectory whose
only action is `FINISH` now pairs as `SEARCH vs FINISH` instead of being
dropped. The old implementation required a tool call on both sides, so
"should have acted, gave up immediately" — a common and informative failure —
could never enter the preference data.

Also adds tests for `_canonical_action_str`, which decides whether two steps
count as the same step, and therefore decides where the divergence lands.

## 3. Task count sync

The parameter-boundary infeasible case made the expanded set 59; four places
still said 58. This has drifted once before (7 → 8, `05ad0a9`), so the two
argparse help strings now derive the count with `len()` instead of hardcoding
it. The three prose mentions (`README.md`, `benchmark/readme.md`,
`benchmark/tasks.py`) are updated by hand.

`run_benchmark.py` promotes `get_expanded_tasks` to a module-level import for
this — it is a pure-data module, 16 ms, and pulls in no heavy dependency.

## Tests

205 passed, 1 skipped. On `main` the suite cannot complete at all because of
the collection error above.

The 3 failures and 3 errors that remain are environment-only and identical on
`main`: `trl` is not installed, and `test_modules` / `test_tool_registry`
require network access.

## Not addressed here

`WrongArgsPolicy`'s "wrong" arguments include `days=7, max_results=5`, which
are the most common *correct* values in the task set — only `aspect` is
actually wrong for search tasks, which is why it still scores 0.667 there.
That is a property of the policy definition rather than of the scorer, and
changing it would move published baseline numbers, so it is left for a
separate discussion.
