### PR TITLE
feat(opd): add multi-turn agentic distillation

### DIFF
--- a/AgenticArxiv/rl/opd_multiturn.py
+++ b/AgenticArxiv/rl/opd_multiturn.py
@@ -1,0 +1,519 @@
+"""Multi-turn on-policy distillation for ReAct tool-use trajectories.
+
+TRL's :class:`GKDTrainer` samples one continuation from the initial prompt and
+assumes that every supervised token is contiguous after that prompt.  Agentic
+rollouts violate both assumptions: tool observations are inserted between
+assistant turns, and those environment tokens must be context-only.  This
+module keeps GKD's teacher/student reverse-KL objective while replacing its
+single-turn sampler and contiguous loss mask.
+
+The implementation deliberately uses textual ReAct actions, matching the
+project's inference and GRPO paths.  Each sample owns an independent
+``AgenticArxivMultiTurnEnv`` instance.  Prompt and observation tokens receive
+label ``-100``; only student-generated assistant tokens participate in the
+distillation loss.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass
+from statistics import mean
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+import torch
+
+from rl.grpo_reward import TOOL_ERROR_PREFIX, _thought_of, parse_react_action
+
+
+IGNORE_INDEX = -100
+
+
+@dataclass
+class MultiTurnOPDRollout:
+    """One fully materialized trajectory and its non-contiguous loss mask."""
+
+    input_ids: List[int]
+    labels: List[int]
+    history: List[Dict[str, Any]]
+    termination_type: str
+    turn_count: int
+    assistant_tokens: int
+    observation_tokens: int
+
+
+@dataclass
+class MultiTurnOPDBatch:
+    """Padded tensors plus auditable trajectories for one training batch."""
+
+    input_ids: torch.Tensor
+    attention_mask: torch.Tensor
+    labels: torch.Tensor
+    trajectories: List[Dict[str, Any]]
+    metrics: Dict[str, float]
+
+
+class MultiTurnOPDCollator:
+    """Left-pad prompt-only rows while preserving task ids for environment setup."""
+
+    def __init__(self, pad_token_id: int):
+        if pad_token_id is None:
+            raise ValueError("Multi-turn OPD requires a pad_token_id")
+        self.pad_token_id = int(pad_token_id)
+
+    def __call__(self, features: Sequence[Mapping[str, Any]]) -> Dict[str, Any]:
+        if not features:
+            raise ValueError("Cannot collate an empty multi-turn OPD batch")
+        sequences = [list(feature["input_ids"]) for feature in features]
+        width = max(len(sequence) for sequence in sequences)
+        prompts, masks = [], []
+        for sequence in sequences:
+            padding = width - len(sequence)
+            prompts.append([self.pad_token_id] * padding + sequence)
+            masks.append([0] * padding + [1] * len(sequence))
+        return {
+            "prompts": torch.tensor(prompts, dtype=torch.long),
+            "prompt_attention_mask": torch.tensor(masks, dtype=torch.long),
+            "task_ids": [str(feature.get("task_id", "")) for feature in features],
+        }
+
+
+def validate_tokenizer_compatibility(student_tokenizer: Any, teacher_tokenizer: Any) -> None:
+    """Fail before training when token ids do not represent the same strings.
+
+    Reverse-KL compares the full student and teacher distributions at each
+    vocabulary index.  Equal vocabulary *sizes* are insufficient: index 42
+    must refer to the same token in both models.
+    """
+
+    student_vocab = student_tokenizer.get_vocab()
+    teacher_vocab = teacher_tokenizer.get_vocab()
+    if student_vocab != teacher_vocab:
+        only_student = len(set(student_vocab) - set(teacher_vocab))
+        only_teacher = len(set(teacher_vocab) - set(student_vocab))
+        remapped = sum(
+            1 for token, token_id in student_vocab.items()
+            if token in teacher_vocab and teacher_vocab[token] != token_id
+        )
+        raise ValueError(
+            "Multi-turn OPD requires identical teacher/student token-to-id vocabularies "
+            f"(student={len(student_vocab)}, teacher={len(teacher_vocab)}, "
+            f"student_only={only_student}, teacher_only={only_teacher}, remapped={remapped})."
+        )
+
+    special_names = (
+        "pad_token_id",
+        "eos_token_id",
+        "bos_token_id",
+        "unk_token_id",
+    )
+    mismatches = [
+        name for name in special_names
+        if getattr(student_tokenizer, name, None) != getattr(teacher_tokenizer, name, None)
+    ]
+    if mismatches:
+        raise ValueError(
+            "Teacher/student special token ids differ: " + ", ".join(mismatches)
+        )
+
+
+def _dispatch_tool(environment: Any, action: Mapping[str, Any]) -> Any:
+    name = str(action["name"])
+    args = dict(action.get("args") or {})
+    method = getattr(environment, name, None)
+    if method is None or not callable(method):
+        raise ValueError(f"Unknown tool: {name}")
+    return method(**args)
+
+
+def _dependency_setup_steps(
+    task: Mapping[str, Any], tasks_by_id: Mapping[str, Mapping[str, Any]]
+) -> List[Mapping[str, Any]]:
+    """Resolve setup calls without leaking the current task's gold action."""
+
+    explicit = task.get("setup") or []
+    if explicit:
+        return list(explicit)
+
+    chain: List[Mapping[str, Any]] = []
+    current = task.get("depends_on")
+    seen = set()
+    while current:
+        if current in seen:
+            raise ValueError(f"Dependency cycle while preparing task {task.get('id')}: {current}")
+        seen.add(current)
+        dependency = tasks_by_id.get(str(current))
+        if dependency is None:
+            raise ValueError(f"Missing dependency task {current!r} for {task.get('id')!r}")
+        chain.append(dependency)
+        current = dependency.get("depends_on")
+
+    steps: List[Mapping[str, Any]] = []
+    for dependency in reversed(chain):
+        expected_tools = dependency.get("expected_tools") or []
+        expected_args = dependency.get("expected_tool_args") or []
+        for index, name in enumerate(expected_tools):
+            args = expected_args[index] if index < len(expected_args) else {}
+            steps.append({"name": name, "args": dict(args or {})})
+    return steps
+
+
+def prepare_rollout_environment(
+    environment: Any,
+    task_id: str,
+    tasks_by_id: Mapping[str, Mapping[str, Any]],
+) -> None:
+    """Reset and seed exactly the state declared by a benchmark task."""
+
+    environment.reset(task_id=task_id)
+    task = tasks_by_id.get(task_id)
+    if task is None:
+        return
+    for setup_action in _dependency_setup_steps(task, tasks_by_id):
+        _dispatch_tool(environment, setup_action)
+
+
+def _observation_suffix_ids(tokenizer: Any, observation: str, max_body_tokens: int) -> List[int]:
+    prefix = list(tokenizer("\nObservation: ", add_special_tokens=False)["input_ids"])
+    body = list(tokenizer(str(observation), add_special_tokens=False)["input_ids"])
+    suffix = list(tokenizer("\nThought:", add_special_tokens=False)["input_ids"])
+    return prefix + body[: max(0, int(max_body_tokens))] + suffix
+
+
+def run_multiturn_opd_rollouts(
+    *,
+    prompt_ids: Sequence[Sequence[int]],
+    task_ids: Sequence[str],
+    tokenizer: Any,
+    environment_factory: Callable[[], Any],
+    tasks_by_id: Mapping[str, Mapping[str, Any]],
+    generate_turn: Callable[[Sequence[Sequence[int]]], Sequence[Sequence[int]]],
+    max_turns: int,
+    max_observation_tokens: int,
+) -> List[MultiTurnOPDRollout]:
+    """Run independent student-policy trajectories and build token-level masks."""
+
+    if len(prompt_ids) != len(task_ids):
+        raise ValueError("prompt_ids and task_ids must have the same length")
+    if max_turns < 1:
+        raise ValueError("max_turns must be at least 1")
+
+    sequences = [list(ids) for ids in prompt_ids]
+    labels = [[IGNORE_INDEX] * len(ids) for ids in sequences]
+    histories: List[List[Dict[str, Any]]] = [[] for _ in sequences]
+    assistant_counts = [0] * len(sequences)
+    observation_counts = [0] * len(sequences)
+    terminations = ["INCOMPLETE"] * len(sequences)
+    environments = [environment_factory() for _ in sequences]
+    for environment, task_id in zip(environments, task_ids):
+        prepare_rollout_environment(environment, str(task_id), tasks_by_id)
+
+    active = list(range(len(sequences)))
+    for turn_index in range(max_turns):
+        if not active:
+            break
+        generated_batch = list(generate_turn([sequences[index] for index in active]))
+        if len(generated_batch) != len(active):
+            raise RuntimeError(
+                f"generate_turn returned {len(generated_batch)} rows for {len(active)} active rollouts"
+            )
+
+        next_active: List[int] = []
+        for generated, index in zip(generated_batch, active):
+            generated_ids = [int(token_id) for token_id in generated]
+            sequences[index].extend(generated_ids)
+            labels[index].extend(generated_ids)
+            assistant_counts[index] += len(generated_ids)
+
+            completion = tokenizer.decode(generated_ids, skip_special_tokens=True)
+            kind, action = parse_react_action(completion)
+            thought = _thought_of(completion)
+            if kind == "finish":
+                histories[index].append({
+                    "thought": thought,
+                    "action": "FINISH",
+                    "observation": "Task completed",
+                })
+                terminations[index] = "FINISH"
+                continue
+            if kind == "parse_error":
+                histories[index].append({
+                    "thought": thought,
+                    "action": "PARSE_ERROR",
+                    "observation": "Unable to parse Action",
+                    "parse_failed": True,
+                })
+                terminations[index] = "PARSE_ERROR"
+                continue
+
+            try:
+                result = _dispatch_tool(environments[index], action)
+                observation = str(result)[:4000]
+            except Exception as exc:  # noqa: BLE001
+                observation = f"{TOOL_ERROR_PREFIX}{exc}"
+
+            histories[index].append({
+                "thought": thought,
+                "action": json.dumps(action, ensure_ascii=False),
+                "observation": observation,
+            })
+
+            if turn_index + 1 < max_turns:
+                suffix_ids = _observation_suffix_ids(
+                    tokenizer, observation, max_observation_tokens
+                )
+                sequences[index].extend(suffix_ids)
+                labels[index].extend([IGNORE_INDEX] * len(suffix_ids))
+                observation_counts[index] += len(suffix_ids)
+                next_active.append(index)
+
+        active = next_active
+
+    for index in active:
+        histories[index].append({
+            "thought": "Maximum number of turns reached",
+            "action": "FORCE_STOP",
+            "observation": "Turn limit",
+        })
+        terminations[index] = "FORCE_STOP"
+    # A tool call on the final allowed turn is also a force stop, but it is not
+    # placed in ``next_active`` because there is no following observation turn.
+    for index, termination in enumerate(terminations):
+        if termination == "INCOMPLETE":
+            histories[index].append({
+                "thought": "Maximum number of turns reached",
+                "action": "FORCE_STOP",
+                "observation": "Turn limit",
+            })
+            terminations[index] = "FORCE_STOP"
+
+    return [
+        MultiTurnOPDRollout(
+            input_ids=sequences[index],
+            labels=labels[index],
+            history=histories[index],
+            termination_type=terminations[index],
+            turn_count=sum(
+                1 for step in histories[index] if step.get("action") != "FORCE_STOP"
+            ),
+            assistant_tokens=assistant_counts[index],
+            observation_tokens=observation_counts[index],
+        )
+        for index in range(len(sequences))
+    ]
+
+
+def pad_multiturn_opd_rollouts(
+    rollouts: Sequence[MultiTurnOPDRollout], pad_token_id: int, device: torch.device
+) -> MultiTurnOPDBatch:
+    """Right-pad complete trajectories without confusing EOS with padding."""
+
+    if not rollouts:
+        raise ValueError("Cannot pad an empty rollout batch")
+    width = max(len(rollout.input_ids) for rollout in rollouts)
+    input_rows, attention_rows, label_rows = [], [], []
+    for rollout in rollouts:
+        if len(rollout.input_ids) != len(rollout.labels):
+            raise ValueError("Every rollout must have one label per input token")
+        padding = width - len(rollout.input_ids)
+        input_rows.append(rollout.input_ids + [pad_token_id] * padding)
+        attention_rows.append([1] * len(rollout.input_ids) + [0] * padding)
+        label_rows.append(rollout.labels + [IGNORE_INDEX] * padding)
+
+    trajectories = [
+        {
+            "history": rollout.history,
+            "timing": {},
+            "token_usage": {},
+            "iteration_count": rollout.turn_count,
+        }
+        for rollout in rollouts
+    ]
+    metrics = {
+        "opd/turns": mean(rollout.turn_count for rollout in rollouts),
+        "opd/finished_rate": mean(
+            1.0 if rollout.termination_type == "FINISH" else 0.0 for rollout in rollouts
+        ),
+        "opd/parse_error_rate": mean(
+            1.0 if rollout.termination_type == "PARSE_ERROR" else 0.0 for rollout in rollouts
+        ),
+        "opd/force_stop_rate": mean(
+            1.0 if rollout.termination_type == "FORCE_STOP" else 0.0 for rollout in rollouts
+        ),
+        "opd/assistant_tokens": mean(rollout.assistant_tokens for rollout in rollouts),
+        "opd/observation_tokens": mean(rollout.observation_tokens for rollout in rollouts),
+    }
+    return MultiTurnOPDBatch(
+        input_ids=torch.tensor(input_rows, dtype=torch.long, device=device),
+        attention_mask=torch.tensor(attention_rows, dtype=torch.long, device=device),
+        labels=torch.tensor(label_rows, dtype=torch.long, device=device),
+        trajectories=trajectories,
+        metrics=metrics,
+    )
+
+
+def make_multiturn_gkd_trainer(gkd_trainer_class: type) -> type:
+    """Create a GKD subclass without hard-coding TRL's experimental import path."""
+
+    class MultiTurnGKDTrainer(gkd_trainer_class):
+        def __init__(
+            self,
+            *args: Any,
+            environment_factory: Callable[[], Any],
+            tasks_by_id: Mapping[str, Mapping[str, Any]],
+            max_turns: int = 4,
+            max_observation_tokens: int = 256,
+            max_sequence_length: Optional[int] = None,
+            **kwargs: Any,
+        ) -> None:
+            self.environment_factory = environment_factory
+            self.tasks_by_id = dict(tasks_by_id)
+            self.max_turns = max(1, int(max_turns))
+            self.max_observation_tokens = max(0, int(max_observation_tokens))
+            self.max_sequence_length = max_sequence_length
+            self._pending_multiturn_metrics: List[Dict[str, float]] = []
+            self.latest_trajectory_results: List[Dict[str, Any]] = []
+            super().__init__(*args, **kwargs)
+
+        @staticmethod
+        def _unpad_prompts(inputs: Mapping[str, Any]) -> List[List[int]]:
+            prompts = inputs["prompts"]
+            masks = inputs["prompt_attention_mask"]
+            return [
+                row[mask.bool()].detach().cpu().tolist()
+                for row, mask in zip(prompts, masks)
+            ]
+
+        def _generate_turn(self, model: Any, sequences: Sequence[Sequence[int]]) -> List[List[int]]:
+            if not sequences:
+                return []
+            device = next(model.parameters()).device
+            width = max(len(sequence) for sequence in sequences)
+            if self.max_sequence_length is not None:
+                remaining = min(self.max_sequence_length - len(sequence) for sequence in sequences)
+                if remaining <= 0:
+                    return [[] for _ in sequences]
+            else:
+                remaining = self.generation_config.max_new_tokens
+            max_new_tokens = min(int(self.generation_config.max_new_tokens), int(remaining))
+
+            input_rows, mask_rows = [], []
+            for sequence in sequences:
+                padding = width - len(sequence)
+                input_rows.append([self.processing_class.pad_token_id] * padding + list(sequence))
+                mask_rows.append([0] * padding + [1] * len(sequence))
+            input_ids = torch.tensor(input_rows, dtype=torch.long, device=device)
+            attention_mask = torch.tensor(mask_rows, dtype=torch.long, device=device)
+            generation_config = copy.deepcopy(self.generation_config)
+            generation_config.max_new_tokens = max_new_tokens
+            generation_config.return_dict_in_generate = True
+            outputs = model.generate(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                generation_config=generation_config,
+            )
+            generated = outputs.sequences[:, width:]
+            eos = generation_config.eos_token_id
+            eos_ids = set(eos if isinstance(eos, (list, tuple)) else [eos]) if eos is not None else set()
+            rows: List[List[int]] = []
+            for tensor_row in generated:
+                row: List[int] = []
+                for token_id in tensor_row.detach().cpu().tolist():
+                    row.append(int(token_id))
+                    if token_id in eos_ids:
+                        break
+                if not eos_ids:
+                    while row and row[-1] == self.processing_class.pad_token_id:
+                        row.pop()
+                rows.append(row)
+            return rows
+
+        def training_step(self, model: Any, inputs: Dict[str, Any], num_items_in_batch: Any = None):
+            try:
+                from trl.models.utils import unwrap_model_for_generation
+            except ImportError:  # pragma: no cover - compatibility with older TRL
+                from trl.models import unwrap_model_for_generation
+
+            prompt_ids = self._unpad_prompts(inputs)
+            task_ids = [str(task_id) for task_id in inputs.get("task_ids", [""] * len(prompt_ids))]
+            with unwrap_model_for_generation(
+                model,
+                self.accelerator,
+                generation_kwargs=self.generation_kwargs,
+            ) as unwrapped_model:
+                rollouts = run_multiturn_opd_rollouts(
+                    prompt_ids=prompt_ids,
+                    task_ids=task_ids,
+                    tokenizer=self.processing_class,
+                    environment_factory=self.environment_factory,
+                    tasks_by_id=self.tasks_by_id,
+                    generate_turn=lambda sequences: self._generate_turn(unwrapped_model, sequences),
+                    max_turns=self.max_turns,
+                    max_observation_tokens=self.max_observation_tokens,
+                )
+
+            batch = pad_multiturn_opd_rollouts(
+                rollouts,
+                pad_token_id=self.processing_class.pad_token_id,
+                device=inputs["prompts"].device,
+            )
+            if int((batch.labels != IGNORE_INDEX).sum()) == 0:
+                raise RuntimeError("Multi-turn OPD generated no assistant tokens; refusing a zero-signal step")
+            inputs["input_ids"] = batch.input_ids
+            inputs["attention_mask"] = batch.attention_mask
+            inputs["labels"] = batch.labels
+            self.latest_trajectory_results = batch.trajectories
+            self._pending_multiturn_metrics.append(batch.metrics)
+
+            # Skip GKDTrainer.training_step: it would replace this trajectory
+            # with a fresh single-turn continuation.  The next class in the MRO
+            # is SFTTrainer/Trainer, which calls our compute_loss below.
+            return super(gkd_trainer_class, self).training_step(
+                model, inputs, num_items_in_batch
+            )
+
+        def compute_loss(self, model: Any, inputs: Mapping[str, Any], return_outputs=False, num_items_in_batch=None):
+            student_outputs = model(
+                input_ids=inputs["input_ids"],
+                attention_mask=inputs["attention_mask"],
+                use_cache=False,
+            )
+            self.teacher_model.eval()
+            with torch.no_grad():
+                teacher_outputs = self.teacher_model(
+                    input_ids=inputs["input_ids"],
+                    attention_mask=inputs["attention_mask"],
+                    use_cache=False,
+                )
+            if student_outputs.logits.shape[-1] != teacher_outputs.logits.shape[-1]:
+                raise RuntimeError(
+                    "Teacher/student vocabulary dimensions differ during multi-turn OPD: "
+                    f"{student_outputs.logits.shape[-1]} vs {teacher_outputs.logits.shape[-1]}"
+                )
+
+            shifted_labels = inputs["labels"][:, 1:]
+            if not bool((shifted_labels != IGNORE_INDEX).any()):
+                raise RuntimeError("Multi-turn OPD loss mask contains no assistant targets")
+            loss = self.generalized_jsd_loss(
+                student_logits=student_outputs.logits[:, :-1, :],
+                teacher_logits=teacher_outputs.logits[:, :-1, :],
+                labels=shifted_labels,
+                beta=self.beta,
+            )
+            return (loss, student_outputs) if return_outputs else loss
+
+        def log(self, logs: Dict[str, float], *args: Any, **kwargs: Any):
+            if self._pending_multiturn_metrics:
+                keys = self._pending_multiturn_metrics[0]
+                for key in keys:
+                    logs.setdefault(
+                        key,
+                        mean(metrics[key] for metrics in self._pending_multiturn_metrics),
+                    )
+                self._pending_multiturn_metrics.clear()
+            return super().log(logs, *args, **kwargs)
+
+    MultiTurnGKDTrainer.__name__ = "MultiTurnGKDTrainer"
+    MultiTurnGKDTrainer.__qualname__ = "MultiTurnGKDTrainer"
+    return MultiTurnGKDTrainer

