### PR TITLE
feat: wire the train/iid/ood split into the benchmark and GRPO CLIs

### DIFF
--- a/AgenticArxiv/benchmark/readme.md
+++ b/AgenticArxiv/benchmark/readme.md
@@ -30,9 +30,33 @@ python -m benchmark.run_benchmark --output /path/to/output
 
 # 指定 session 前缀（用于区分不同测试轮次，默认 bench_r<timestamp>）
 python -m benchmark.run_benchmark --prefix bench_r1
+
+# 只跑某一份切分（见下）
+python -m benchmark.run_benchmark --task-set expanded --offline --split iid_test
 ```
 
 默认 8 个任务 x 3 种 Agent x 3 次重复 = 72 次运行。
+
+### 训练/留出集切分
+
+`--split` 从 `data/splits/v1.json` 取一份任务：
+
+| 名字 | 条数 | 是什么 |
+|---|---:|---|
+| `train` | 42 | 训练集 |
+| `iid_test` | 13 | 同模板、未见过的参数实例——「换个参数还会不会」 |
+| `ood_test` | 4 | 完全未见过的模板/链长——「换个形态还会不会」 |
+| `rl_train` | 13 | `train` 中成功率处于中间带的部分，**算出来的、不在文件里** |
+
+切分在**模板**层面进行：`search_AI_1d_3` 与 `search_AI_30d_25` 是同一模板换参数，
+按任务随机切会让它们分居两侧，测出来的「泛化」其实是记忆。
+
+两个留出集都要看：只有 iid 提升可能是记住了模板，ood 也提升才更像基础能力变强。
+
+`rl_train` 供 `rl/train_grpo.py --split rl_train` 使用——GRPO 的优势是组内相对的，
+成功率贴近 0 或 1 的任务每条采样奖励一致，方差为零、不产生梯度，放进训练集是空转。
+
+也可显式指定文件：`--split data/splits/v2.json:ood_test`。阶段间对比必须引用同一份文件。
 
 ## 退化策略基线
 
@@ -136,6 +160,8 @@ draw/images/
 | termination_type | 终止类型: FINISH / FORCE_STOP / ERROR / INCOMPLETE |
 | tool_call_accurate | 实际工具调用是否与预期工具序列完全相等（顺序严格、无多余/重复调用），只比工具名 |
 | arg_score | 参数级匹配度 `[0,1]`：逐步比对期望键的**取值**；未声明 `expected_tool_args` 时为 1.0 |
+| ref_score | 指代解析准确率 `[0,1]`：比对**解析出的 `paper_id`** 而非 `ref` 的写法；未声明 `expected_paper` 时为 1.0 |
+| false_finish | 以 `FINISH` 结束、但期望工具没做全。只抓「做少了」，绕路多调不算 |
 | parse_failures | LLM 响应解析失败次数 |
 | tool_exec_failures | 工具执行失败次数 |
 
@@ -150,6 +176,7 @@ benchmark/
   runner.py           # BenchmarkRunner：驱动 Agent 执行测试集
   metrics.py          # TaskMetrics：从 run() 结果提取指标
   baselines.py        # 确定性退化策略与评分敏感性汇总
+  splits.py           # 模板层 train/iid/ood 切分与 load_split
   report.py           # BenchmarkReport：生成 Markdown/CSV/JSON 报告
   run_benchmark.py    # CLI 入口
   run_baselines.py    # 离线退化策略诊断 CLI

--- a/AgenticArxiv/benchmark/run_benchmark.py
+++ b/AgenticArxiv/benchmark/run_benchmark.py
@@ -24,6 +24,7 @@ if PROJECT_ROOT not in sys.path:
 from tools.bootstrap import require_all_tools
 from benchmark.tasks import get_all_tasks
 from benchmark.tasks_expanded import get_expanded_tasks
+from benchmark.splits import DEFAULT_SPLIT_PATH, load_split
 from benchmark.runner import BenchmarkRunner
 from benchmark.report import BenchmarkReport
 from config import settings
@@ -79,6 +80,14 @@ def main():
     )
     parser.add_argument("--snapshot", default=None, help="指定快照路径（默认 data/mock_arxiv_snapshot.json）")
     parser.add_argument(
+        "--split", default=None, metavar="[FILE:]NAME",
+        help=(
+            f"只跑某一份切分，如 iid_test（用 {DEFAULT_SPLIT_PATH.name}）或 "
+            "data/splits/v2.json:ood_test。iid=同模板换参数，ood=未见过的模板；"
+            "训练前后对比必须引用同一份文件，否则数字不可比。需配合 --task-set expanded"
+        ),
+    )
+    parser.add_argument(
         "--task-set", choices=["default", "expanded"], default="default",
         help=(
             f"default=benchmark/tasks.py 的 {len(get_all_tasks())} 条；"
@@ -119,6 +128,25 @@ def main():
         if not task_list:
             print(f"错误: 未找到任务 {args.task_ids}")
             sys.exit(1)
+    elif args.split:
+        try:
+            wanted = set(load_split(args.split))
+        except (OSError, ValueError, KeyError) as exc:
+            print(f"错误: {exc}")
+            sys.exit(1)
+        by_id = {t["id"]: t for t in pool}
+        task_list = [by_id[tid] for tid in sorted(wanted) if tid in by_id]
+        missing = wanted - set(by_id)
+        if missing:
+            # 切分文件是按完整任务集划的。少了任务通常意味着任务池被别的
+            # 开关缩过（--task-set default 只有 8 条，或未加 --offline
+            # 跳掉了绑定快照的那些），此时跑出来的数字不能与别的阶段比。
+            print(f"错误: 切分 '{args.split}' 里有 {len(missing)} 条任务不在当前任务池中，"
+                  f"例如 {sorted(missing)[:3]}")
+            print("      切分按 --task-set expanded 的完整任务集划定；"
+                  "绑定快照的任务还需要 --offline")
+            sys.exit(1)
+        print(f"使用切分 {args.split}（{len(task_list)} 条）")
     elif args.tasks:
         task_list = [t for t in pool if t.get("category") == args.tasks]
         if not task_list:

--- a/AgenticArxiv/benchmark/splits.py
+++ b/AgenticArxiv/benchmark/splits.py
@@ -13,14 +13,23 @@
 只有 ood 提升更可能是基础能力变强。
 """
 
+import json
 import random
 from collections import defaultdict
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 # 成功率分档边界。GRPO 的梯度来自组内奖励方差，两端不产生梯度，
 # 所以训练集应以中间带为主，两端更适合留作评测的上下限。
 FLOOR_MAX = 0.2
 CEILING_MIN = 0.8
+
+# 固化的切分。阶段间对比必须引用同一份文件，否则数字不可比。
+DEFAULT_SPLIT_PATH = Path(__file__).resolve().parents[2] / "data" / "splits" / "v1.json"
+
+# 文件里没有、按 rates 算出来的一份：train 中处于中间带的任务。
+# 不落盘是有意的 —— 它完全由 train 与 rates 决定，多存一份就多一处会漂的地方。
+COMPUTED_SPLITS = ("rl_train",)
 
 
 def template_key(task: Dict[str, Any]) -> Tuple[str, int]:
@@ -130,3 +139,40 @@ def rl_train_ids(
         tid for tid in split["train"]
         if tid in rates and difficulty_band(rates[tid]) == "middle"
     )
+
+
+def load_split(spec: str) -> List[str]:
+    """按名字取一份切分的任务 id。
+
+    spec 形如 `iid_test`（用 DEFAULT_SPLIT_PATH）或
+    `data/splits/v2.json:iid_test`（显式指定文件）。
+
+    除文件里存的 train / iid_test / ood_test 外，还接受 `rl_train`：
+    train 中成功率处于中间带的部分，见 rl_train_ids。它是算出来的，
+    不存在于文件里。
+    """
+    path_part, _, name = spec.rpartition(":")
+    path = Path(path_part) if path_part else DEFAULT_SPLIT_PATH
+    if not name:
+        raise ValueError(f"切分名为空: {spec!r}")
+    if not path.exists():
+        raise FileNotFoundError(f"切分文件不存在: {path}")
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    groups = payload.get("split", payload)
+    available = sorted(set(groups) | set(COMPUTED_SPLITS))
+
+    if name in groups:
+        return list(groups[name])
+    if name not in COMPUTED_SPLITS:
+        raise ValueError(f"切分 {name!r} 不存在于 {path}，可选: {available}")
+
+    rates = payload.get("rates")
+    if not rates:
+        # 中间带是按实测成功率划的。没有 rates 就没有中间带，
+        # 这时返回空列表会让训练集静默变空，不如直接报错。
+        raise ValueError(f"{path} 没有记录 rates，无法算出 {name!r}")
+    ids = rl_train_ids(groups, rates)
+    if not ids:
+        raise ValueError(f"{path} 的 train 里没有中间带任务，{name!r} 为空")
+    return ids

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -23,6 +23,7 @@ import dataclasses
 import os
 import sys
 from pathlib import Path
+from typing import Optional
 
 PACKAGE_ROOT = Path(__file__).resolve().parents[1]
 REPO_ROOT = PACKAGE_ROOT.parent
@@ -44,6 +45,8 @@ import tools.pdf_download_tool  # noqa: F401
 import tools.pdf_translate_tool  # noqa: F401
 
 from benchmark.tasks import get_all_tasks
+from benchmark.splits import DEFAULT_SPLIT_PATH, load_split
+from benchmark.tasks_expanded import get_expanded_tasks
 from rl.canary import CanaryEvaluator, CanaryCallback
 from rl.grpo_reward import (
     build_prompt_dataset,
@@ -70,6 +73,44 @@ def _precision_flags():
     return precision_flags()
 
 
+def _load_tasks(task_set: str, split: Optional[str]):
+    """选择训练任务集。
+
+    默认仍是 benchmark/tasks.py 的 8 条冒烟任务 —— 换默认值会让此前所有
+    训练曲线不可比，所以要用完整任务集必须显式 --task_set expanded。
+
+    `--split rl_train` 取的是 train 中成功率处于中间带的那部分：GRPO 的
+    优势是组内相对的，成功率贴近 0 或 1 的任务，同一 prompt 采样出的轨迹
+    奖励一致，组内方差为零、优势为零、不产生任何梯度。把它们放进训练集
+    是纯粹的空转，还会把 frac_reward_zero_std 顶到 1 触发方差守卫。
+    """
+    pool = get_expanded_tasks() if task_set == "expanded" else get_all_tasks()
+    if not split:
+        if task_set != "expanded":
+            print(
+                f"⚠️  正在用 benchmark/tasks.py 的 {len(pool)} 条冒烟任务训练。"
+                "完整任务集用 --task_set expanded；\n"
+                "    只训练有梯度的那部分用 --task_set expanded "
+                f"--split rl_train（{DEFAULT_SPLIT_PATH.name}）"
+            )
+        return pool
+
+    wanted = set(load_split(split))
+    by_id = {t["id"]: t for t in pool}
+    chosen = [by_id[tid] for tid in sorted(wanted) if tid in by_id]
+    missing = wanted - set(by_id)
+    if missing:
+        # 切分按完整任务集划定，缺任务说明任务池选错了，
+        # 此时训练集会静默变小，训出来的东西与切分不对应。
+        raise SystemExit(
+            f"❌ 切分 '{split}' 里有 {len(missing)} 条任务不在当前任务集中，"
+            f"例如 {sorted(missing)[:3]}\n"
+            "   切分按 --task_set expanded 的完整任务集划定"
+        )
+    print(f"📑 使用切分 {split}（{len(chosen)} 条）")
+    return chosen
+
+
 def _gold_completion_tokens(tokenizer, tasks) -> int:
     """标准动作渲染成 ReAct 文本后的最大 token 数。
 
@@ -86,6 +127,18 @@ def _gold_completion_tokens(tokenizer, tasks) -> int:
     return max(lengths)
 
 
+def _global_step(state) -> int:
+    """当前步数，取不到就按 0（视作还在开局宽限期内）。
+
+    宽限期只用来区分「开局就没梯度」和「练到没梯度」，判错的代价是
+    多报一次故障；为它让训练崩掉才是更坏的结果。
+    """
+    try:
+        return int(getattr(state, "global_step", 0) or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
 class RewardVarianceGuard(TrainerCallback):
     """组内奖励方差为 0 时中止训练。
 
@@ -99,10 +152,16 @@ class RewardVarianceGuard(TrainerCallback):
     而这一栏很容易被忽略。这里把它变成一次响亮的失败。
     """
 
-    def __init__(self, patience: int = 5):
+    def __init__(self, patience: int = 5, grace_steps: int = 20):
         self.patience = patience
+        # 只有开局 grace_steps 步内的零方差才算故障。此后再出现，通常是策略
+        # 已经在当前任务集上做满了 —— 尤其 --split rl_train 只有十来条中间带
+        # 任务，模型学会之后每组都是满分，方差自然归零。那是「该换任务了」，
+        # 不是「训练坏了」，把它当故障会白扔一个已经练好的 checkpoint。
+        self.grace_steps = grace_steps
         self.streak = 0
         self.tripped = False
+        self.converged = False
 
     def on_log(self, args, state, control, logs=None, **kwargs):
         if not logs:
@@ -122,9 +181,22 @@ class RewardVarianceGuard(TrainerCallback):
         if self.streak < self.patience:
             return
 
-        self.tripped = True
         control.should_training_stop = True
         mean = logs.get("reward")
+        step = _global_step(state)
+        if step > self.grace_steps:
+            # 收敛而非故障：正常停止，保留 checkpoint
+            self.converged = True
+            print(
+                f"\n⏹  第 {step} 步起连续 {self.streak} 步组内奖励方差为 0"
+                + (f"（奖励恒为 {float(mean):.4f}）" if mean is not None else "")
+                + "，策略已在当前任务集上收敛，提前停止并保存。\n"
+                "   要继续训练需要换一批任务：重新划中间带（成功率会随训练漂移，"
+                "旧的 rl_train 会逐渐变成 ceiling），或扩充任务集。"
+            )
+            return
+
+        self.tripped = True
         print(
             f"\n❌ 连续 {self.streak} 步组内奖励方差为 0"
             + (f"（奖励恒为 {float(mean):.4f}）" if mean is not None else "")
@@ -151,6 +223,8 @@ def main(
     max_turns: int = 4,
     temperature: float = 1.0,
     snapshot: str = None,
+    task_set: str = "default",
+    split: str = None,
     allow_zero_variance: bool = False,
     canary_steps: int = 50,
     min_canary_reward: float = -1.0,
@@ -181,7 +255,7 @@ def main(
     policy = AutoModelForCausalLM.from_pretrained(resolved)
 
     # --- 数据集：直接由任务集派生，无需预生成 ---
-    tasks = get_all_tasks()
+    tasks = _load_tasks(task_set, split)
     rows = build_prompt_dataset(tasks)
     train_dataset = Dataset.from_list(rows)
     print(f"📚 任务数: {len(tasks)}（GRPO 为在线算法，无需预生成轨迹数据）")
@@ -333,6 +407,17 @@ if __name__ == "__main__":
     )
     p.add_argument("--temperature", type=float, default=1.0)
     p.add_argument("--snapshot", default=None)
+    p.add_argument(
+        "--task_set", choices=["default", "expanded"], default="default",
+        help="default=benchmark/tasks.py 的 8 条冒烟任务（保持现状）；"
+             "expanded=完整基准集。改默认值会让既有训练曲线不可比，故需显式指定",
+    )
+    p.add_argument(
+        "--split", default=None, metavar="[FILE:]NAME",
+        help=f"只用某一份切分训练，如 rl_train（用 {DEFAULT_SPLIT_PATH.name}）或 "
+             "data/splits/v2.json:train。rl_train 只含成功率中间带的任务——"
+             "GRPO 的梯度来自组内奖励方差，两端的任务不产生梯度。需配合 --task_set expanded",
+    )
     p.add_argument(
         "--canary_steps", type=int, default=50,
         help="每隔多少步运行 canary 评估（0 表示禁用）",

--- a/AgenticArxiv/tests/test_splits.py
+++ b/AgenticArxiv/tests/test_splits.py
@@ -5,11 +5,14 @@
 """
 
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
 from benchmark.splits import (
+    DEFAULT_SPLIT_PATH,
     difficulty_band,
+    load_split,
     make_split,
     rl_train_ids,
     summarize,
@@ -204,6 +207,66 @@ class PinnedV1SplitTest(unittest.TestCase):
 
     def test_recorded_rates_refer_to_real_tasks(self):
         self.assertEqual(set(self.pinned["rates"]) - self.ids, set())
+
+
+class LoadSplitTest(unittest.TestCase):
+    """按名字取切分：benchmark 与训练脚本共用一份读取逻辑。
+
+    两处各写一遍 json.load 就是两处会各自漂的地方，而「训练用了哪一份切分」
+    这件事一旦对不上，训练前后的数字就不可比 —— 那正是切分存在的理由。
+    """
+
+    def test_bare_name_uses_the_default_pinned_file(self):
+        self.assertEqual(load_split("iid_test"),
+                         json.loads(DEFAULT_SPLIT_PATH.read_text())["split"]["iid_test"])
+
+    def test_explicit_path_overrides_the_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "v9.json"
+            path.write_text(json.dumps({"split": {"train": ["only_one"]}}))
+            self.assertEqual(load_split(f"{path}:train"), ["only_one"])
+
+    def test_rl_train_is_computed_not_stored(self):
+        """rl_train 不在文件里，是 train 与 rates 算出来的。"""
+        payload = json.loads(DEFAULT_SPLIT_PATH.read_text())
+        self.assertNotIn("rl_train", payload["split"])
+        self.assertEqual(load_split("rl_train"),
+                         rl_train_ids(payload["split"], payload["rates"]))
+
+    def test_rl_train_is_a_subset_of_train_in_the_middle_band(self):
+        payload = json.loads(DEFAULT_SPLIT_PATH.read_text())
+        rates = payload["rates"]
+        ids = load_split("rl_train")
+        self.assertTrue(set(ids) <= set(payload["split"]["train"]))
+        for tid in ids:
+            self.assertEqual(difficulty_band(rates[tid]), "middle", tid)
+
+    def test_unknown_name_lists_what_is_available(self):
+        with self.assertRaises(ValueError) as ctx:
+            load_split("nope")
+        message = str(ctx.exception)
+        self.assertIn("rl_train", message)
+        self.assertIn("iid_test", message)
+
+    def test_missing_file_is_reported_as_such(self):
+        with self.assertRaises(FileNotFoundError):
+            load_split("/nonexistent/path.json:train")
+
+    def test_rl_train_without_rates_is_an_error_not_an_empty_set(self):
+        """没有 rates 就没有中间带。静默返回空集会让训练集悄悄变空。"""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "norates.json"
+            path.write_text(json.dumps({"split": {"train": ["a", "b"]}}))
+            with self.assertRaises(ValueError):
+                load_split(f"{path}:rl_train")
+
+    def test_rl_train_that_comes_out_empty_is_an_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "allceiling.json"
+            path.write_text(json.dumps(
+                {"split": {"train": ["a", "b"]}, "rates": {"a": 1.0, "b": 0.0}}))
+            with self.assertRaises(ValueError):
+                load_split(f"{path}:rl_train")
 
 
 if __name__ == "__main__":

--- a/AgenticArxiv/tests/test_training_guards.py
+++ b/AgenticArxiv/tests/test_training_guards.py
@@ -8,8 +8,11 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+from benchmark.splits import load_split
+from benchmark.tasks import get_all_tasks
+from benchmark.tasks_expanded import get_expanded_tasks
 from rl.precision import precision_flags
-from rl.train_grpo import RewardVarianceGuard
+from rl.train_grpo import RewardVarianceGuard, _load_tasks
 from rl.train_sft import _check_lengths, _messages_of, _to_prompt_completion
 
 
@@ -85,10 +88,12 @@ class CheckLengthsTest(unittest.TestCase):
 
 
 class RewardVarianceGuardTest(unittest.TestCase):
-    def _fire(self, guard, n, **logs):
+    def _fire(self, guard, n, step=1, **logs):
+        """step 现在会影响行为：开局零方差是故障，练久了是收敛。"""
         control = SimpleNamespace(should_training_stop=False)
         for _ in range(n):
-            guard.on_log(Mock(), Mock(), control, logs=dict(logs))
+            guard.on_log(Mock(), SimpleNamespace(global_step=step), control,
+                         logs=dict(logs))
         return control
 
     def test_healthy_variance_never_stops(self):
@@ -124,6 +129,38 @@ class RewardVarianceGuardTest(unittest.TestCase):
         guard = RewardVarianceGuard(patience=1)
         control = self._fire(guard, 5, loss=0.1, epoch=1.0)
         self.assertFalse(control.should_training_stop)
+
+    def test_zero_variance_after_the_grace_period_is_convergence_not_failure(self):
+        """练到没梯度 ≠ 开局就没梯度。
+
+        --split rl_train 只有十来条中间带任务，学会之后每组都是满分，
+        方差自然归零。把它判成故障会白扔一个已经练好的 checkpoint。
+        """
+        guard = RewardVarianceGuard(patience=3, grace_steps=20)
+        control = self._fire(guard, 3, step=50, frac_reward_zero_std=1.0, reward=1.0)
+        self.assertTrue(control.should_training_stop)
+        self.assertTrue(guard.converged)
+        self.assertFalse(guard.tripped)      # 不以失败退出，checkpoint 保留
+
+    def test_zero_variance_inside_the_grace_period_is_still_a_failure(self):
+        """开局就零方差多半是基座还吐不出可解析动作，那是真故障。"""
+        guard = RewardVarianceGuard(patience=3, grace_steps=20)
+        control = self._fire(guard, 3, step=5, frac_reward_zero_std=1.0, reward=-0.84)
+        self.assertTrue(control.should_training_stop)
+        self.assertTrue(guard.tripped)
+        self.assertFalse(guard.converged)
+
+    def test_the_boundary_step_still_counts_as_grace(self):
+        guard = RewardVarianceGuard(patience=1, grace_steps=20)
+        self._fire(guard, 1, step=20, frac_reward_zero_std=1.0)
+        self.assertTrue(guard.tripped)
+
+    def test_an_unusable_global_step_falls_back_to_failure(self):
+        """拿不到步数时按开局处理：宁可多报一次故障，也不要因它崩掉。"""
+        guard = RewardVarianceGuard(patience=1, grace_steps=20)
+        control = SimpleNamespace(should_training_stop=False)
+        guard.on_log(Mock(), Mock(), control, logs={"frac_reward_zero_std": 1.0})
+        self.assertTrue(guard.tripped)
 
 
 class PrecisionFlagsTest(unittest.TestCase):
@@ -240,6 +277,38 @@ class StageVerifierTest(unittest.TestCase):
             self.assertEqual(data["stage"], "sft")
             self.assertTrue(data["passed"])
             self.assertEqual(data["metrics"]["parse_rate"], 0.8)
+
+
+class TrainingTaskSetTest(unittest.TestCase):
+    """GRPO 训到哪些任务上。
+
+    此前写死 get_all_tasks()，也就是 benchmark/tasks.py 那 8 条冒烟任务 ——
+    59 条的完整基准集和 data/splits/v1.json 的切分都在，训练脚本一条都没用上。
+    """
+
+    def test_default_still_uses_the_smoke_subset(self):
+        """默认值不动：换了会让此前所有训练曲线不可比。"""
+        self.assertEqual(len(_load_tasks("default", None)), len(get_all_tasks()))
+
+    def test_expanded_uses_the_full_benchmark_set(self):
+        self.assertEqual(len(_load_tasks("expanded", None)), len(get_expanded_tasks()))
+
+    def test_rl_train_split_keeps_only_the_middle_band(self):
+        """两端的任务同一 prompt 采样出的奖励一致，组内方差为零，没有梯度。"""
+        chosen = {t["id"] for t in _load_tasks("expanded", "rl_train")}
+        self.assertEqual(chosen, set(load_split("rl_train")))
+        self.assertLess(len(chosen), len(get_expanded_tasks()))
+
+    def test_split_against_the_wrong_task_set_fails_loudly(self):
+        """切分按完整任务集划定；配上冒烟集会静默少掉大半训练数据。"""
+        with self.assertRaises(SystemExit) as ctx:
+            _load_tasks("default", "rl_train")
+        self.assertIn("不在当前任务集中", str(ctx.exception))
+
+    def test_task_ids_come_back_in_a_deterministic_order(self):
+        first = [t["id"] for t in _load_tasks("expanded", "train")]
+        self.assertEqual(first, sorted(first))
+        self.assertEqual(first, [t["id"] for t in _load_tasks("expanded", "train")])
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ PPO 更适合生产级大模型训练（7B+），本项目作为学习 demo 不�
 ### P1 — 中期（数据与评测）
 
 - [x] **任务集扩充**：基准集扩到 59 条（`benchmark/tasks_expanded.py`，`--task-set expanded`），涵盖 search / ref_form / composite / state / optional / constraint / long_chain / infeasible 八类；`benchmark/tasks.py` 保留为 8 条冒烟子集。两边统一走 `benchmark/task_spec.py` 的 `TaskSpec`：`expected_tools` 与 `expected_tool_args` 由同一份 `steps` 派生，不再手写两份平行列表漂移。区分度用 `benchmark/run_baselines.py` 的确定性退化策略量化并逐类目卡门槛（`tests/test_reward_discrimination.py`）——修掉参数档的四处漏分后，「无视任务永远搜 cs.AI」在检索类任务上从 0.833 降到 0.446，「本该什么都不做却调了工具」从 +0.165 变成 −0.235。
+- [x] **评测口径与切分**：报告从「成功率 + token 均值 + 迭代均值」扩到 `pass^k` 可靠性（tau-bench 口径，逐任务估计再平均；样本不足的任务记为跳过而非 0）、`false_finish`（以 FINISH 结束但期望工具没做全——退化策略实测 `always_finish` 91.5%、`reference` 0%）、`ref_score`（比解析出的 `paper_id` 而非 `ref` 的写法，同时消掉字符串比对的假阳性与假阴性）、代价按成功次数归一（`skill_cli` 从贵 43% 变成贵 99%）与失败形态拆分。任务集按**模板**切成 train/iid_test/ood_test（`benchmark/splits.py`，固化于 `data/splits/v1.json`），`--split` 在 `run_benchmark.py` 与 `train_grpo.py` 两侧接通；`rl_train` 只取成功率中间带，两端的任务组内方差为零、不产生梯度。
 - [ ] **eval/ badcase replay**：目录树中的 `eval/`（`eval_cases.jsonl`、`badcase_replay.py`）实际尚不存在，需实现坏例回放闭环。
 - [ ] **Reward hacking 排查**：在现有 `RewardVarianceGuard` / `CanaryCallback` 基础上补 reward-hacking 案例库与多粒度权重课程调优。
 


### PR DESCRIPTION
Step 1 of the plan for the remaining **P1 — 数据与评测** items: make the split
machinery from #49 actually reachable, and stop GRPO training on the smoke
subset.

## The gap

#49 landed `benchmark/splits.py` with 25 tests. Nothing called it. Grepping for
consumers outside its own definition and tests returned zero for `make_split`
and `rl_train_ids` alike. `run_benchmark.py` had no `--split`, and
`train_grpo.py:184` read:

```python
tasks = get_all_tasks()          # benchmark/tasks.py — 8 smoke tasks
```

So the 59-task set and the pinned `train`/`iid_test`/`ood_test` split were both
sitting unused, and every reported number was still measured on tasks the
policy would be trained on. Splits exist to separate "learned the capability"
from "memorised these instances"; unreachable, they separate nothing.

## `load_split`

One loader in `benchmark/splits.py`, shared by both CLIs:

```
--split iid_test                        # data/splits/v1.json
--split data/splits/v2.json:ood_test    # explicit file
```

Inlining `json.load` in two CLIs would be two places to drift, and "which split
did this run use" is precisely the fact that must not drift — otherwise the
before/after numbers are not comparable, which was the point of pinning a split
in the first place.

Four names are available:

| name | count | what it is |
|---|---:|---|
| `train` | 42 | training set |
| `iid_test` | 13 | same template, unseen parameters |
| `ood_test` | 4 | templates never trained on |
| `rl_train` | 13 | the middle band of `train` — **computed, not stored** |

`rl_train` is deliberately not a fourth list in the file: it is fully determined
by `train` and `rates`, and storing it would be one more thing that can go
stale. When `rates` is absent, or the middle band comes out empty, `load_split`
raises rather than returning `[]` — a silently empty training set is worse than
a loud failure.

## `run_benchmark.py --split`

Priority sits below an explicit `--task-ids` and above `--tasks`.

If the split names tasks that are not in the current pool, the run stops with
the reason. That happens for two real reasons — `--task-set default` only has
8 tasks, and without `--offline` the snapshot-bound tasks are dropped — and in
both cases the run would silently cover a fraction of the split, producing
numbers that cannot be compared with any other stage.

```
$ python -m benchmark.run_benchmark --split iid_test --agents mcp
错误: 切分 'iid_test' 里有 13 条任务不在当前任务池中，例如 [...]
      切分按 --task-set expanded 的完整任务集划定；绑定快照的任务还需要 --offline

