### PR TITLE
修正 README 中的奖励范围与输出示例

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -73,10 +73,10 @@ EOF
 python -m AgenticArxiv.rl.rollout search_01 traces/train/
 ```
 
-**Expected output**:
+**Example output (reward varies with the actual trajectory and is in `[-1, 1]`)**:
 ```
 ✅ Task search_01 rollout completed
-   Reward: 1.50
+   Reward: 1.00
    Metrics: task_completed=True, tool_call_accurate=True
    Trajectory saved to: traces/train/rollout_20260621_150000.jsonl
 ```
@@ -381,7 +381,7 @@ result = {
 
 reward_calc = RewardCalculator()
 reward, metrics = reward_calc.compute_reward(task_def, result)
-print(f'Reward: {reward:.2f}')  # Expected: ~1.5
+print(f'Reward: {reward:.2f}')  # Reward range: [-1, 1]; the value depends on the trajectory
 ```
 
 ---

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -75,10 +75,10 @@ EOF
 python -m AgenticArxiv.rl.rollout search_01 traces/train/
 ```
 
-**Salida esperada**:
+**Ejemplo de salida (la recompensa varía según la trayectoria y está en `[-1, 1]`)**:
 ```
 ✅ Rollout de Task search_01 completado
-   Reward: 1.50
+   Reward: 1.00
    Metrics: task_completed=True, tool_call_accurate=True
    Trajectory guardada en: traces/train/rollout_20260621_150000.jsonl
 ```
@@ -376,7 +376,7 @@ result = {
 
 reward_calc = RewardCalculator()
 reward, metrics = reward_calc.compute_reward(task_def, result)
-print(f'Reward: {reward:.2f}')  # Esperado: ~1.5
+print(f'Reward: {reward:.2f}')  # Rango de recompensa: [-1, 1]; el valor depende de la trayectoria
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ EOF
 python -m AgenticArxiv.rl.rollout search_01 traces/train/
 ```
 
-**期望输出**：
+**输出示例（奖励随实际轨迹变化，范围为 `[-1, 1]`）**：
 ```
 ✅ Task search_01 rollout 完成
-   Reward: 1.50
+   Reward: 1.00
    Metrics: task_completed=True, tool_call_accurate=True
    Trajectory 保存至: traces/train/rollout_20260621_150000.jsonl
 ```
@@ -399,7 +399,7 @@ result = {
 
 reward_calc = RewardCalculator()
 reward, metrics = reward_calc.compute_reward(task_def, result)
-print(f'Reward: {reward:.2f}')  # 期望: ~1.5
+print(f'Reward: {reward:.2f}')  # 奖励范围：[-1, 1]，具体值取决于轨迹
 ```
 
 ---


### PR DESCRIPTION
## 修改理由

`1.5` 对应早期设计文档 `docs/rl_building.md` 中的加法奖励：任务完成 `+1.0`、工具调用准确 `+0.5`，无惩罚时合计 `1.5`。

当前 `AgenticArxiv/rl/reward.py` 已采用格式、工具、参数、过程、结果五项奖励。`compute_reward_breakdown()` 对加权奖励进行归一化，并通过 `_clip()` 将最终奖励限制在 `[-1, 1]`；`rollout.py` 打印的是这个最终奖励。中文、英文和西班牙文 README 的输出示例仍写为 `Reward: 1.50`，奖励计算示例也标注“期望: ~1.5”，与当前实现不一致。

## 修改内容

同步修改 README.md、README.en.md 和 README.es-ES.md，每份文件各 3 行。

- 将“期望输出”改为“输出示例”，注明奖励范围及其随实际轨迹变化。
- 将示例奖励值从 `1.50` 改为范围内的 `1.00`，仅作示例，不代表固定结果。
- 修正奖励计算示例的注释，去掉过时的 `~1.5` 预期。