--- a/AgenticArxiv/rl/train_opd.py
+++ b/AgenticArxiv/rl/train_opd.py
@@ -7,11 +7,11 @@ D_KL(π_student ‖ π_teacher)（mode-seeking：学生分布收敛到教师在�
 的 on-policy 升级，也是 GRPO 的互替路径——有强教师时用蒸馏省掉 RL 的
 探索成本；没有教师时仍应走 GRPO（verifiable reward 路线）。
 
-本实现的定位与边界（KISS）：
-- **单轮**：每条样本只蒸馏「一个 ReAct 动作」，不做多轮环境反馈。
-  TRL GKDTrainer 基于 SFTTrainer，只有 prompt/completion 的单段切分，
-  没有 GRPO 那套 rollout_func / env_mask 多轮机制；多轮 OPD 需要自写
-  loss，不在本脚本范围（README 有记录）。
+本实现支持两种模式：
+- **单轮（默认）**：保留 TRL GKDTrainer 的原始行为，便于复现实验。
+- **多轮（--max_turns > 1）**：学生执行 Action → Observation → Action，
+  Observation 仅作为上下文且 loss mask 为 0，reverse-KL 只计算学生生成 token。
+  每条轨迹使用独立 MockArxivEnv，避免工具和会话状态串扰。
 - **教师需本地 logprob**：外部 API 教师拿不到逐 token logprob，因此
   --teacher 必须是本地 HF 模型或 HF 仓库名。上限是教师：蒸馏不会超过
   教师在本任务上的水平。