$ python -m benchmark.run_benchmark --task-set expanded --offline --split iid_test
使用切分 iid_test（13 条）
```

## `train_grpo.py --task_set / --split`

**The default is unchanged** — still the 8 smoke tasks. Changing it would make
every existing training curve incomparable, which is a separate decision and
not one to make as a side effect of wiring. Instead, running without an explicit
task set now prints what the better options are.

`--split rl_train` selects the 13 middle-band tasks. GRPO's advantage is
group-relative: on a task whose success rate sits near 0 or 1, every sampled
trajectory for that prompt gets the same reward, so the advantage is zero and
the step produces no gradient at all. Those tasks are idle compute in a training
set, and they push `frac_reward_zero_std` toward 1.

Mismatched split and task set exits rather than training on whatever overlaps.

**Worth deciding separately:** whether the default should become
`--task_set expanded --split rl_train`. Training on an 8-task smoke subset looks
unintended, but flipping it changes what every future run means, so it is left
as an explicit flag here.

## `RewardVarianceGuard` gets a grace period

A side effect the split makes reachable. The guard treated any sustained
zero-variance as a failure and exited 1, discarding the checkpoint. That is
right when the base model cannot yet emit parseable actions — but `rl_train`
has 13 tasks, and once the policy has learned them every group scores full
marks and the variance legitimately goes to zero. That is "time to change
tasks", not "training is broken", and failing there throws away a checkpoint
that was fine.

`grace_steps` (default 20) splits the two: zero-variance inside the grace
period is still a failure (`tripped`, exit 1); after it the run stops normally
and keeps the checkpoint (`converged`). When the step cannot be read it is
treated as 0 — i.e. as a failure — because over-reporting a failure is cheaper
than letting the guard crash the run.

The existing test fixture passed a `Mock` as `state`; the step now affects
behaviour, so it passes a real one.

## Tests

345 passed (328 before this PR: +8 for `load_split`, +5 for the training task
set, +4 for the grace period). Baseline discrimination gates are unaffected and
still PASS.

`trl` is now installed in the dev environment, so `test_training_guards.py` and
the three `test_grpo_reward.py` cases that were previously reported as failures
run and pass — they were environment-blocked, not broken. The only remaining
errors are the three `test_modules` / `test_tool_registry` cases that require
network access.

## Next

With `--split` reachable, step 2 is the `eval/` badcase loop: select failures
by `false_finish` / `ref_score` rather than by exception, freeze them into
`eval_cases.jsonl`, and replay them deterministically through the existing
`MockArxivEnv(mode="replay")` and snapshot. That artifact doubles as the
reward-hacking case library the P1 TODO asks for.
