### PR TITLE
feat(benchmark): report reliability, false finishes, reference resolution, and cost per success

### DIFF
--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -46,6 +46,8 @@ class TaskMetrics:
     # 声称完成但期望工具没做全。与 tool_call_accurate 的区别见 is_false_finish：
     # 后者对「做多了」也判 False，这里只抓「做少了」。
     false_finish: bool = False
+    # 指代解析准确率。未声明 expected_paper 的任务恒为 1.0，不参与扣分。
+    ref_score: float = 1.0
 
     # --- 原始数据 ---
     error: Optional[str] = None
@@ -99,6 +101,10 @@ def extract_metrics(
 
     false_finish = is_false_finish(termination_type, tool_sequence, expected_tools)
 
+    ref_score = reference_resolution_score(history, task_def.get("expected_paper"))
+    if ref_score is None:
+        ref_score = 1.0
+
     error = None
     if termination_type == "ERROR" and history:
         error = history[-1].get("observation", "")
@@ -127,6 +133,7 @@ def extract_metrics(
         tool_exec_failures=tool_exec_failures,
         arg_score=arg_score,
         false_finish=false_finish,
+        ref_score=ref_score,
         error=error,
     )
 
@@ -224,6 +231,65 @@ def is_false_finish(
     if termination_type != "FINISH" or not expected_tools:
         return False
     return lcs_length(tool_sequence, expected_tools) < len(expected_tools)
+
+
+# observation 里 paper_id 出现过三种写法，都要认：
+#   {'paper_id': '2608.14539v1', ...}      dict 的 str()，单引号
+#   {"paper_id": "2608.14539v1", ...}      JSON，双引号
+#   已创建翻译任务 task_id=..., paper_id=None    工具自己拼的可读文本
+_PAPER_ID_PATTERNS = (
+    re.compile(r"""['"]paper_id['"]\s*:\s*['"]([^'"]+)['"]"""),
+    re.compile(r"""\bpaper_id\s*=\s*([A-Za-z0-9._/-]+)"""),
+)
+_VERSION_SUFFIX = re.compile(r"v\d+$")
+
+
+def resolved_paper_id(observation: Any) -> Optional[str]:
+    """从 observation 里取出工具**实际解析到**的 paper_id，取不到返回 None。"""
+    text = observation if isinstance(observation, str) else str(observation or "")
+    for pattern in _PAPER_ID_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            value = match.group(1).strip()
+            return None if value.lower() in ("none", "null", "") else value
+    return None
+
+
+def _same_paper(left: str, right: str) -> bool:
+    """比较论文身份时忽略版本号：v1 与 v2 是同一篇论文的不同版本。"""
+    return _VERSION_SUFFIX.sub("", left.strip()) == _VERSION_SUFFIX.sub("", right.strip())
+
+
+def reference_resolution_score(
+    history: Sequence[Dict[str, Any]], expected_paper: Optional[str]
+) -> Optional[float]:
+    """指代解析准确率：工具解析到的论文，是不是任务指的那篇。
+
+    返回 [0,1]，任务未声明 expected_paper 时返回 None。
+
+    `ref` 支持序号 / arXiv ID / 标题子串 / null，是本 agent 真正的难点，
+    而按字符串比对参数对它**同时会假阳性和假阴性**：
+
+        假阳性  期望 {"ref":"Learning State"} 实际 {"ref":"Learning State"}
+                参数分满分，但子串匹配到了另一篇 —— 下错了论文
+        假阴性  期望 {"ref":"Decoding the Past"} 实际 {"ref":3}
+                参数分接近 0，但两者解析到同一篇 —— 其实做对了
+
+    所以不比参数，比工具返回值里的 paper_id：**指代形式随便用，
+    但必须落到正确的那篇论文**。
+
+    只统计观测里带 paper_id 的步骤 —— 检索类工具不解析单篇论文，不计入。
+    一步都没解析到，说明 agent 压根没碰论文，记 0。
+    """
+    if not expected_paper:
+        return None
+    resolved = [
+        pid for step in (history or [])
+        if (pid := resolved_paper_id(step.get("observation"))) is not None
+    ]
+    if not resolved:
+        return 0.0
+    return sum(_same_paper(pid, expected_paper) for pid in resolved) / len(resolved)
 
 
 def _check_tool_sequence(actual: List[str], expected: List[str]) -> bool:

--- a/AgenticArxiv/benchmark/metrics.py
+++ b/AgenticArxiv/benchmark/metrics.py
@@ -4,7 +4,7 @@
 import json
 import re
 from dataclasses import dataclass, field, asdict
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Sequence
 
 
 # 非工具调用的动作标记
@@ -43,6 +43,9 @@ class TaskMetrics:
     # 只看工具名的话，「下载标题含 X 的那篇」即使下错论文，
     # 工具序列仍是 [download_arxiv_pdf]，会被判为准确。
     arg_score: float = 1.0
+    # 声称完成但期望工具没做全。与 tool_call_accurate 的区别见 is_false_finish：
+    # 后者对「做多了」也判 False，这里只抓「做少了」。
+    false_finish: bool = False
 
     # --- 原始数据 ---
     error: Optional[str] = None
@@ -94,6 +97,8 @@ def extract_metrics(
     if arg_score is None:
         arg_score = 1.0
 
+    false_finish = is_false_finish(termination_type, tool_sequence, expected_tools)
+
     error = None
     if termination_type == "ERROR" and history:
         error = history[-1].get("observation", "")
@@ -121,6 +126,7 @@ def extract_metrics(
         parse_failures=parse_failures,
         tool_exec_failures=tool_exec_failures,
         arg_score=arg_score,
+        false_finish=false_finish,
         error=error,
     )
 
@@ -177,6 +183,47 @@ def _extract_tool_sequence(history: List[Dict]) -> List[str]:
         if name:
             tools.append(name)
     return tools
+
+
+def lcs_length(left: Sequence[Any], right: Sequence[Any]) -> int:
+    """最长公共子序列长度。
+
+    与 rl/reward.py 共用一份实现。此前两处各有一份 —— 同一个 helper
+    在多处复制，是 _precision_flags 那个 bug 的成因（三份里两份没跟上修复）。
+    """
+    row = [0] * (len(right) + 1)
+    for left_item in left:
+        previous = 0
+        for j, right_item in enumerate(right, 1):
+            saved = row[j]
+            row[j] = previous + 1 if left_item == right_item else max(row[j], row[j - 1])
+            previous = saved
+    return row[-1]
+
+
+def is_false_finish(
+    termination_type: str,
+    tool_sequence: Sequence[str],
+    expected_tools: Sequence[str],
+) -> bool:
+    """声称完成，但期望的工具调用没做全。
+
+    与 `not tool_call_accurate` 不是一回事，两者刻意区分：
+    严格序列比对对「做多了」和「做少了」一视同仁，而这里只抓「做少了」。
+
+        搜索 → 下载 → 多查一次缓存 → FINISH     召回率 1，不算假完成（只是绕路）
+        查缓存 → FINISH（本该还要下载）          召回率 <1，**假完成**
+
+    抓的是「不做事也能拿分」这条奖励漏洞。实测 state_cache_before_dl
+    24 次运行里 18 次属于此类（75%）：查完缓存直接 FINISH，
+    task_completed=True，任务根本没做。
+
+    判据只用任务已声明的 expected_tools，不引入终态谓词，
+    也不需要为每个任务写检查逻辑。
+    """
+    if termination_type != "FINISH" or not expected_tools:
+        return False
+    return lcs_length(tool_sequence, expected_tools) < len(expected_tools)
 
 
 def _check_tool_sequence(actual: List[str], expected: List[str]) -> bool:

--- a/AgenticArxiv/benchmark/report.py
+++ b/AgenticArxiv/benchmark/report.py
@@ -42,6 +42,14 @@ class BenchmarkReport:
                 "completion_rate": _rate(items, "task_completed"),
                 "tool_accuracy": _rate(items, "tool_call_accurate"),
                 "arg_accuracy": _avg(items, "arg_score"),
+                # 两个分母各有用途：对全部运行取率可跨 Agent 比较；
+                # 对 FINISH 运行取率回答「它说完成时有多少次在撒谎」。
+                "false_finish_rate": _rate(items, "false_finish"),
+                "false_finish_of_completed": (
+                    sum(1 for m in items if m.false_finish)
+                    / sum(1 for m in items if m.task_completed)
+                    if any(m.task_completed for m in items) else 0.0
+                ),
                 "avg_parse_failures": _avg(items, "parse_failures"),
                 "avg_tool_failures": _avg(items, "tool_exec_failures"),
             }
@@ -137,6 +145,7 @@ class BenchmarkReport:
                 "termination": m.termination_type,
                 "tool_accurate": m.tool_call_accurate,
                 "arg_score": m.arg_score,
+                "false_finish": m.false_finish,
                 "tools": ",".join(m.tool_call_sequence),
                 "expected": ",".join(m.expected_tools),
                 "parse_fail": m.parse_failures,
@@ -215,6 +224,7 @@ class BenchmarkReport:
             ("任务完成率", "completion_rate"),
             ("工具调用准确率", "tool_accuracy"),
             ("参数准确率", "arg_accuracy"),
+            ("假完成率", "false_finish_rate"),
             ("平均解析失败", "avg_parse_failures"),
             ("平均工具失败", "avg_tool_failures"),
         ]

--- a/AgenticArxiv/benchmark/report.py
+++ b/AgenticArxiv/benchmark/report.py
@@ -93,6 +93,47 @@ class BenchmarkReport:
             summary[agent_type] = row
         return summary
 
+    def cost_by_agent(self, criterion: str = "accurate") -> Dict[str, Dict[str, Any]]:
+        """交付一个成功结果的代价，以及失败时的代价形态。
+
+        分母取成功数而非运行数，分子取**全部**运行的用量：失败的尝试同样
+        烧 token 和时间，把它们排除在外会让「经常失败但失败得很快」的
+        Agent 显得便宜。
+
+        另外按成功/失败分开报迭代数。对全部运行取平均会双向污染：
+        撞上限的失败跑满迭代（拉高），提前放弃的失败只跑一两步（拉低），
+        混在一起既不代表成功时的效率，也不代表失败的代价。
+        """
+        is_success = SUCCESS_CRITERIA[criterion]
+        grouped: Dict[str, List[TaskMetrics]] = defaultdict(list)
+        for m in self.metrics:
+            grouped[m.agent_type].append(m)
+
+        summary: Dict[str, Dict[str, Any]] = {}
+        for agent_type, items in grouped.items():
+            wins = [m for m in items if is_success(m)]
+            losses = [m for m in items if not is_success(m)]
+            n_win = len(wins)
+            total_tokens = sum(m.total_tokens for m in items)
+            total_calls = sum(len(m.tool_call_sequence) for m in items)
+            total_ms = sum(m.total_time_ms for m in items)
+            summary[agent_type] = {
+                "runs": len(items),
+                "successes": n_win,
+                # 一次成功也没有时，「每次成功的代价」无从谈起 —— 返回 None
+                # 而不是 0 或无穷大，两者都会在排序里给出错误结论。
+                "tokens_per_success": total_tokens / n_win if n_win else None,
+                "calls_per_success": total_calls / n_win if n_win else None,
+                "ms_per_success": total_ms / n_win if n_win else None,
+                "median_iterations_success": _median([m.iteration_count for m in wins]),
+                "median_iterations_failure": _median([m.iteration_count for m in losses]),
+                # 失败形态：撞上限（死循环）与提前放弃是两种不同的病
+                "failed_at_limit": sum(1 for m in losses if m.termination_type == "FORCE_STOP"),
+                "failed_claiming_done": sum(1 for m in losses if m.termination_type == "FINISH"),
+                "failed_with_error": sum(1 for m in losses if m.termination_type == "ERROR"),
+            }
+        return summary
+
     def difficulty_bands(self, criterion: str = "accurate") -> Dict[str, List[str]]:
         """按成功率把任务分三档，跨 Agent 合并统计。
 
@@ -243,6 +284,38 @@ class BenchmarkReport:
 
         lines.append("")
 
+        # 代价（按成功归一化）
+        cost = self.cost_by_agent()
+        if cost:
+            lines.append("### 代价（按成功次数归一化）")
+            lines.append("")
+            lines.append(header)
+            lines.append(sep)
+            cost_rows = [
+                ("Token / 成功", "tokens_per_success"),
+                ("工具调用 / 成功", "calls_per_success"),
+                ("耗时(ms) / 成功", "ms_per_success"),
+                ("迭代数中位·成功", "median_iterations_success"),
+                ("迭代数中位·失败", "median_iterations_failure"),
+            ]
+            for label, key in cost_rows:
+                vals = []
+                for a in agents:
+                    v = cost.get(a, {}).get(key)
+                    vals.append("n/a" if v is None else _fmt(v))
+                lines.append(f"| {label} | " + " | ".join(vals) + " |")
+            lines.append("")
+            lines.append("失败形态：")
+            lines.append("")
+            lines.append(header)
+            lines.append(sep)
+            for label, key in [("撞迭代上限", "failed_at_limit"),
+                               ("声称完成但错", "failed_claiming_done"),
+                               ("异常终止", "failed_with_error")]:
+                vals = [str(cost.get(a, {}).get(key, 0)) for a in agents]
+                lines.append(f"| {label} | " + " | ".join(vals) + " |")
+            lines.append("")
+
         # 难度分档
         bands_md = self.difficulty_bands_md()
         if bands_md:
@@ -374,6 +447,17 @@ def pass_hat_k(n: int, c: int, k: int) -> Optional[float]:
     if c < k:
         return 0.0
     return math.comb(c, k) / math.comb(n, k)
+
+
+def _median(values: List[float]) -> Optional[float]:
+    """中位数。用中位而非均值：迭代数的分布被撞上限的样本拉出长尾。"""
+    if not values:
+        return None
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return float(ordered[mid])
+    return (ordered[mid - 1] + ordered[mid]) / 2
 
 
 def _avg(items: List[TaskMetrics], attr: str) -> float:

--- a/AgenticArxiv/benchmark/report.py
+++ b/AgenticArxiv/benchmark/report.py
@@ -4,6 +4,7 @@
 import csv
 import json
 import os
+import math
 from collections import defaultdict
 from typing import List, Dict, Any, Optional
 
@@ -45,6 +46,62 @@ class BenchmarkReport:
                 "avg_tool_failures": _avg(items, "tool_exec_failures"),
             }
         return summary
+
+    def reliability_by_agent(
+        self, ks=(1, 2, 3), criterion: str = "accurate"
+    ) -> Dict[str, Dict[str, Any]]:
+        """按 Agent 聚合 pass^k：先在每个任务内估计，再对任务取平均。
+
+        必须先按任务估计再平均 —— 直接把所有运行混在一起算，
+        「一个任务稳定成功、另一个稳定失败」会和「两个任务各成功一半」
+        得到相同的数字，而这两种情况的可靠性完全不同。
+        """
+        if criterion not in SUCCESS_CRITERIA:
+            raise ValueError(f"未知判据 {criterion}，可选 {sorted(SUCCESS_CRITERIA)}")
+        is_success = SUCCESS_CRITERIA[criterion]
+
+        grouped: Dict[str, Dict[str, List[TaskMetrics]]] = defaultdict(lambda: defaultdict(list))
+        for m in self.metrics:
+            grouped[m.agent_type][m.task_id].append(m)
+
+        summary: Dict[str, Dict[str, Any]] = {}
+        for agent_type, by_task in grouped.items():
+            row: Dict[str, Any] = {"criterion": criterion, "tasks": len(by_task)}
+            trials = [len(items) for items in by_task.values()]
+            row["min_trials"] = min(trials) if trials else 0
+            for k in ks:
+                scores = []
+                skipped = 0
+                for items in by_task.values():
+                    value = pass_hat_k(len(items), sum(1 for m in items if is_success(m)), k)
+                    if value is None:
+                        skipped += 1
+                    else:
+                        scores.append(value)
+                row[f"pass^{k}"] = sum(scores) / len(scores) if scores else None
+                # 试验次数不足的任务单独记账，不混进平均值
+                row[f"pass^{k}_skipped"] = skipped
+            summary[agent_type] = row
+        return summary
+
+    def difficulty_bands(self, criterion: str = "accurate") -> Dict[str, List[str]]:
+        """按成功率把任务分三档，跨 Agent 合并统计。
+
+        GRPO 的梯度来自组内奖励方差：成功率贴近 0 或 1 的任务，
+        同一 prompt 采样出的轨迹奖励一致，优势为零、不产生梯度。
+        中间带才是有效的训练样本，两端更适合留作评测的上下限。
+        """
+        is_success = SUCCESS_CRITERIA[criterion]
+        by_task: Dict[str, List[TaskMetrics]] = defaultdict(list)
+        for m in self.metrics:
+            by_task[m.task_id].append(m)
+
+        bands: Dict[str, List[str]] = {"floor": [], "middle": [], "ceiling": []}
+        for task_id, items in sorted(by_task.items()):
+            rate = sum(1 for m in items if is_success(m)) / len(items)
+            key = "floor" if rate < 0.2 else "ceiling" if rate > 0.8 else "middle"
+            bands[key].append(task_id)
+        return bands
 
     def summary_by_task(self) -> Dict[str, Dict[str, Any]]:
         """按任务 ID 聚合"""
@@ -125,6 +182,29 @@ class BenchmarkReport:
 
         lines.append("")
 
+        # 可靠性对比表
+        rel = self.reliability_by_agent()
+        if rel:
+            lines.append("### 可靠性（pass^k：k 次试验全部成功）")
+            lines.append("")
+            lines.append(header)
+            lines.append(sep)
+            for k in (1, 2, 3):
+                vals = []
+                for a in agents:
+                    v = rel.get(a, {}).get(f"pass^{k}")
+                    vals.append("n/a" if v is None else f"{v:.0%}")
+                lines.append(f"| pass^{k} | " + " | ".join(vals) + " |")
+            skipped = max(rel[a].get("pass^3_skipped", 0) for a in agents)
+            min_trials = min(rel[a].get("min_trials", 0) for a in agents)
+            if skipped:
+                lines.append("")
+                lines.append(
+                    f"> {skipped} 个任务的试验次数不足 3，未计入 pass^3"
+                    f"（最少的任务只有 {min_trials} 次）。"
+                )
+            lines.append("")
+
         # 准确性对比表
         lines.append("### 准确性对比")
         lines.append("")
@@ -150,6 +230,12 @@ class BenchmarkReport:
 
         lines.append("")
 
+        # 难度分档
+        bands_md = self.difficulty_bands_md()
+        if bands_md:
+            lines.append(bands_md)
+            lines.append("")
+
         # 按任务对比
         task_summary = self.summary_by_task()
         if task_summary:
@@ -163,6 +249,19 @@ class BenchmarkReport:
                     f"| {s['completion_rate']:.0%} | {s['tool_accuracy']:.0%} |"
                 )
 
+        return "\n".join(lines)
+
+    def difficulty_bands_md(self) -> str:
+        bands = self.difficulty_bands()
+        total = sum(len(v) for v in bands.values())
+        if not total:
+            return ""
+        lines = ["### 任务难度分档（跨 Agent 合并成功率）", ""]
+        lines.append("| 档位 | 成功率 | 任务数 | 用途 |")
+        lines.append("|---|---|---|---|")
+        lines.append(f"| floor | < 20% | {len(bands['floor'])} | 评测下限；GRPO 无梯度 |")
+        lines.append(f"| middle | 20~80% | {len(bands['middle'])} | **GRPO 训练集**；奖励方差最大 |")
+        lines.append(f"| ceiling | > 80% | {len(bands['ceiling'])} | 评测上限；GRPO 无梯度 |")
         return "\n".join(lines)
 
     def to_csv(self, path: str):
@@ -231,6 +330,38 @@ class BenchmarkReport:
 
 
 # ---- 工具函数 ----
+
+# 可靠性判据。pass^k 对「成功」的定义敏感，所以显式列出而不是写死一个。
+SUCCESS_CRITERIA = {
+    "completed": lambda m: m.task_completed,
+    "accurate": lambda m: m.task_completed and m.tool_call_accurate,
+}
+
+
+def pass_hat_k(n: int, c: int, k: int) -> Optional[float]:
+    """pass^k：从 n 次试验里随机抽 k 次，全部成功的概率。
+
+    采用 τ-bench 的 pass^k（**全部**成功），而非 HumanEval 的 pass@k
+    （**至少一次**成功）。前者衡量可靠性，k 越大越低；后者衡量能力上界，
+    k 越大越高。Agent 关心的是前者 —— 一个「三次里对一次」的 Agent
+    不能用，哪怕它的单次成功率看着不错。
+
+        pass^k = C(c, k) / C(n, k)
+
+    这是无偏估计，用上了全部 n 次试验，而不是只取前 k 次。
+    pass^1 恒等于朴素成功率 c/n，可作自检。
+
+    n < k 时无法估计，返回 None（由调用方决定跳过还是报缺失），
+    静默按 0 计会把「样本不够」和「真的做不到」混为一谈。
+    """
+    if k <= 0:
+        raise ValueError("k 必须为正")
+    if n < k:
+        return None
+    if c < k:
+        return 0.0
+    return math.comb(c, k) / math.comb(n, k)
+
 
 def _avg(items: List[TaskMetrics], attr: str) -> float:
     if not items:

--- a/AgenticArxiv/benchmark/report.py
+++ b/AgenticArxiv/benchmark/report.py
@@ -42,6 +42,7 @@ class BenchmarkReport:
                 "completion_rate": _rate(items, "task_completed"),
                 "tool_accuracy": _rate(items, "tool_call_accurate"),
                 "arg_accuracy": _avg(items, "arg_score"),
+                "ref_accuracy": _avg(items, "ref_score"),
                 # 两个分母各有用途：对全部运行取率可跨 Agent 比较；
                 # 对 FINISH 运行取率回答「它说完成时有多少次在撒谎」。
                 "false_finish_rate": _rate(items, "false_finish"),
@@ -146,6 +147,7 @@ class BenchmarkReport:
                 "tool_accurate": m.tool_call_accurate,
                 "arg_score": m.arg_score,
                 "false_finish": m.false_finish,
+                "ref_score": m.ref_score,
                 "tools": ",".join(m.tool_call_sequence),
                 "expected": ",".join(m.expected_tools),
                 "parse_fail": m.parse_failures,
@@ -224,6 +226,7 @@ class BenchmarkReport:
             ("任务完成率", "completion_rate"),
             ("工具调用准确率", "tool_accuracy"),
             ("参数准确率", "arg_accuracy"),
+            ("指代解析准确率", "ref_accuracy"),
             ("假完成率", "false_finish_rate"),
             ("平均解析失败", "avg_parse_failures"),
             ("平均工具失败", "avg_tool_failures"),

--- a/AgenticArxiv/rl/reward.py
+++ b/AgenticArxiv/rl/reward.py
@@ -10,7 +10,7 @@ import math
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
-from benchmark.metrics import TaskMetrics, argument_match_score, extract_metrics
+from benchmark.metrics import TaskMetrics, argument_match_score, extract_metrics, lcs_length
 
 
 TERMINAL_ACTIONS = {"FINISH", "FORCE_STOP", "ERROR"}
@@ -174,7 +174,7 @@ class RewardCalculator:
         # 「本该什么都不做却动了手」不该比「做错了」罚得更轻。
         if not expected:
             return 1.0 if not actual else -1.0
-        lcs = _lcs_length(actual, expected)
+        lcs = lcs_length(actual, expected)
         precision = lcs / len(actual) if actual else 0.0
         recall = lcs / len(expected)
         f1 = 2 * precision * recall / (precision + recall) if precision + recall else 0.0
@@ -275,17 +275,6 @@ def _parse_action(action: Any) -> Optional[Dict[str, Any]]:
     except (json.JSONDecodeError, TypeError):
         return None
     return parsed if isinstance(parsed, dict) else None
-
-
-def _lcs_length(left: Sequence[str], right: Sequence[str]) -> int:
-    row = [0] * (len(right) + 1)
-    for left_item in left:
-        previous = 0
-        for j, right_item in enumerate(right, 1):
-            saved = row[j]
-            row[j] = previous + 1 if left_item == right_item else max(row[j], row[j - 1])
-            previous = saved
-    return row[-1]
 
 
 def _scale_ratio(numerator: int, denominator: int) -> float:

--- a/AgenticArxiv/tests/test_cost_metrics.py
+++ b/AgenticArxiv/tests/test_cost_metrics.py
@@ -1,0 +1,100 @@
+"""按成功归一化的代价指标。
+
+对全部运行取平均会双向污染：撞上限的失败跑满迭代（拉高），
+提前放弃的失败只跑一两步（拉低）。混在一起得到的数字既不代表
+成功时的效率，也不代表失败的代价。
+"""
+
+import unittest
+
+from benchmark.metrics import TaskMetrics
+from benchmark.report import BenchmarkReport, _median
+
+
+def _m(agent, ok, tokens, iters, tools=(), termination=None):
+    if termination is None:
+        termination = "FINISH" if ok else "FORCE_STOP"
+    return TaskMetrics(
+        task_id="t", agent_type=agent, trial=0,
+        task_completed=termination == "FINISH", tool_call_accurate=ok,
+        termination_type=termination, total_tokens=tokens,
+        iteration_count=iters, tool_call_sequence=list(tools),
+        total_time_ms=tokens,          # 让耗时可预测，便于断言
+    )
+
+
+class MedianTest(unittest.TestCase):
+    def test_odd_length(self):
+        self.assertEqual(_median([3, 1, 2]), 2.0)
+
+    def test_even_length_averages_the_middle_pair(self):
+        self.assertEqual(_median([1, 2, 3, 4]), 2.5)
+
+    def test_empty_is_none_not_zero(self):
+        self.assertIsNone(_median([]))
+
+    def test_resists_the_long_tail(self):
+        # 均值会被撞上限的样本拉走，中位不会
+        values = [2, 2, 2, 2, 50]
+        self.assertEqual(_median(values), 2.0)
+        self.assertNotEqual(_median(values), sum(values) / len(values))
+
+
+class CostByAgentTest(unittest.TestCase):
+    def _cost(self, metrics, agent="regex"):
+        return BenchmarkReport(metrics, model="test").cost_by_agent()[agent]
+
+    def test_failed_runs_count_toward_the_numerator(self):
+        # 两次运行共 300 token，只有一次成功 -> 300，不是 100
+        row = self._cost([_m("regex", True, 100, 2), _m("regex", False, 200, 5)])
+        self.assertEqual(row["tokens_per_success"], 300.0)
+        self.assertEqual(row["successes"], 1)
+        self.assertEqual(row["runs"], 2)
+
+    def test_cheap_but_useless_agent_is_not_flattered(self):
+        # 失败得快 != 便宜。这正是不能只统计成功运行的原因。
+        good = self._cost([_m("regex", True, 500, 3)] * 2)
+        fast_fail = self._cost([_m("regex", True, 500, 3)] + [_m("regex", False, 50, 1)] * 8)
+        self.assertLess(good["tokens_per_success"], fast_fail["tokens_per_success"])
+
+    def test_zero_successes_gives_none_not_zero_or_infinity(self):
+        row = self._cost([_m("regex", False, 100, 5)] * 3)
+        self.assertIsNone(row["tokens_per_success"])
+        self.assertIsNone(row["calls_per_success"])
+        self.assertIsNone(row["ms_per_success"])
+
+    def test_calls_per_success_counts_tool_calls_not_steps(self):
+        row = self._cost([_m("regex", True, 10, 4, tools=("a", "b", "c"))])
+        self.assertEqual(row["calls_per_success"], 3.0)
+
+    def test_iterations_are_reported_separately_for_wins_and_losses(self):
+        metrics = [_m("regex", True, 10, 2), _m("regex", True, 10, 2),
+                   _m("regex", False, 10, 9)]
+        row = self._cost(metrics)
+        self.assertEqual(row["median_iterations_success"], 2.0)
+        self.assertEqual(row["median_iterations_failure"], 9.0)
+
+    def test_no_failures_leaves_failure_median_as_none(self):
+        row = self._cost([_m("regex", True, 10, 2)])
+        self.assertIsNone(row["median_iterations_failure"])
+
+    def test_failure_modes_are_split(self):
+        metrics = [
+            _m("regex", False, 10, 9, termination="FORCE_STOP"),
+            _m("regex", False, 10, 1, termination="FINISH"),
+            _m("regex", False, 10, 1, termination="ERROR"),
+            _m("regex", True, 10, 2),
+        ]
+        row = self._cost(metrics)
+        self.assertEqual(row["failed_at_limit"], 1)
+        self.assertEqual(row["failed_claiming_done"], 1)   # 声称完成但工具不对
+        self.assertEqual(row["failed_with_error"], 1)
+
+    def test_appears_in_the_markdown_report(self):
+        md = BenchmarkReport([_m("regex", True, 10, 2)], model="test").comparison_table_md()
+        self.assertIn("Token / 成功", md)
+        self.assertIn("失败形态", md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AgenticArxiv/tests/test_false_finish.py
+++ b/AgenticArxiv/tests/test_false_finish.py
@@ -1,0 +1,127 @@
+"""假完成：声称完成，但期望的工具调用没做全。
+
+抓的是「不做事也能拿分」这条奖励漏洞。实测 state_cache_before_dl
+24 次运行里 18 次属于此类（75%）—— 查完缓存直接 FINISH，
+task_completed=True，但论文根本没下载。只看 task_completed 这一栏，它是满分。
+"""
+
+import json
+import unittest
+
+from benchmark.metrics import extract_metrics, is_false_finish, lcs_length
+from benchmark.report import BenchmarkReport
+
+SEARCH, DOWNLOAD, CACHE = "get_recently_submitted_cs_papers", "download_arxiv_pdf", "get_paper_cache_status"
+
+
+def _step(name, args=None):
+    return {"thought": "t", "action": json.dumps({"name": name, "args": args or {}}), "observation": ""}
+
+
+def _finish():
+    return {"thought": "done", "action": "FINISH", "observation": "任务完成"}
+
+
+class LcsLengthTest(unittest.TestCase):
+    """与 rl/reward.py 共用一份实现，改动必须两边同时生效。"""
+
+    def test_matches_known_values(self):
+        self.assertEqual(lcs_length(["a", "b", "c"], ["a", "c"]), 2)
+        self.assertEqual(lcs_length([], ["a"]), 0)
+        self.assertEqual(lcs_length(["a"], []), 0)
+
+    def test_respects_order(self):
+        self.assertEqual(lcs_length(["b", "a"], ["a", "b"]), 1)
+
+    def test_reward_module_uses_the_same_function(self):
+        from rl import reward
+        self.assertIs(reward.lcs_length, lcs_length)
+
+
+class IsFalseFinishTest(unittest.TestCase):
+    def test_all_expected_tools_called_is_not_a_false_finish(self):
+        self.assertFalse(is_false_finish("FINISH", [SEARCH, DOWNLOAD], [SEARCH, DOWNLOAD]))
+
+    def test_missing_a_required_tool_is_a_false_finish(self):
+        # 实测样本：查完缓存就 FINISH，本该还要下载
+        self.assertTrue(is_false_finish("FINISH", [CACHE], [CACHE, DOWNLOAD]))
+
+    def test_extra_tools_are_not_a_false_finish(self):
+        # 与 tool_call_accurate 的关键区别：严格序列比对会判 False，这里不算
+        self.assertFalse(is_false_finish("FINISH", [SEARCH, CACHE, DOWNLOAD], [SEARCH, DOWNLOAD]))
+
+    def test_doing_nothing_at_all_is_a_false_finish(self):
+        self.assertTrue(is_false_finish("FINISH", [], [DOWNLOAD]))
+
+    def test_wrong_order_counts_as_a_false_finish(self):
+        # 先下载后检索，说明下载时会话里还没有论文列表 —— 工作没能真正完成。
+        # 这是刻意的取舍：LCS 计顺序，所以顺序错等于该做的没做成。
+        self.assertTrue(is_false_finish("FINISH", [DOWNLOAD, SEARCH], [SEARCH, DOWNLOAD]))
+
+    def test_force_stop_is_never_a_false_finish(self):
+        # 撞上限不算「声称完成」，它已经被 termination_type 记下了
+        self.assertFalse(is_false_finish("FORCE_STOP", [], [DOWNLOAD]))
+
+    def test_error_is_never_a_false_finish(self):
+        self.assertFalse(is_false_finish("ERROR", [], [DOWNLOAD]))
+
+    def test_tasks_expecting_no_tools_are_never_false_finishes(self):
+        # 「什么都不该做」的任务，FINISH 就是正确行为
+        self.assertFalse(is_false_finish("FINISH", [], []))
+
+
+class ExtractMetricsIntegrationTest(unittest.TestCase):
+    def _metrics(self, history, expected):
+        return extract_metrics({"id": "t", "expected_tools": expected},
+                               {"history": history}, "regex", 0)
+
+    def test_the_measured_failure_mode_is_flagged(self):
+        m = self._metrics([_step(CACHE, {"ref": 2}), _finish()], [CACHE, DOWNLOAD])
+        self.assertTrue(m.task_completed)        # 只看这一栏是满分
+        self.assertTrue(m.false_finish)          # 这一栏才暴露问题
+
+    def test_a_clean_run_is_not_flagged(self):
+        m = self._metrics([_step(SEARCH), _step(DOWNLOAD), _finish()], [SEARCH, DOWNLOAD])
+        self.assertTrue(m.task_completed)
+        self.assertFalse(m.false_finish)
+
+    def test_detour_is_inaccurate_but_not_a_false_finish(self):
+        # 两个指标必须能区分「绕路」和「没做」
+        m = self._metrics([_step(SEARCH), _step(CACHE), _step(DOWNLOAD), _finish()], [SEARCH, DOWNLOAD])
+        self.assertFalse(m.tool_call_accurate)   # 严格序列不符
+        self.assertFalse(m.false_finish)         # 但活确实干了
+
+    def test_json_wrapped_finish_does_not_break_the_check(self):
+        history = [_step(DOWNLOAD), _step("FINISH")]
+        self.assertFalse(self._metrics(history, [DOWNLOAD]).false_finish)
+
+
+class ReportAggregationTest(unittest.TestCase):
+    def _report(self, rows):
+        metrics = [
+            extract_metrics({"id": tid, "expected_tools": exp}, {"history": hist}, agent, i)
+            for i, (tid, exp, hist, agent) in enumerate(rows)
+        ]
+        return BenchmarkReport(metrics, model="test")
+
+    def test_reports_both_denominators(self):
+        rows = [
+            ("t1", [DOWNLOAD], [_step(CACHE), _finish()], "regex"),          # 假完成
+            ("t2", [DOWNLOAD], [_step(DOWNLOAD), _finish()], "regex"),       # 正常
+            ("t3", [DOWNLOAD], [{"thought": "x", "action": "FORCE_STOP", "observation": ""}], "regex"),
+        ]
+        row = self._report(rows).summary_by_agent()["regex"]
+        self.assertAlmostEqual(row["false_finish_rate"], 1 / 3)            # 占全部运行
+        self.assertAlmostEqual(row["false_finish_of_completed"], 1 / 2)    # 占 FINISH 运行
+
+    def test_no_completed_runs_does_not_divide_by_zero(self):
+        rows = [("t", [DOWNLOAD], [{"thought": "x", "action": "ERROR", "observation": ""}], "regex")]
+        self.assertEqual(self._report(rows).summary_by_agent()["regex"]["false_finish_of_completed"], 0.0)
+
+    def test_appears_in_the_markdown_report(self):
+        rows = [("t", [DOWNLOAD], [_step(CACHE), _finish()], "regex")]
+        self.assertIn("假完成率", self._report(rows).comparison_table_md())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AgenticArxiv/tests/test_reference_resolution.py
+++ b/AgenticArxiv/tests/test_reference_resolution.py
@@ -1,0 +1,127 @@
+"""指代解析准确率：工具解析到的论文，是不是任务指的那篇。
+
+`ref` 支持序号 / arXiv ID / 标题子串 / null，是本 agent 真正的难点。
+按字符串比对参数对它同时会假阳性和假阴性，所以改比工具返回值里的 paper_id：
+指代形式随便用，但必须落到正确的那篇论文。
+"""
+
+import json
+import unittest
+
+from benchmark.metrics import (
+    extract_metrics,
+    reference_resolution_score,
+    resolved_paper_id,
+)
+
+P1, P2 = "2608.14539v1", "2608.14548v1"
+
+
+def _step(observation, name="download_arxiv_pdf", args=None):
+    return {"thought": "t",
+            "action": json.dumps({"name": name, "args": args or {}}),
+            "observation": observation}
+
+
+def _dict_obs(pid):
+    # 真实形态：base_agent 对 dict 结果做 str()，得到 Python repr
+    return str({"session_id": "s", "paper_id": pid, "status": "READY"})
+
+
+class ResolvedPaperIdTest(unittest.TestCase):
+    """三种真实写法都要认，取自 traces/ 里的实际观测。"""
+
+    def test_python_repr_single_quotes(self):
+        self.assertEqual(resolved_paper_id(_dict_obs(P1)), P1)
+
+    def test_json_double_quotes(self):
+        self.assertEqual(resolved_paper_id(json.dumps({"paper_id": P1})), P1)
+
+    def test_key_value_text_form(self):
+        self.assertEqual(
+            resolved_paper_id(f"已创建翻译任务 task_id=t1, paper_id={P1}，状态=PENDING"), P1)
+
+    def test_explicit_none_is_not_a_paper(self):
+        self.assertIsNone(resolved_paper_id("已创建翻译任务 task_id=t1, paper_id=None，状态=PENDING"))
+
+    def test_error_observation_yields_nothing(self):
+        self.assertIsNone(resolved_paper_id("工具执行失败: 未找到论文"))
+
+    def test_search_observation_yields_nothing(self):
+        self.assertIsNone(resolved_paper_id("成功获取 5 篇论文:\n  - Some Title"))
+
+    def test_handles_non_string_observations(self):
+        self.assertIsNone(resolved_paper_id(None))
+        self.assertEqual(resolved_paper_id({"paper_id": P1}), P1)
+
+
+class ReferenceResolutionScoreTest(unittest.TestCase):
+    def test_returns_none_when_task_declares_no_expected_paper(self):
+        self.assertIsNone(reference_resolution_score([_step(_dict_obs(P1))], None))
+
+    def test_correct_paper_scores_one(self):
+        self.assertEqual(reference_resolution_score([_step(_dict_obs(P1))], P1), 1.0)
+
+    def test_wrong_paper_scores_zero(self):
+        self.assertEqual(reference_resolution_score([_step(_dict_obs(P2))], P1), 0.0)
+
+    def test_touching_no_paper_at_all_scores_zero(self):
+        # agent 压根没碰论文，不能算它没错
+        self.assertEqual(reference_resolution_score([_step("成功获取 5 篇论文")], P1), 0.0)
+
+    def test_averages_over_resolving_steps(self):
+        history = [_step(_dict_obs(P1)), _step(_dict_obs(P2))]
+        self.assertEqual(reference_resolution_score(history, P1), 0.5)
+
+    def test_search_steps_are_not_counted(self):
+        # 检索不解析单篇论文，不该稀释分数
+        history = [_step("成功获取 5 篇论文", name="get_recently_submitted_cs_papers"),
+                   _step(_dict_obs(P1))]
+        self.assertEqual(reference_resolution_score(history, P1), 1.0)
+
+    def test_version_suffix_is_ignored(self):
+        # v1 与 v2 是同一篇论文的不同版本
+        self.assertEqual(reference_resolution_score([_step(_dict_obs("2608.14539v2"))], "2608.14539v1"), 1.0)
+
+    def test_different_paper_is_not_excused_by_version_stripping(self):
+        self.assertEqual(reference_resolution_score([_step(_dict_obs("2608.99999v1"))], "2608.14539v1"), 0.0)
+
+
+class WhyNotArgumentMatchingTest(unittest.TestCase):
+    """这两条正是引入本指标的理由 —— 参数比对在此处会给出错误结论。"""
+
+    def test_catches_a_wrong_paper_that_argument_matching_would_pass(self):
+        # 参数字符串与期望完全一致，但标题子串匹配到了另一篇
+        history = [_step(_dict_obs(P2), args={"ref": "Learning State"})]
+        self.assertEqual(reference_resolution_score(history, P1), 0.0)
+
+    def test_credits_a_different_ref_form_that_argument_matching_would_fail(self):
+        # 用序号而非标题子串，参数分接近 0，但解析到同一篇
+        history = [_step(_dict_obs(P1), args={"ref": 3})]
+        self.assertEqual(reference_resolution_score(history, P1), 1.0)
+
+
+class ExtractMetricsIntegrationTest(unittest.TestCase):
+    def _metrics(self, history, task):
+        return extract_metrics(task, {"history": history}, "regex", 0)
+
+    def test_task_without_expected_paper_is_not_penalised(self):
+        m = self._metrics([_step(_dict_obs(P1))], {"id": "t", "expected_tools": []})
+        self.assertEqual(m.ref_score, 1.0)
+
+    def test_task_with_expected_paper_is_scored(self):
+        task = {"id": "t", "expected_tools": ["download_arxiv_pdf"], "expected_paper": P1}
+        self.assertEqual(self._metrics([_step(_dict_obs(P1))], task).ref_score, 1.0)
+        self.assertEqual(self._metrics([_step(_dict_obs(P2))], task).ref_score, 0.0)
+
+    def test_right_tool_wrong_paper_is_only_visible_in_ref_score(self):
+        # 工具序列完全正确，唯有 ref_score 暴露下错了论文
+        task = {"id": "t", "expected_tools": ["download_arxiv_pdf"], "expected_paper": P1}
+        m = self._metrics([_step(_dict_obs(P2)), {"thought": "d", "action": "FINISH", "observation": "任务完成"}], task)
+        self.assertTrue(m.tool_call_accurate)
+        self.assertFalse(m.false_finish)
+        self.assertEqual(m.ref_score, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AgenticArxiv/tests/test_reliability.py
+++ b/AgenticArxiv/tests/test_reliability.py
@@ -1,0 +1,130 @@
+"""pass^k 与难度分档。
+
+单次成功率会掩盖不稳定：实测 state_ref_ordinal_cn 在 8 次试验里
+regex 5/8、mcp 4/8 —— 看着「一半能对」，但没有一次能连续三次做对。
+pass^k 把这件事量出来。
+"""
+
+import unittest
+
+from benchmark.metrics import TaskMetrics
+from benchmark.report import BenchmarkReport, SUCCESS_CRITERIA, pass_hat_k
+
+
+def _m(task_id, agent_type, trial, ok, completed=None):
+    completed = ok if completed is None else completed
+    return TaskMetrics(
+        task_id=task_id, agent_type=agent_type, trial=trial,
+        task_completed=completed, tool_call_accurate=ok,
+        termination_type="FINISH" if completed else "FORCE_STOP",
+    )
+
+
+def _report(plan, agent="regex"):
+    """plan: {task_id: [是否成功, ...]}"""
+    metrics = [
+        _m(task, agent, i, bool(ok))
+        for task, outcomes in plan.items()
+        for i, ok in enumerate(outcomes)
+    ]
+    return BenchmarkReport(metrics, model="test")
+
+
+class PassHatKTest(unittest.TestCase):
+    def test_pass_1_equals_naive_success_rate(self):
+        # 自检：k=1 必须退化成朴素成功率
+        for n, c in ((8, 5), (4, 1), (10, 10), (3, 0)):
+            self.assertAlmostEqual(pass_hat_k(n, c, 1), c / n, places=9)
+
+    def test_uses_the_unbiased_combinatorial_estimator(self):
+        # C(5,3)/C(8,3) = 10/56
+        self.assertAlmostEqual(pass_hat_k(8, 5, 3), 10 / 56, places=9)
+
+    def test_all_successes_gives_one(self):
+        self.assertEqual(pass_hat_k(8, 8, 3), 1.0)
+
+    def test_fewer_successes_than_k_gives_zero(self):
+        self.assertEqual(pass_hat_k(8, 2, 3), 0.0)
+
+    def test_is_non_increasing_in_k(self):
+        # pass^k 衡量可靠性，k 越大只会越低（与 HumanEval 的 pass@k 相反）
+        values = [pass_hat_k(8, 5, k) for k in (1, 2, 3, 4)]
+        self.assertEqual(values, sorted(values, reverse=True))
+
+    def test_too_few_trials_returns_none_not_zero(self):
+        # 「样本不够」不能和「真的做不到」混为一谈
+        self.assertIsNone(pass_hat_k(2, 2, 3))
+
+    def test_rejects_non_positive_k(self):
+        with self.assertRaises(ValueError):
+            pass_hat_k(8, 5, 0)
+
+
+class ReliabilityByAgentTest(unittest.TestCase):
+    def test_perfectly_stable_agent_scores_one_everywhere(self):
+        row = _report({"a": [1, 1, 1, 1]}).reliability_by_agent()["regex"]
+        self.assertEqual((row["pass^1"], row["pass^2"], row["pass^3"]), (1.0, 1.0, 1.0))
+
+    def test_coin_flip_task_collapses_at_higher_k(self):
+        row = _report({"a": [1, 0, 1, 0]}).reliability_by_agent()["regex"]
+        self.assertAlmostEqual(row["pass^1"], 0.5)
+        self.assertAlmostEqual(row["pass^2"], 1 / 6)
+        self.assertEqual(row["pass^3"], 0.0)
+
+    def test_averages_per_task_not_over_pooled_runs(self):
+        # 「一稳成一稳败」与「两个各一半」的朴素成功率都是 50%，
+        # 但可靠性完全不同 —— 必须先按任务估计再平均
+        split = _report({"ok": [1, 1, 1, 1], "bad": [0, 0, 0, 0]}).reliability_by_agent()["regex"]
+        mixed = _report({"x": [1, 0, 1, 0], "y": [1, 0, 1, 0]}).reliability_by_agent()["regex"]
+        self.assertAlmostEqual(split["pass^1"], mixed["pass^1"])   # 朴素成功率相同
+        self.assertGreater(split["pass^3"], mixed["pass^3"])       # 可靠性不同
+
+    def test_tasks_with_too_few_trials_are_counted_not_averaged_in(self):
+        row = _report({"short": [1, 1], "long": [1, 1, 1, 1]}).reliability_by_agent()["regex"]
+        self.assertEqual(row["pass^3_skipped"], 1)
+        self.assertEqual(row["pass^3"], 1.0)      # 只由 long 贡献，不被 short 拉低
+        self.assertEqual(row["min_trials"], 2)
+
+    def test_criterion_accurate_requires_both_completed_and_accurate(self):
+        # 声称完成但工具序列不对，不算成功
+        metrics = [_m("a", "regex", i, ok=False, completed=True) for i in range(4)]
+        report = BenchmarkReport(metrics, model="test")
+        self.assertEqual(report.reliability_by_agent(criterion="accurate")["regex"]["pass^1"], 0.0)
+        self.assertEqual(report.reliability_by_agent(criterion="completed")["regex"]["pass^1"], 1.0)
+
+    def test_rejects_unknown_criterion(self):
+        with self.assertRaises(ValueError):
+            _report({"a": [1]}).reliability_by_agent(criterion="nope")
+
+    def test_every_declared_criterion_is_callable(self):
+        sample = _m("a", "regex", 0, True)
+        for name, fn in SUCCESS_CRITERIA.items():
+            self.assertIsInstance(fn(sample), bool, name)
+
+
+class DifficultyBandsTest(unittest.TestCase):
+    """GRPO 的梯度来自组内奖励方差，成功率贴近 0 或 1 的任务不产生梯度。"""
+
+    def test_splits_into_floor_middle_ceiling(self):
+        bands = _report({
+            "never": [0, 0, 0, 0],
+            "half": [1, 0, 1, 0],
+            "always": [1, 1, 1, 1],
+        }).difficulty_bands()
+        self.assertEqual(bands["floor"], ["never"])
+        self.assertEqual(bands["middle"], ["half"])
+        self.assertEqual(bands["ceiling"], ["always"])
+
+    def test_boundaries_are_inclusive_of_the_middle_band(self):
+        bands = _report({"low": [1, 0, 0, 0, 0], "high": [1, 1, 1, 1, 0]}).difficulty_bands()
+        self.assertEqual(bands["middle"], ["high", "low"])   # 20% 与 80% 都算中间带
+
+    def test_merges_agents_so_a_task_lands_in_one_band(self):
+        metrics = ([_m("t", "regex", i, True) for i in range(4)]
+                   + [_m("t", "mcp", i, False) for i in range(4)])
+        bands = BenchmarkReport(metrics, model="test").difficulty_bands()
+        self.assertEqual(bands["middle"], ["t"])             # 合并后 50%
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Toward the **P1 — 数据与评测** items still open in the README. The task set and
its discrimination gate landed in #36 / #39 / #40 / #47; this PR is about the
*reporting* side, which has not moved: `BenchmarkReport` still summarises a run
as a success rate, a mean token count, and a mean iteration count.

Each of those three numbers is misleading in a specific, reproducible way, and
a fourth — the argument score — is measuring the wrong thing for the one
decision this agent actually has to get right. Four commits, one per metric,
each with tests.

## 1. A success rate hides instability — `pass^k`

Measured over 8 trials per task, `state_ref_ordinal_cn` succeeds 5 times out of
8. That reads as "mostly works". The probability that three consecutive
attempts all succeed is **18%**. The task is not usable, and it is the same one
that earlier produced a spurious 13-point gap between two agent types when only
2 trials were run.

`pass^k` is the probability that k independent trials *all* succeed — tau-bench's
definition, not HumanEval's `pass@k` (at least one of k). The first measures
reliability and falls as k grows; the second measures an upper bound on
capability and rises.

Estimated as `C(c, k) / C(n, k)` over c successes in n trials: unbiased, uses
every trial rather than the first k, and `pass^1` reduces to the naive success
rate — which the tests use as a self-check.

Two choices that matter:

- **Estimate per task, then average over tasks.** Pooling all runs makes "one
  task always passes, another always fails" indistinguishable from "two tasks
  each pass half the time". Those have very different reliability.
- **A task with fewer than k trials returns `None` and counts as skipped**, not
  as 0. "Not enough samples" and "genuinely cannot do it" are different claims;
  the report says how many tasks were dropped.

On the 8-trial subset:

| agent | pass^1 | pass^2 | pass^3 |
|---|---:|---:|---:|
| mcp | 75% | 66% | 60% |
| regex | 81% | 76% | 73% |

Also adds `difficulty_bands()` — floor (<20%) / middle (20–80%) / ceiling
(>80%). GRPO's gradient comes from reward variance within a group, so tasks
pinned at either end produce no gradient at all. The middle band is the useful
training set; the two ends are better kept as evaluation floor and ceiling.

## 2. `task_completed` is the agent's own claim — `false_finish`

`task_completed` is `last_action == FINISH`. Nothing checks the claim. On
"check whether paper 2 is downloaded, and download it if not", the model checks
the cache and finishes without downloading: **18 of 24 runs (75%)** end that
way, and every one scores `task_completed = True`.

`false_finish` flags a run that terminates in `FINISH` while at least one
expected tool was never called. Deliberately *not* the same as
`not tool_call_accurate` — strict sequence matching fails a run for doing too
much as well as too little, and only the second is a false claim of success:

```
search, download, extra cache lookup, FINISH   recall 1    detour, not a false finish
cache lookup, FINISH (download required)       recall <1   false finish
```

Wrong ordering counts too, since LCS respects order: downloading before
searching means there was no paper list to resolve the reference against. There
is a test pinning that choice.

Reported with two denominators, because they answer different questions:
`false_finish_rate` over all runs is comparable across agents with different
finish rates; `false_finish_of_completed` over `FINISH` runs answers "when it
says it is done, how often is that false".

**Validation against the degenerate baselines** — the metric separates exactly
the behaviour it is meant to, and nothing else:

| policy | false-finish |
|---|---:|
| `reference` | 0 / 59 (0.0%) |
| `always_finish` | 54 / 59 (91.5%) |
| `always_search` | 40 / 59 (67.8%) |
| `wrong_args` | 0 / 59 (0.0%) |

`always_finish`'s 5 unflagged tasks are the 5 `infeasible` ones, where calling
nothing *is* correct. `wrong_args` scores 0% correctly: it calls the right
tools with wrong values, which is an argument failure, not a false finish. The
two metrics are orthogonal by construction and measure orthogonal in practice.

## 3. Reference resolution is scored by phrasing — `ref_score`

`ref` accepts an ordinal, an arXiv id, a title substring, or null, and
resolving it is the hard part of this agent. Comparing the argument as a string
gets that wrong in both directions:

```
false pass   expected {"ref":"Learning State"}   actual {"ref":"Learning State"}
             argument score 1.0 — but the substring matched a different paper,
             and the wrong PDF was downloaded
false fail   expected {"ref":"Decoding the Past"} actual {"ref":3}
             argument score near 0 — but both resolve to the same paper
```

So score the resolved entity instead of the phrasing. Every tool that touches a
paper returns `paper_id`; compare that against the paper the task names. Any
reference form is accepted; landing on the wrong paper is not.

This is also what lets multiple correct paths stay correct without end-state
predicates or per-task verification logic. Tasks opt in with one optional field,
`expected_paper`. `expected_tools` is untouched, and tasks without the field
score 1.0 and are not penalised.

`paper_id` appears in observations in three shapes, all seen in `traces/`:

```
{'paper_id': '2608.14539v1', ...}            str() of a dict, single quotes
{"paper_id": "2608.14539v1", ...}            JSON
已创建翻译任务 task_id=..., paper_id=None      text the tool assembles itself
```

Checked against all 81 observations in `traces/` and `eval/results/`: 19 carry
a resolvable id and all 19 parse; the 2 that mention `paper_id` without one are
an error message containing the word and an explicit `paper_id=None`. No false
positives.

Only steps whose observation carries a `paper_id` count — search does not
resolve a single paper and must not dilute the score. Version suffixes are
ignored (`v1` and `v2` are the same paper); a different id is still wrong, with
its own test.

## 4. Cost averaged over runs flatters unreliable agents

Failed attempts burn tokens too, and an agent that fails fast looks cheap.
Same totals, divided by successes instead of runs, on the existing 258-run
comparison:

| metric | mcp | regex | skill_cli |
|---|---:|---:|---:|
| avg tokens per run | 3763 | 3696 | 5288 |
| **tokens per success** | 4149 | 4075 | **8121** |

`skill_cli` goes from 43% more expensive to 99% more expensive, because 30 of
its 86 runs delivered nothing.

Reporting iterations separately for wins and losses shows why:

| | mcp | regex | skill_cli |
|---|---:|---:|---:|
| median iterations, success | 2.0 | 2.0 | 2.0 |
| median iterations, failure | 3.0 | 3.5 | 6.0 |
| hit the iteration limit | 3 | 3 | **24** |

All three are equally efficient when they succeed. The entire gap is in how
they fail. Averaging over all runs reports this as "3.3 iterations vs 2.5",
which reads as uniformly slower and hides the actual failure mode.

The numerator keeps failed runs — there is a test that an agent which fails
fast must not come out cheaper than one that succeeds. Zero successes returns
`None` rather than 0 or infinity, both of which sort incorrectly.

## One conflict resolved while rebasing

These commits predate #40 and the PPO rewrite. `_tool_score` in `rl/reward.py`
conflicted:

- `main` returns **−1.0** when a task expects no tools and the policy called
  one; the branch predates that and returns 0.0. Kept `main`'s −1.0 — that is
  the infeasible penalty from #40, and dropping it would reopen the leak.
- The branch replaces `reward.py`'s private `_lcs_length` with the shared
  `lcs_length` now living in `benchmark/metrics.py`. Kept that — two copies of
  one helper is how the `_precision_flags` bug happened.

Baselines are byte-identical before and after, which confirms the resolution
preserved #40's semantics: `reference` 1.000, `always_finish` −0.121,
`always_search` 0.017, `random_tool` −0.056, `wrong_args` 0.454; both health
gates PASS.

## Tests

272 passed, 1 skipped (205 before this PR; +67 across four new test modules).
The 3 failures and 3 errors that remain are environment-only and identical on
`main`: `trl` is not installed, and `test_modules` / `test_tool_registry`
require network access.