@@ -26,6 +26,7 @@ D_KL(π_student ‖ π_teacher)（mode-seeking：学生分布收敛到教师在�
 使用方式：
     python -m AgenticArxiv.rl.train_opd --model outputs/sft/final
     python -m AgenticArxiv.rl.train_opd --model outputs/sft/final --teacher Qwen/Qwen2.5-7B-Instruct
+    python -m AgenticArxiv.rl.train_opd --max_turns 4 --snapshot data/mock_arxiv_snapshot.json
     python -m AgenticArxiv.rl.train_opd --report_to tensorboard
 """
 
@@ -61,6 +62,11 @@ from benchmark.tasks_expanded import get_expanded_tasks
 from rl.canary import CanaryCallback, CanaryEvaluator
 from rl.grpo_reward import build_prompt_dataset
 from rl.observability import describe_logging, resolve_report_to
+from rl.opd_multiturn import (
+    MultiTurnOPDCollator,
+    make_multiturn_gkd_trainer,
+    validate_tokenizer_compatibility,
+)
 from rl.reward import RewardCalculator
 from rl.stage_verifier import StageVerifier
 
@@ -204,11 +210,23 @@ def _gold_action_tokens(tokenizer, tasks) -> int:
     return max(lengths)
 
 
+def _model_context_limit(model) -> Optional[int]:
+    """Return a usable decoder context limit, ignoring tokenizer sentinel values."""
+    config = getattr(model, "config", None)
+    candidates = []
+    for name in ("max_position_embeddings", "n_positions", "max_sequence_length"):
+        value = getattr(config, name, None)
+        if isinstance(value, int) and 0 < value < 10_000_000:
+            candidates.append(value)
+    return min(candidates) if candidates else None
+
+
 def main(
     model: str = "outputs/sft/final",
     teacher: str = DEFAULT_TEACHER,
     output_dir: str = "outputs/opd",
     epochs: int = 1,
+    max_steps: int = -1,
     batch_size: int = 2,
     grad_accum: int = 1,
     lr: float = 1e-5,
@@ -216,6 +234,8 @@ def main(
     lmbda: float = 1.0,
     beta: float = REVERSE_KL_BETA,
     max_new_tokens: int = 256,
+    max_turns: int = 1,
+    max_observation_tokens: int = 256,
     snapshot: str = None,
     task_set: str = "default",
     canary_steps: int = 50,
@@ -250,6 +270,14 @@ def main(
     student = AutoModelForCausalLM.from_pretrained(student_path)
 
     print(f"🎓 加载教师模型: {teacher_path}")
+    teacher_tokenizer = AutoTokenizer.from_pretrained(teacher_path)
+    if teacher_tokenizer.pad_token is None:
+        teacher_tokenizer.pad_token = teacher_tokenizer.eos_token
+    if max_turns > 1:
+        try:
+            validate_tokenizer_compatibility(tokenizer, teacher_tokenizer)
+        except ValueError as exc:
+            raise SystemExit(f"❌ {exc}") from exc
     teacher_model = AutoModelForCausalLM.from_pretrained(teacher_path, **_teacher_load_kwargs())
     teacher_model.requires_grad_(False)  # 教师全程 eval + no_grad，双保险防意外更新
     print(f"   显存提示：学生与教师同驻显存；吃紧时换更小的教师（如 Qwen2.5-3B/1.5B-Instruct）")
@@ -268,9 +296,43 @@ def main(
             f"请改用 --max_new_tokens {need + 64}"
         )
 
+    multiturn = max_turns > 1
+    if max_turns < 1:
+        raise SystemExit("❌ --max_turns 必须至少为 1")
+    if max_observation_tokens < 0:
+        raise SystemExit("❌ --max_observation_tokens 不能为负数")
+
+    # Multi-turn mode needs room for every assistant turn and every inserted
+    # observation.  A small fixed marker allowance covers ``Observation:`` and
+    # the following ``Thought:`` prompt without tying this guard to one tokenizer.
+    if multiturn:
+        max_sequence_length = (
+            max_prompt_tokens
+            + max_turns * max_new_tokens
+            + (max_turns - 1) * (max_observation_tokens + 32)
+        )
+        context_limits = [
+            value
+            for value in (
+                _model_context_limit(student),
+                _model_context_limit(teacher_model),
+            )
+            if value is not None
+        ]
+        context_limit = min(context_limits) if context_limits else None
+        if context_limit is not None and max_sequence_length > context_limit:
+            raise SystemExit(
+                f"❌ 多轮 OPD 最坏需要 {max_sequence_length} tokens，但模型上下文仅 "
+                f"{context_limit}。请降低 --max_turns / --max_new_tokens / "
+                "--max_observation_tokens。"
+            )
+    else:
+        max_sequence_length = max_prompt_tokens + max_new_tokens
+
     cfg_kwargs = {
         "output_dir": str(REPO_ROOT / output_dir),
         "num_train_epochs": epochs,
+        "max_steps": max_steps,
         "per_device_train_batch_size": batch_size,
         "gradient_accumulation_steps": grad_accum,
         "learning_rate": lr,
@@ -279,7 +341,7 @@ def main(
         "beta": beta,
         "max_new_tokens": max_new_tokens,
         # SFTConfig.max_length：ChatML collator 的截断预算，prompt + 生成余量
-        "max_length": max_prompt_tokens + max_new_tokens,
+        "max_length": max_sequence_length,
         "logging_steps": 1,
         "save_strategy": "no",
         "report_to": backends,
@@ -299,33 +361,54 @@ def main(
     config = GKDConfig(**cfg)
 
     print(describe_logging(backends, logging_dir if backends else None))
+    mode_description = f"多轮，max_turns={max_turns}" if multiturn else "单轮兼容模式"
     print(
-        f"🚀 开始 OPD 训练（lmbda={lmbda} 全 on-policy 采样，"
+        f"🚀 开始 OPD 训练（{mode_description}，lmbda={lmbda} 全 on-policy 采样，"
         f"beta={beta} → {'reverse-KL D_KL(学生‖教师)' if beta == 1.0 else 'JSD 插值'}）"
     )
-    trainer = GKDTrainer(
+
+    # Multi-turn rollout itself requires the deterministic environment even if
+    # Canary and final verification are disabled.
+    needs_env = multiturn or canary_steps > 0 or verify
+    env = None
+    environment_factory = None
+    if needs_env:
+        snapshot_path = Path(snapshot) if snapshot else DEFAULT_SNAPSHOT
+        if not snapshot_path.exists():
+            reason = "多轮 OPD / Canary / 阶段验证" if multiturn else "Canary / 阶段验证"
+            raise SystemExit(
+                f"❌ {reason}需要离线快照 {snapshot_path}\n"
+                "   请先运行: python -m AgenticArxiv.rl.build_snapshot"
+                "（单轮模式可用 --canary_steps 0 --no-verify 跳过）"
+            )
+        from rl.grpo_reward import load_mock_env
+        env = load_mock_env(snapshot_path)
+        if multiturn:
+            from rl.multiturn_env import make_environment_factory
+            environment_factory = make_environment_factory(snapshot_path)
+
+    trainer_class = make_multiturn_gkd_trainer(GKDTrainer) if multiturn else GKDTrainer
+    trainer_kwargs = {}
+    if multiturn:
+        trainer_kwargs.update({
+            "data_collator": MultiTurnOPDCollator(tokenizer.pad_token_id),
+            "environment_factory": environment_factory,
+            "tasks_by_id": {task["id"]: task for task in tasks},
+            "max_turns": max_turns,
+            "max_observation_tokens": max_observation_tokens,
+            "max_sequence_length": max_sequence_length,
+        })
+    trainer = trainer_class(
         model=student,
         teacher_model=teacher_model,
         args=config,
         train_dataset=train_dataset,
         processing_class=tokenizer,
+        **trainer_kwargs,
     )
 
     # --- Canary 回调：每 N 步在固定任务上评估，检测学生退化 ---
     # OPD 本身无奖励信号，但产出模型仍要在环境里过关；快照只在 canary / 验证时需要
-    needs_env = canary_steps > 0 or verify
-    env = None
-    if needs_env:
-        snapshot_path = Path(snapshot) if snapshot else DEFAULT_SNAPSHOT
-        if not snapshot_path.exists():
-            raise SystemExit(
-                f"❌ Canary / 阶段验证需要离线快照 {snapshot_path}\n"
-                "   请先运行: python -m AgenticArxiv.rl.build_snapshot"
-                "（或 --canary_steps 0 --no-verify 跳过两者）"
-            )
-        from rl.grpo_reward import load_mock_env
-        env = load_mock_env(snapshot_path)
-
     canary_cb = None
     if canary_steps > 0:
         canary_evaluator = CanaryEvaluator(
@@ -384,6 +467,10 @@ if __name__ == "__main__":
     )
     p.add_argument("--output_dir", default="outputs/opd")
     p.add_argument("--epochs", type=int, default=1)
+    p.add_argument(
+        "--max_steps", type=int, default=-1,
+        help="限制优化步数；-1 按 epochs 完整训练，可用 1 做 GPU 端到端烟雾验证",
+    )
     p.add_argument("--batch_size", type=int, default=2)
     p.add_argument("--grad_accum", type=int, default=1)
     p.add_argument("--lr", type=float, default=1e-5)
@@ -398,6 +485,14 @@ if __name__ == "__main__":
              "0.0=反方向；其余为 JSD 插值",
     )
     p.add_argument("--max_new_tokens", type=int, default=256, help="学生单步动作生成预算")
+    p.add_argument(
+        "--max_turns", type=int, default=1,
+        help="每条 on-policy 轨迹的最大 ReAct 轮数；1 保留原单轮 OPD，>1 启用多轮 OPD",
+    )
+    p.add_argument(
+        "--max_observation_tokens", type=int, default=256,
+        help="每轮写回上下文的 Observation token 上限；这些 token 的 loss mask 恒为 0",
+    )
     p.add_argument("--snapshot", default=None)
     p.add_argument(
         "--task_set", choices=["default", "expanded"], default="default",

--- a/AgenticArxiv/tests/test_opd.py
+++ b/AgenticArxiv/tests/test_opd.py
@@ -170,7 +170,11 @@ class TeacherLoadKwargsTest(unittest.TestCase):
 
 class GoldActionTokensTest(unittest.TestCase):
     def test_longest_tool_name_wins(self):
-        tokenizer = SimpleNamespace(__call__=lambda self, text, **kw: {"input_ids": list(range(len(text)))})
+        class Tokenizer:
+            def __call__(self, text, **kwargs):
+                return {"input_ids": list(range(len(text)))}
+
+        tokenizer = Tokenizer()
         tasks = [{"expected_tools": ["short", "a_much_longer_tool_name"]}]
         need = opd._gold_action_tokens(tokenizer, tasks)
         longest = "a_much_longer_tool_name"
@@ -178,7 +182,11 @@ class GoldActionTokensTest(unittest.TestCase):
         self.assertEqual(need, expected)
 
     def test_tasks_without_tools_yield_zero(self):
-        tokenizer = SimpleNamespace(__call__=lambda self, text, **kw: {"input_ids": list(range(len(text)))})
+        class Tokenizer:
+            def __call__(self, text, **kwargs):
+                return {"input_ids": list(range(len(text)))}
+
+        tokenizer = Tokenizer()
         self.assertEqual(opd._gold_action_tokens(tokenizer, [{"expected_tools": []}]), 0)
 
 
@@ -204,13 +212,13 @@ class ReverseKLDirectionTest(unittest.TestCase):
     def test_beta_1_is_reverse_kl_student_first(self):
         student = torch.tensor([[[2.0, 0.0, -1.0, 0.5]]])
         teacher = torch.tensor([[[0.0, 1.0, 3.0, -0.5]]])
-        loss = float(self.loss(student, teacher, beta=1.0))
+        loss = float(type(self).loss(student, teacher, beta=1.0))
         self.assertAlmostEqual(loss, self._hand_kl(student, teacher), places=5)
 
     def test_beta_0_is_the_opposite_direction(self):
         student = torch.tensor([[[2.0, 0.0, -1.0, 0.5]]])
         teacher = torch.tensor([[[0.0, 1.0, 3.0, -0.5]]])
-        loss_beta0 = float(self.loss(student, teacher, beta=0.0))
+        loss_beta0 = float(type(self).loss(student, teacher, beta=0.0))
         self.assertAlmostEqual(loss_beta0, self._hand_kl(teacher, student), places=5)
         # 方向不同 ⇒ 两个损失不相等；相等说明语义被翻转，OPD 方向失效
         self.assertNotAlmostEqual(

--- a/AgenticArxiv/tests/test_opd_multiturn.py
+++ b/AgenticArxiv/tests/test_opd_multiturn.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Unit tests for multi-turn OPD rollout, masking, and environment isolation."""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PACKAGE_ROOT))
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+from rl.opd_multiturn import (  # noqa: E402
+    IGNORE_INDEX,
+    MultiTurnOPDCollator,
+    _dependency_setup_steps,
+    make_multiturn_gkd_trainer,
+    pad_multiturn_opd_rollouts,
+    run_multiturn_opd_rollouts,
+    validate_tokenizer_compatibility,
+)
+
+
+class CharacterTokenizer:
+    """Small reversible tokenizer: every Unicode code point is one token."""
+
+    pad_token_id = 0
+    eos_token_id = 3
+    bos_token_id = 2
+    unk_token_id = 1
+
+    def __init__(self, vocab=None):
+        self._vocab = vocab or {"a": 4, "b": 5}
+
+    def __call__(self, text, add_special_tokens=False):
+        return {"input_ids": [ord(char) for char in str(text)]}
+
+    def decode(self, ids, skip_special_tokens=True):
+        special = {self.pad_token_id, self.eos_token_id, self.bos_token_id}
+        return "".join(chr(token) for token in ids if not skip_special_tokens or token not in special)
+
+    def get_vocab(self):
+        return dict(self._vocab)
+
+
+class FakeEnvironment:
+    def __init__(self, identity):
+        self.identity = identity
+        self.task_id = None
+        self.search_calls = 0
+
+    def reset(self, task_id="", **kwargs):
+        self.task_id = task_id
+
+    def get_recently_submitted_cs_papers(self, **kwargs):
+        self.search_calls += 1
+        return [{"env": self.identity, "query": kwargs}]
+
+    def download_arxiv_pdf(self, ref=1):
+        return {"env": self.identity, "ref": ref, "status": "READY"}
+
+
+def encode(tokenizer, text):
+    return tokenizer(text, add_special_tokens=False)["input_ids"]
+
+
+class MultiTurnCollatorTest(unittest.TestCase):
+    def test_left_padding_and_task_ids_are_preserved(self):
+        batch = MultiTurnOPDCollator(0)([
+            {"input_ids": [7, 8], "task_id": "a"},
+            {"input_ids": [9], "task_id": "b"},
+        ])
+        self.assertEqual(batch["prompts"].tolist(), [[7, 8], [0, 9]])
+        self.assertEqual(batch["prompt_attention_mask"].tolist(), [[1, 1], [0, 1]])
+        self.assertEqual(batch["task_ids"], ["a", "b"])
+
+
+class TokenizerCompatibilityTest(unittest.TestCase):
+    def test_identical_mapping_is_accepted(self):
+        validate_tokenizer_compatibility(CharacterTokenizer(), CharacterTokenizer())
+
+    def test_same_size_but_remapped_vocabulary_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "remapped=2"):
+            validate_tokenizer_compatibility(
+                CharacterTokenizer({"a": 4, "b": 5}),
+                CharacterTokenizer({"a": 5, "b": 4}),
+            )
+
+    def test_special_token_mismatch_is_rejected(self):
+        teacher = CharacterTokenizer()
+        teacher.eos_token_id = 99
+        with self.assertRaisesRegex(ValueError, "eos_token_id"):
+            validate_tokenizer_compatibility(CharacterTokenizer(), teacher)
+
+
+class EnvironmentSetupTest(unittest.TestCase):
+    def test_dependency_steps_are_oldest_first_and_exclude_current_gold(self):
+        tasks = {
+            "search": {
+                "id": "search",
+                "expected_tools": ["get_recently_submitted_cs_papers"],
+                "expected_tool_args": [{"aspect": "AI"}],
+            },
+            "download": {
+                "id": "download",
+                "depends_on": "search",
+                "expected_tools": ["download_arxiv_pdf"],
+                "expected_tool_args": [{"ref": 1}],
+            },
+        }
+        self.assertEqual(
+            _dependency_setup_steps(tasks["download"], tasks),
+            [{"name": "get_recently_submitted_cs_papers", "args": {"aspect": "AI"}}],
+        )
+
+    def test_explicit_setup_takes_precedence(self):
+        task = {
+            "id": "x",
+            "depends_on": "ignored",
+            "setup": [{"name": "download_arxiv_pdf", "args": {"ref": 2}}],
+        }
+        self.assertEqual(_dependency_setup_steps(task, {}), task["setup"])
+
+
+class MultiTurnRolloutTest(unittest.TestCase):
+    def setUp(self):
+        self.tokenizer = CharacterTokenizer()
+
+    def test_action_observation_finish_and_noncontiguous_mask(self):
+        environments = []
+
+        def factory():
+            environment = FakeEnvironment(len(environments))
+            environments.append(environment)
+            return environment
+
+        scripted = [
+            'Thought: search\nAction: {"name":"get_recently_submitted_cs_papers","args":{"aspect":"AI"}}',
+            "Thought: done\nAction: FINISH",
+        ]
+        calls = 0
+
+        def generate_turn(sequences):
+            nonlocal calls
+            response = encode(self.tokenizer, scripted[calls])
+            calls += 1
+            return [response for _ in sequences]
+
+        rollouts = run_multiturn_opd_rollouts(
+            prompt_ids=[[80]],
+            task_ids=["search"],
+            tokenizer=self.tokenizer,
+            environment_factory=factory,
+            tasks_by_id={"search": {"id": "search"}},
+            generate_turn=generate_turn,
+            max_turns=3,
+            max_observation_tokens=32,
+        )
+        rollout = rollouts[0]
+        first_action = encode(self.tokenizer, scripted[0])
+        final_action = encode(self.tokenizer, scripted[1])
+
+        self.assertEqual(rollout.termination_type, "FINISH")
+        self.assertEqual([step["action"] for step in rollout.history][-1], "FINISH")
+        self.assertEqual(rollout.labels[0], IGNORE_INDEX)  # prompt
+        self.assertEqual(rollout.labels[1 : 1 + len(first_action)], first_action)
+        observation_start = 1 + len(first_action)
+        observation_end = observation_start + rollout.observation_tokens
+        self.assertTrue(all(label == IGNORE_INDEX for label in rollout.labels[observation_start:observation_end]))
+        self.assertEqual(rollout.labels[observation_end:], final_action)
+        self.assertGreater(rollout.observation_tokens, 0)
+        self.assertEqual(environments[0].search_calls, 1)
+
+    def test_each_sample_receives_an_independent_environment(self):
+        environments = []
+
+        def factory():
+            environment = FakeEnvironment(len(environments))
+            environments.append(environment)
+            return environment
+
+        action = encode(
+            self.tokenizer,
+            'Thought: search\nAction: {"name":"get_recently_submitted_cs_papers","args":{}}',
+        )
+        rollouts = run_multiturn_opd_rollouts(
+            prompt_ids=[[1], [2]],
+            task_ids=["a", "b"],
+            tokenizer=self.tokenizer,
+            environment_factory=factory,
+            tasks_by_id={},
+            generate_turn=lambda sequences: [action for _ in sequences],
+            max_turns=1,
+            max_observation_tokens=8,
+        )
+        self.assertEqual(len({id(environment) for environment in environments}), 2)
+        self.assertEqual([environment.task_id for environment in environments], ["a", "b"])
+        self.assertEqual([environment.search_calls for environment in environments], [1, 1])
+        self.assertTrue(all(rollout.termination_type == "FORCE_STOP" for rollout in rollouts))
+        self.assertEqual([rollout.turn_count for rollout in rollouts], [1, 1])
+
+    def test_tool_error_becomes_real_observation_and_rollout_continues(self):
+        scripted = [
+            'Thought: try tool\nAction: {"name":"missing_tool","args":{}}',
+            "Thought: stop\nAction: FINISH",
+        ]
+        calls = 0
+
+        def generate_turn(sequences):
+            nonlocal calls
+            response = encode(self.tokenizer, scripted[calls])
+            calls += 1
+            return [response for _ in sequences]
+
+        rollout = run_multiturn_opd_rollouts(
+            prompt_ids=[[1]],
+            task_ids=["x"],
+            tokenizer=self.tokenizer,
+            environment_factory=lambda: FakeEnvironment(0),
+            tasks_by_id={},
+            generate_turn=generate_turn,
+            max_turns=2,
+            max_observation_tokens=64,
+        )[0]
+
+        self.assertEqual(rollout.termination_type, "FINISH")
+        self.assertEqual(rollout.turn_count, 2)
+        self.assertIn("Unknown tool: missing_tool", rollout.history[0]["observation"])
+        self.assertGreater(rollout.observation_tokens, 0)
+
+    def test_parse_error_is_terminal_but_generated_tokens_remain_targets(self):
+        invalid = encode(self.tokenizer, "not a ReAct action")
+        rollout = run_multiturn_opd_rollouts(
+            prompt_ids=[[10, 11]],
+            task_ids=["x"],
+            tokenizer=self.tokenizer,
+            environment_factory=lambda: FakeEnvironment(0),
+            tasks_by_id={},
+            generate_turn=lambda sequences: [invalid],
+            max_turns=4,
+            max_observation_tokens=8,
+        )[0]
+        self.assertEqual(rollout.termination_type, "PARSE_ERROR")
+        self.assertEqual(rollout.labels[:2], [IGNORE_INDEX, IGNORE_INDEX])
+        self.assertEqual(rollout.labels[2:], invalid)
+
+    def test_padding_uses_lengths_even_when_pad_equals_a_valid_token(self):
+        action = encode(self.tokenizer, "Thought: done\nAction: FINISH")
+        rollouts = run_multiturn_opd_rollouts(
+            prompt_ids=[[0], [4, 5]],
+            task_ids=["a", "b"],
+            tokenizer=self.tokenizer,
+            environment_factory=lambda: FakeEnvironment(0),
+            tasks_by_id={},
+            generate_turn=lambda sequences: [action for _ in sequences],
+            max_turns=1,
+            max_observation_tokens=8,
+        )
+        batch = pad_multiturn_opd_rollouts(rollouts, pad_token_id=0, device=torch.device("cpu"))
+        self.assertEqual(batch.attention_mask[0, 0].item(), 1)
+        self.assertEqual(batch.attention_mask[0, -1].item(), 0)
+        self.assertEqual(batch.labels[0, -1].item(), IGNORE_INDEX)
+
+
+class NonContiguousLossMaskTest(unittest.TestCase):
+    class FakeGKD:
+        @staticmethod
+        def generalized_jsd_loss(student_logits, teacher_logits, labels, beta):
+            per_position = (student_logits - teacher_logits).pow(2).sum(dim=-1)
+            return per_position[labels != IGNORE_INDEX].mean()
+
+    class LogitModel(torch.nn.Module):
+        def __init__(self, values):
+            super().__init__()
+            self.values = torch.nn.Parameter(torch.tensor(values, dtype=torch.float32))
+
+        def forward(self, **kwargs):
+            return SimpleNamespace(logits=self.values)
+
+    def test_compute_loss_uses_only_shifted_assistant_positions(self):
+        trainer_class = make_multiturn_gkd_trainer(self.FakeGKD)
+        trainer = object.__new__(trainer_class)
+        trainer.beta = 1.0
+        student = self.LogitModel([[[0.0, 0.0], [1.0, 0.0], [2.0, 0.0], [3.0, 0.0]]])
+        teacher = self.LogitModel([[[1.0, 0.0], [1.0, 0.0], [0.0, 0.0], [0.0, 0.0]]])
+        teacher.requires_grad_(False)
+        trainer.teacher_model = teacher
+        inputs = {
+            "input_ids": torch.tensor([[1, 2, 3, 4]]),
+            "attention_mask": torch.ones(1, 4, dtype=torch.long),
+            # target positions after the causal shift: assistant, environment, assistant
+            "labels": torch.tensor([[IGNORE_INDEX, 2, IGNORE_INDEX, 4]]),
+        }
+        loss = trainer.compute_loss(student, inputs)
+        loss.backward()
+
+        # Logit index 1 predicts token 3, whose label is the masked environment token.
+        self.assertEqual(float(student.values.grad[0, 1].abs().sum()), 0.0)
+        self.assertGreater(float(student.values.grad[0, 0].abs().sum()), 0.0)
+        self.assertGreater(float(student.values.grad[0, 2].abs().sum()), 0.0)
+        self.assertTrue(all(parameter.grad is None for parameter in teacher.parameters()))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/README.en.md
+++ b/README.en.md
@@ -237,6 +237,11 @@ The training pipeline bakes in several layers of automatic validation that turn 
 **Steps**:
 ```bash
 python -m AgenticArxiv.rl.train_opd --model outputs/sft/final --teacher Qwen/Qwen2.5-7B-Instruct
+
+# Multi-turn Agentic OPD: execute Action → Observation → Action
+python -m AgenticArxiv.rl.train_opd --model outputs/sft/final \
+  --teacher Qwen/Qwen2.5-7B-Instruct --max_turns 4 \
+  --snapshot data/mock_arxiv_snapshot.json
 ```
 
 **Output**: `./outputs/opd/final` model
@@ -252,7 +257,9 @@ python -m AgenticArxiv.rl.train_opd --model outputs/sft/final --teacher Qwen/Qwe
 
 OPD can also be used as a trick: warm start before RL, teacher-KL regularization inside RL, or verl's PG-OPD (reverse KL treated as a reward for policy gradient).
 
-**Current boundary (KISS single-turn)**: TRL's GKDTrainer only has a single prompt/completion split, so this implementation distills **one ReAct action per sample** without multi-turn environment feedback (multi-turn OPD would require a custom loss, not supported yet). Student and teacher share GPU memory (1.5B student + 7B teacher ≈ 24GB in bf16; switch to a 3B / 1.5B teacher if tight). Verified on trl 1.5.1 (`trl.experimental.gkd`); `beta=1.0` selects the reverse-KL direction (locked by a numeric unit test in `tests/test_opd.py`). Canary and stage verification are shared with GRPO — OPD training itself uses no reward, but the resulting model still has to pass the environment checks.
+**Single-turn and multi-turn modes**: `--max_turns 1` (the default) preserves TRL GKDTrainer's original single prompt/completion behavior. `--max_turns > 1` enables Agentic OPD: every trajectory receives an independent `MockArxivEnv`, tool calls are executed, and the real Observation is inserted into the next turn. Prompt and Observation labels are `-100`; reverse-KL is computed only on student-generated assistant tokens. The first version requires identical teacher/student token-to-id vocabularies and fails before training if they differ. Student and teacher share GPU memory (a 1.5B student plus 7B teacher use roughly 17GB for bf16 weights alone; gradients, optimizer states, and logits need additional memory, so a smaller teacher or student is recommended on a 32GB GPU). Verified on trl 1.5.1 (`trl.experimental.gkd`); `beta=1.0` selects reverse-KL (locked by a numeric unit test in `tests/test_opd.py`). Canary and stage verification remain shared with GRPO: OPD itself uses no reward, but its output model must still pass environment checks.
+
+**Offline comparison**: run SFT, `--max_turns 1`, `--max_turns > 1`, and GRPO with the same snapshot and task set, then compare the common `StageVerifier` results in each output directory's `final/verification_report.json`. Those rewards are evaluation-only and never enter the OPD loss.
 
 ---
 
@@ -289,6 +296,7 @@ AgenticArXiv-RL/
 │  │  ├─ train_grpo.py             # ⭐ GRPO training (with training guards)
 │  │  ├─ train_ppo.py              # ⭐ PPO training (Actor-Critic)
 │  │  ├─ train_opd.py              # ⭐ OPD training (on-policy distillation, swappable with GRPO)
+│  │  ├─ opd_multiturn.py          # Multi-turn rollout, Observation masks, and custom GKD loss
 │  │  ├─ env.py                    # RLEnv + MockArxivEnv (offline snapshot env)
 │  │  ├─ multiturn_env.py          # TRL multi-turn env adapter (environment_factory, one instance per generation)
 │  │  ├─ reward.py                 # RewardCalculator (5-component reward + curriculum)

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -232,6 +232,11 @@ El pipeline de entrenamiento incorpora varias capas de validación automática q
 **Pasos**:
 ```bash
 python -m AgenticArxiv.rl.train_opd --model outputs/sft/final --teacher Qwen/Qwen2.5-7B-Instruct
+
+# OPD agéntico multi-turno: ejecutar Action → Observation → Action
+python -m AgenticArxiv.rl.train_opd --model outputs/sft/final \
+  --teacher Qwen/Qwen2.5-7B-Instruct --max_turns 4 \
+  --snapshot data/mock_arxiv_snapshot.json
 ```
 
 **Salida**: modelo `./outputs/opd/final`
@@ -247,7 +252,9 @@ python -m AgenticArxiv.rl.train_opd --model outputs/sft/final --teacher Qwen/Qwe
 
 OPD también puede usarse como truco: warm start antes de RL, regularización teacher-KL dentro de RL, o el PG-OPD de verl (la KL reversa tratada como recompensa para el gradiente de política).
 
-**Límite actual (KISS de un solo paso)**: el GKDTrainer de TRL solo tiene un corte prompt/completion único, así que esta implementación destila **una acción ReAct por muestra**, sin retroalimentación multi-turno del entorno (la OPD multi-turno requeriría una pérdida propia, aún no soportada). Estudiante y profesor comparten la GPU (estudiante 1.5B + profesor 7B ≈ 24GB en bf16; usa un profesor de 3B / 1.5B si vas justo). Verificado en trl 1.5.1 (`trl.experimental.gkd`); `beta=1.0` selecciona la dirección reverse-KL (fijada por un test numérico en `tests/test_opd.py`). Canary y verificación por etapa se comparten con GRPO — el entrenamiento OPD en sí no usa recompensa, pero el modelo resultante sigue teniendo que pasar las comprobaciones del entorno.
+**Modos single-turn y multi-turn**: `--max_turns 1` (predeterminado) conserva el comportamiento original prompt/completion de GKDTrainer. `--max_turns > 1` activa OPD agéntico: cada trayectoria recibe un `MockArxivEnv` independiente, se ejecutan las herramientas y la Observation real se inserta en el turno siguiente. Las etiquetas del prompt y de Observation son `-100`; reverse-KL se calcula solo sobre tokens assistant generados por el estudiante. La primera versión exige vocabularios token-to-id idénticos y falla antes de entrenar si difieren. Estudiante y profesor comparten GPU (1.5B + 7B necesitan unos 17GB solo para pesos bf16; gradientes, optimizador y logits requieren memoria adicional, por lo que se recomienda un modelo menor en una GPU de 32GB). Verificado con trl 1.5.1 (`trl.experimental.gkd`); `beta=1.0` selecciona reverse-KL. Canary y la verificación por etapa siguen compartiéndose con GRPO.
+
+**Comparación offline**: ejecuta SFT, `--max_turns 1`, `--max_turns > 1` y GRPO con el mismo snapshot y task set, y compara los resultados comunes de `StageVerifier` en `final/verification_report.json` de cada directorio de salida. Esas recompensas solo se usan para evaluación y nunca entran en la pérdida OPD.
 
 ---
 
@@ -284,6 +291,7 @@ AgenticArXiv-RL/
 │  │  ├─ train_grpo.py             # ⭐ Entrenamiento GRPO (con guardias de entrenamiento)
 │  │  ├─ train_ppo.py              # ⭐ Entrenamiento PPO (Actor-Critic)
 │  │  ├─ train_opd.py              # ⭐ Entrenamiento OPD (destilación on-policy, intercambiable con GRPO)
+│  │  ├─ opd_multiturn.py          # Rollout multi-turno, máscaras Observation y pérdida GKD propia
 │  │  ├─ env.py                    # RLEnv + MockArxivEnv (entorno de snapshot offline)
 │  │  ├─ multiturn_env.py          # Adaptador multiturno para TRL (environment_factory, una instancia por generación)
 │  │  ├─ reward.py                 # RewardCalculator (recompensa de 5 componentes + currículum)

--- a/README.md
+++ b/README.md
@@ -244,6 +244,11 @@ tensorboard --logdir outputs/grpo/logs
 **步骤**：
 ```bash
 python -m AgenticArxiv.rl.train_opd --model outputs/sft/final --teacher Qwen/Qwen2.5-7B-Instruct
+
+# 多轮 Agentic OPD：真实执行 Action → Observation → Action
+python -m AgenticArxiv.rl.train_opd --model outputs/sft/final \
+  --teacher Qwen/Qwen2.5-7B-Instruct --max_turns 4 \
+  --snapshot data/mock_arxiv_snapshot.json
 ```
 
 **产出**：`./outputs/opd/final` 模型
@@ -259,7 +264,9 @@ python -m AgenticArxiv.rl.train_opd --model outputs/sft/final --teacher Qwen/Qwe
 
 OPD 也能当 trick 用：RL 前的 warm start、RL 中的 teacher-KL 正则、verl 的 PG-OPD（把 reverse-KL 当奖励做策略梯度）。
 
-**当前边界（KISS 单轮版）**：TRL GKDTrainer 只有 prompt/completion 的单段切分，本实现每条样本蒸馏**一个 ReAct 动作**，不含多轮环境反馈（多轮 OPD 需自写 loss，暂不支持）。学生与教师同驻显存（1.5B 学生 + 7B 教师 bf16 约 24GB，吃紧可换 3B / 1.5B 教师）。已在 trl 1.5.1（`trl.experimental.gkd`）上验证；`beta=1.0` 即 reverse-KL 方向（`tests/test_opd.py` 有数值单测锁死）。Canary 与阶段验证沿用 GRPO 同一套——OPD 训练本身无奖励，但产出模型仍要在环境里过关。
+**单轮与多轮**：`--max_turns 1`（默认）保留 TRL GKDTrainer 的单段 prompt/completion 行为；`--max_turns > 1` 启用 Agentic OPD。多轮模式为每条轨迹创建独立 `MockArxivEnv`，执行工具后把真实 Observation 写回下一轮上下文；prompt 和 Observation token 的 loss mask 为 `-100`，reverse-KL 只覆盖学生生成的 assistant token。第一版要求教师与学生的 token-to-id vocabulary 完全一致，不兼容时在加载模型后、训练前明确失败。学生与教师同驻显存（1.5B 学生 + 7B 教师仅权重 bf16 约 17GB，训练还需梯度、优化器和 logits 显存；32GB 卡建议使用更小教师或学生）。已在 trl 1.5.1（`trl.experimental.gkd`）上验证；`beta=1.0` 即 reverse-KL 方向（`tests/test_opd.py` 有数值单测锁死）。Canary 与阶段验证沿用 GRPO 同一套——OPD 训练本身无奖励，但产出模型仍要在环境里过关。
+
+**离线对比**：用相同的 snapshot 与 task set 分别运行 SFT、`--max_turns 1`、`--max_turns > 1` 和 GRPO，并比较各输出目录 `final/verification_report.json` 中由 `StageVerifier` 生成的同口径结果；这些 reward 只用于评测，不会进入 OPD loss。
 
 ### 阶段4：PPO（Proximal Policy Optimization）
 
@@ -307,6 +314,7 @@ AgenticArXiv-RL/
 │  │  ├─ train_grpo.py             # ⭐ GRPO 训练（含训练守卫）
 │  │  ├─ train_ppo.py              # ⭐ PPO 训练（Actor-Critic）
 │  │  ├─ train_opd.py              # ⭐ OPD 训练（on-policy 蒸馏，与 GRPO 互替）
+│  │  ├─ opd_multiturn.py          # 多轮 OPD rollout、Observation mask 与自定义 GKD loss
 │  │  ├─ env.py                    # RLEnv + MockArxivEnv（离线快照环境）
 │  │  ├─ multiturn_env.py          # TRL 多轮环境适配器（environment_factory，每代独立实例）
 │  │  ├─ reward.py                 # RewardCalculator（五分量可验证奖励 + 课程）


### PR DESCRIPTION
## Summary

- add live multi-turn OPD rollouts for `Action → Observation → Action` tool-use trajectories
- execute every tool call in an independent `MockArxivEnv` and feed the real Observation into the next student turn
- compute reverse-KL only on student-generated assistant tokens while masking prompts, environment observations, and padding
- preserve the current single-turn `GKDTrainer` path as the default with `--max_turns 1`

## Implementation

- add a custom multi-turn GKD trainer with non-contiguous token-level loss masks
- handle `FINISH`, parse errors, tool errors, and `max_turns` force stops
- fail early unless teacher and student have identical token-to-id vocabularies and special-token ids
- add context-budget and Observation-length guards plus rollout health metrics
- retain Canary and `StageVerifier` integration and document a common offline comparison workflow
- include unit coverage for masks, reverse-KL gradient positions, frozen teacher parameters, environment isolation, dependency setup, tokenizer mismatches, tool errors, force stops, and pad/EOS collisions

## Validation

- `python -m unittest discover -s AgenticArxiv/tests -p "test_*.py"`: **404 tests passed**
- real one-step GPU training with student and teacher both `Qwen/Qwen2.5-0.5B-Instruct`, `--max_turns 2`, and TRL 1.5.1 on an NVIDIA RTX 4080 SUPER (32 GB): completed successfully with 2 rollout turns, 100% finish rate, and 0 parse/force-stop rate
- `git diff --check`: clean

## Scope

This keeps the teacher local for per-token logits and intentionally does not add cross-tokenizer alignment, reward models, value models, or asynchronous rollout infrastructure.

Closes #56