### PR TITLE
feat: add offline-replayable keyword arXiv search

### DIFF
--- a/AgenticArxiv/benchmark/tasks_expanded.py
+++ b/AgenticArxiv/benchmark/tasks_expanded.py
@@ -64,6 +64,21 @@ _SEARCH = family(
     difficulty="easy",
 )
 
+_KEYWORD_SEARCH_PARAMS = [
+    {"id": "agentic_rl", "query": "all:agentic reinforcement learning"},
+    {"id": "llm", "query": "all:large language model"},
+    {"id": "rag", "query": "all:retrieval augmented generation"},
+]
+
+_KEYWORD_SEARCH = family(
+    task_id=lambda p: f"search_kw_{p['id']}",
+    text=lambda p: f"按关键词检索 arXiv：{p['query']}，最多返回 5 篇论文",
+    steps=lambda p: [Step("search_arxiv_papers", {"query": p["query"], "max_results": 5, "days": 30})],
+    params=_KEYWORD_SEARCH_PARAMS,
+    category="keyword_search",
+    difficulty="medium",
+)
+
 _SEED_AI5 = (Step("get_recently_submitted_cs_papers",
                   {"aspect": "AI", "days": 7, "max_results": 5}),)
 
@@ -684,7 +699,7 @@ _LONG_CHAIN: List[TaskSpec] = [
 
 
 EXPANDED_TASKS: List[Dict[str, Any]] = build(
-    _SEARCH + _OTHERS + _CONSTRAINTS + _INFEASIBLE + _LONG_CHAIN
+    _SEARCH + _KEYWORD_SEARCH + _OTHERS + _CONSTRAINTS + _INFEASIBLE + _LONG_CHAIN
 )
 
 

--- a/AgenticArxiv/rl/build_snapshot.py
+++ b/AgenticArxiv/rl/build_snapshot.py
@@ -28,20 +28,28 @@ from rl.env import MockArxivEnv
 
 # 覆盖 benchmark/rl 任务集里出现过的所有方向
 DEFAULT_ASPECTS = ["*", "AI", "LG", "CL", "CV", "RO", "CR"]
+DEFAULT_KEYWORD_QUERIES = [
+    "all:agentic reinforcement learning",
+    "all:large language model",
+    "all:retrieval augmented generation",
+]
 
 
 def build(
     snapshot_path: str = "../data/mock_arxiv_snapshot.json",
     aspects=None,
+    keyword_queries=None,
     max_results: int = 50,
     days: int = 30,
 ) -> None:
     aspects = list(aspects or DEFAULT_ASPECTS)
+    keyword_queries = list(keyword_queries or DEFAULT_KEYWORD_QUERIES)
     path = Path(snapshot_path)
     env = MockArxivEnv(snapshot_path=path, mode="record")
 
     print(f"生成 MockEnv 快照 → {path}")
-    print(f"  aspects={aspects} max_results={max_results} days={days}")
+    print(f"  aspects={aspects} keyword_queries={keyword_queries}")
+    print(f"  max_results={max_results} days={days}")
 
     ok, fail = 0, 0
     for aspect in aspects:
@@ -61,6 +69,22 @@ def build(
             print(f"  [FAIL] aspect={aspect:<3} → {e}")
             fail += 1
 
+    for query in keyword_queries:
+        try:
+            papers = env.execute_tool(
+                "search_arxiv_papers",
+                {
+                    "query": query,
+                    "days": days,
+                    "max_results": max_results,
+                },
+            )
+            print(f"  [OK]   query={query!r} → {len(papers)} 篇")
+            ok += 1
+        except Exception as e:
+            print(f"  [FAIL] query={query!r} → {e}")
+            fail += 1
+
     env.save_snapshot()
     total = sum(len(v) for v in env.snapshot.values())
     print(f"\n完成：{ok} 个 aspect 成功、{fail} 个失败，共 {total} 条快照记录")
@@ -71,6 +95,7 @@ def main():
     parser = argparse.ArgumentParser(description="生成 MockArxivEnv 快照")
     parser.add_argument("--snapshot", default="../data/mock_arxiv_snapshot.json")
     parser.add_argument("--aspects", nargs="+", default=None)
+    parser.add_argument("--keyword-queries", nargs="+", default=None)
     parser.add_argument("--max_results", type=int, default=50)
     parser.add_argument("--days", type=int, default=30)
     args = parser.parse_args()
@@ -78,6 +103,7 @@ def main():
     build(
         snapshot_path=args.snapshot,
         aspects=args.aspects,
+        keyword_queries=args.keyword_queries,
         max_results=args.max_results,
         days=args.days,
     )

--- a/AgenticArxiv/rl/env.py
+++ b/AgenticArxiv/rl/env.py
@@ -14,9 +14,10 @@
 3. **key 含 session_id**：每次 rollout 的 session_id 都不同，缓存永远 miss。
    → key 归一化时剔除易变字段。
 
-四个工具在离线模式下的处理策略不同：
+五个工具在离线模式下的处理策略不同：
 
     get_recently_submitted_cs_papers  网络请求 → 快照回放
+    search_arxiv_papers               网络请求 → 快照回放 / 确定性降级
     download_arxiv_pdf                网络请求 → 离线桩（写占位文件 + 更新 store）
     translate_arxiv_pdf               子进程   → 由 LocalSideEffectManager 拦截，不进 env
     get_paper_cache_status            纯本地   → 直接真实执行（读内存 store）
@@ -24,6 +25,7 @@
 
 import json
 import os
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Dict, Optional, Set
 
@@ -34,7 +36,10 @@ from utils.logger import log
 _VOLATILE_ARG_KEYS = {"session_id", "output_path", "save_to_file"}
 
 # 需要走快照回放的"网络型"工具
-DEFAULT_SNAPSHOT_TOOLS: Set[str] = {"get_recently_submitted_cs_papers"}
+_RECENT_SEARCH_TOOL = "get_recently_submitted_cs_papers"
+_KEYWORD_SEARCH_TOOL = "search_arxiv_papers"
+_SEARCH_TOOLS = {_RECENT_SEARCH_TOOL, _KEYWORD_SEARCH_TOOL}
+DEFAULT_SNAPSHOT_TOOLS: Set[str] = set(_SEARCH_TOOLS)
 
 
 class MockArxivEnv:
@@ -77,7 +82,13 @@ class MockArxivEnv:
         self.snapshot: Dict[str, Dict[str, Any]] = {}
 
         # 统计信息，便于确认 rollout 真的没打外网
-        self.stats = {"hit": 0, "miss": 0, "real_calls": 0, "offline_stubs": 0}
+        self.stats = {
+            "hit": 0,
+            "miss": 0,
+            "real_calls": 0,
+            "offline_stubs": 0,
+            "fallback": 0,
+        }
 
         if self.snapshot_path and self.snapshot_path.exists():
             with open(self.snapshot_path, "r", encoding="utf-8") as f:
@@ -103,6 +114,8 @@ class MockArxivEnv:
 
         # 3) 快照工具
         key = self._make_key(args)
+        if tool_name == _KEYWORD_SEARCH_TOOL:
+            key = self._keyword_search_key(args)
         tool_data = self.snapshot.get(tool_name, {})
 
         # record 模式必须每次都真打，否则派生逻辑会"帮倒忙"：
@@ -117,18 +130,28 @@ class MockArxivEnv:
         if key in tool_data:
             self.stats["hit"] += 1
             result = tool_data[key]["result"]
+            if tool_name == _KEYWORD_SEARCH_TOOL:
+                result = self._limit_search_result(result, args)
             self._sync_session_papers(tool_name, args, result)
             return result
 
         # 3a) 搜索工具：按"论文池"语义派生，而不是死抠精确 key
         #     真实 API 下 max_results=5 / 7 / 10 都能正常返回，mock 也应如此，
         #     否则策略稍微改个参数就变成 KeyError，奖励信号会被污染成"全是工具失败"。
-        if tool_name == "get_recently_submitted_cs_papers":
+        if tool_name == _RECENT_SEARCH_TOOL:
             derived = self._derive_search_result(args, tool_data)
             if derived is not None:
                 self.stats["hit"] += 1
                 self._sync_session_papers(tool_name, args, derived)
                 return derived
+
+        if tool_name == _KEYWORD_SEARCH_TOOL:
+            fallback = self._keyword_search_fallback(args, tool_data)
+            if fallback is not None:
+                self.stats["hit"] += 1
+                self.stats["fallback"] += 1
+                self._sync_session_papers(tool_name, args, fallback)
+                return fallback
 
         self.stats["miss"] += 1
         if self.mode == "replay":
@@ -143,7 +166,7 @@ class MockArxivEnv:
             result = registry.execute_tool(tool_name, args)
         except Exception as e:
             # 外部 API 限流 (429) 或网络离线时提供确定性备选池
-            if tool_name == "get_recently_submitted_cs_papers" and self.mode == "auto":
+            if tool_name == _RECENT_SEARCH_TOOL and self.mode == "auto":
                 aspect = str(args.get("aspect", "*"))
                 max_r = int(args.get("max_results", 5))
                 result = [
@@ -166,13 +189,17 @@ class MockArxivEnv:
 
     def _sync_session_papers(self, tool_name: str, args: Dict[str, Any], result: Any) -> None:
         """若带 session_id 且为搜索工具，同步更新 store 中的 papers 缓存"""
-        if tool_name == "get_recently_submitted_cs_papers" and isinstance(result, list):
+        if tool_name in _SEARCH_TOOLS and isinstance(result, list):
             session_id = args.get("session_id")
             if session_id:
                 try:
                     from models.schemas import Paper
                     from models.store import store
-                    papers = [Paper(**p) if isinstance(p, dict) else p for p in result]
+                    papers = [
+                        Paper(**{key: value for key, value in paper.items() if not key.startswith("_")})
+                        if isinstance(paper, dict) else paper
+                        for paper in result
+                    ]
                     store.set_last_papers(session_id, papers)
                 except Exception:
                     pass
@@ -217,6 +244,63 @@ class MockArxivEnv:
             max_results = 50
         max_results = max(1, min(max_results, len(pool)))
         return pool[:max_results]
+
+    @staticmethod
+    def _limit_search_result(result: Any, args: Dict[str, Any]) -> Any:
+        """Apply the requested limit to a cached keyword-search result pool."""
+        if not isinstance(result, list):
+            return result
+        try:
+            max_results = int(args.get("max_results", 10))
+        except (TypeError, ValueError):
+            max_results = 10
+        return result[:max(1, min(max_results, len(result)))]
+
+    @classmethod
+    def _keyword_search_key(cls, args: Dict[str, Any]) -> str:
+        """Key keyword-search snapshots by a normalized query hash."""
+        query = " ".join(str((args or {}).get("query", "")).split()).casefold()
+        stable = {"query_sha256": sha256(query.encode("utf-8")).hexdigest()}
+        days = (args or {}).get("days")
+        if days is not None:
+            stable["days"] = days
+        return json.dumps(stable, sort_keys=True, ensure_ascii=False)
+
+    @classmethod
+    def _keyword_search_fallback(
+        cls, args: Dict[str, Any], tool_data: Dict[str, Any]
+    ) -> Optional[list]:
+        """Return an explicitly marked, deterministic subset for an unseen query."""
+        pool = []
+        seen_ids = set()
+        for key in sorted(tool_data):
+            result = tool_data[key].get("result")
+            if not isinstance(result, list):
+                continue
+            for paper in result:
+                if not isinstance(paper, dict):
+                    continue
+                paper_id = str(paper.get("id", ""))
+                if paper_id in seen_ids:
+                    continue
+                seen_ids.add(paper_id)
+                pool.append(paper)
+        if not pool:
+            return None
+
+        query = " ".join(str((args or {}).get("query", "")).split()).casefold()
+        start = int.from_bytes(sha256(query.encode("utf-8")).digest()[:8], "big") % len(pool)
+        ordered = pool[start:] + pool[:start]
+        selected = cls._limit_search_result(ordered, args)
+        if not selected:
+            return None
+
+        marked = [dict(paper) for paper in selected]
+        marked[0]["_mock_env"] = {
+            "offline_fallback": True,
+            "message": "关键词未命中离线快照；返回固定回退子集，不代表查询匹配结果。",
+        }
+        return marked
 
     # ---------- 离线下载桩 ----------
 
@@ -322,5 +406,6 @@ class MockArxivEnv:
         s = self.stats
         return (
             f"mode={self.mode} hit={s['hit']} miss={s['miss']} "
-            f"real_calls={s['real_calls']} offline_stubs={s['offline_stubs']}"
+            f"real_calls={s['real_calls']} offline_stubs={s['offline_stubs']} "
+            f"fallback={s['fallback']}"
         )

--- a/AgenticArxiv/rl/grpo_reward.py
+++ b/AgenticArxiv/rl/grpo_reward.py
@@ -378,6 +378,8 @@ def make_multiturn_rollout_func(environment_factory, max_turns: int = 4):
                 try:
                     if action["name"] == "get_recently_submitted_cs_papers":
                         result = environments[index].get_recently_submitted_cs_papers(**args)
+                    elif action["name"] == "search_arxiv_papers":
+                        result = environments[index].search_arxiv_papers(**args)
                     elif action["name"] == "download_arxiv_pdf":
                         result = environments[index].download_arxiv_pdf(**args)
                     elif action["name"] == "translate_arxiv_pdf":

--- a/AgenticArxiv/rl/multiturn_env.py
+++ b/AgenticArxiv/rl/multiturn_env.py
@@ -57,6 +57,27 @@ class AgenticArxivMultiTurnEnv:
         self.store.set_last_papers(self.session_id, papers)
         return result
 
+    def search_arxiv_papers(
+        self, query: str, max_results: int = 10, days: Optional[int] = None
+    ) -> list[dict[str, Any]]:
+        """Search arXiv by keyword, title, or author within this rollout.
+
+        Args:
+            query: Bare text or an ``all:``, ``ti:``, or ``au:`` query.
+            max_results: Maximum number of papers to return.
+            days: Optional submission-time window in days.
+        """
+        result = self.backend.execute_tool(
+            "search_arxiv_papers",
+            {"query": query, "max_results": max_results, "days": days},
+        )
+        papers = [
+            Paper(**{key: value for key, value in item.items() if not key.startswith("_")})
+            for item in result
+        ]
+        self.store.set_last_papers(self.session_id, papers)
+        return result
+
     def download_arxiv_pdf(self, ref: str | int = 1) -> dict[str, Any]:
         """Download a paper selected from the latest search results.
 

--- a/AgenticArxiv/tests/test_keyword_search.py
+++ b/AgenticArxiv/tests/test_keyword_search.py
@@ -1,0 +1,125 @@
+"""Regression coverage for the P0 keyword-search tool and offline replay."""
+
+from datetime import datetime
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PACKAGE_ROOT))
+os.environ.setdefault("STORE_BACKEND", "memory")
+
+from benchmark.tasks_expanded import get_by_category  # noqa: E402
+from rl.env import MockArxivEnv  # noqa: E402
+from tools.arxiv_tool import _keyword_query_expression, search_arxiv_papers  # noqa: E402
+
+
+def _paper(index: int) -> dict:
+    return {
+        "id": f"2601.0000{index}v1",
+        "title": f"Paper {index}",
+        "authors": ["Test Author"],
+        "summary": "test summary",
+        "published": "2026-01-01 00:00:00",
+        "updated": "2026-01-01 00:00:00",
+        "pdf_url": f"https://arxiv.org/pdf/2601.0000{index}v1",
+        "primary_category": "cs.AI",
+        "categories": ["cs.AI"],
+        "comment": None,
+        "links": [],
+    }
+
+
+class KeywordQueryTest(unittest.TestCase):
+    def test_maps_bare_text_and_supported_prefixes(self):
+        self.assertEqual(_keyword_query_expression("agentic RL"), 'all:"agentic RL"')
+        self.assertEqual(_keyword_query_expression("ti: Agentic RL"), 'ti:"Agentic RL"')
+        self.assertEqual(_keyword_query_expression("au: Jane Doe"), 'au:"Jane Doe"')
+
+    def test_rejects_empty_query(self):
+        with self.assertRaises(ValueError):
+            _keyword_query_expression("   ")
+
+    def test_search_uses_the_normalized_arxiv_expression(self):
+        class Result:
+            def get_short_id(self):
+                return "2601.00001v1"
+
+            title = "Agentic RL"
+            authors = []
+            summary = "summary"
+            published = datetime(2026, 1, 1)
+            updated = None
+            pdf_url = "https://arxiv.org/pdf/2601.00001v1"
+            primary_category = "cs.AI"
+            categories = ["cs.AI"]
+            comment = None
+            links = []
+
+        with mock.patch("tools.arxiv_tool.arxiv.Client") as client_cls, \
+             mock.patch("tools.arxiv_tool.arxiv.Search") as search_cls:
+            client_cls.return_value.results.return_value = [Result()]
+            papers = search_arxiv_papers("ti: Agentic RL", max_results=3)
+
+        self.assertEqual(papers[0]["id"], "2601.00001v1")
+        self.assertEqual(search_cls.call_args.kwargs["query"], 'ti:"Agentic RL"')
+
+
+class KeywordSnapshotReplayTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.snapshot_path = Path(self.tmpdir.name) / "snapshot.json"
+        self.known_args = {
+            "query": "all:agentic reinforcement learning",
+            "max_results": 3,
+            "days": 30,
+        }
+
+        recorder = MockArxivEnv(self.snapshot_path, mode="record")
+        with mock.patch("rl.env.registry.execute_tool", return_value=[_paper(1), _paper(2), _paper(3)]):
+            recorder.execute_tool("search_arxiv_papers", self.known_args)
+        recorder.save_snapshot()
+
+    def tearDown(self):
+        self.tmpdir.cleanup()
+
+    def test_query_hash_replay_reuses_the_pool_with_a_new_limit(self):
+        env = MockArxivEnv(self.snapshot_path, mode="replay")
+        result = env.execute_tool(
+            "search_arxiv_papers",
+            {**self.known_args, "max_results": 1},
+        )
+        self.assertEqual([paper["id"] for paper in result], ["2601.00001v1"])
+        self.assertEqual(env.stats["real_calls"], 0)
+        self.assertEqual(env.stats["fallback"], 0)
+
+    def test_unseen_query_uses_a_marked_deterministic_fallback(self):
+        args = {"query": "all:unseen query", "max_results": 2, "days": 30}
+        first = MockArxivEnv(self.snapshot_path, mode="replay").execute_tool(
+            "search_arxiv_papers", args
+        )
+        second_env = MockArxivEnv(self.snapshot_path, mode="replay")
+        second = second_env.execute_tool("search_arxiv_papers", args)
+
+        self.assertEqual([paper["id"] for paper in first], [paper["id"] for paper in second])
+        self.assertTrue(first[0]["_mock_env"]["offline_fallback"])
+        self.assertEqual(second_env.stats["real_calls"], 0)
+        self.assertEqual(second_env.stats["fallback"], 1)
+
+
+class KeywordTaskSpecTest(unittest.TestCase):
+    def test_keyword_tasks_have_a_complete_argument_oracle(self):
+        tasks = get_by_category("keyword_search")
+        self.assertEqual(len(tasks), 3)
+        for task in tasks:
+            with self.subTest(task=task["id"]):
+                self.assertEqual(task["expected_tools"], ["search_arxiv_papers"])
+                self.assertEqual(len(task["expected_tool_args"]), 1)
+                self.assertTrue(task["expected_tool_args"][0]["query"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/AgenticArxiv/tests/test_multiturn_env.py
+++ b/AgenticArxiv/tests/test_multiturn_env.py
@@ -29,6 +29,8 @@ class FakeBackend:
     def execute_tool(self, name, args):
         if name == "get_recently_submitted_cs_papers":
             return [PAPER]
+        if name == "search_arxiv_papers":
+            return [{**PAPER, "_mock_env": {"offline_fallback": True}}]
         raise AssertionError(name)
 
 
@@ -50,6 +52,12 @@ class MultiTurnEnvTest(unittest.TestCase):
         self.env.reset(task_id="next")
         with self.assertRaises(ValueError):
             self.env.download_arxiv_pdf(1)
+
+    def test_keyword_search_then_download_uses_same_session_state(self):
+        papers = self.env.search_arxiv_papers("all:agentic reinforcement learning", 3, 30)
+        downloaded = self.env.download_arxiv_pdf(1)
+        self.assertEqual(len(papers), 1)
+        self.assertEqual(downloaded["paper_id"], PAPER["id"])
 
 
 if __name__ == "__main__":

--- a/AgenticArxiv/tests/test_tool_bootstrap.py
+++ b/AgenticArxiv/tests/test_tool_bootstrap.py
@@ -26,13 +26,18 @@ from tools.bootstrap import (  # noqa: E402
     registered_tool_count,
     require_all_tools,
 )
+from tools.tool_registry import registry  # noqa: E402
 
 
 class RegisterAllToolsTest(unittest.TestCase):
-    def test_all_four_register_in_a_healthy_environment(self):
+    def test_all_tools_register_in_a_healthy_environment(self):
         self.assertEqual(register_all_tools(), {})
         self.assertEqual(missing_tools(), [])
-        self.assertEqual(registered_tool_count(), len(TOOL_MODULES))
+        expected_count = sum(len(names) for names in TOOL_MODULES.values())
+        self.assertEqual(registered_tool_count(), expected_count)
+        self.assertIn("search_arxiv_papers", {
+            tool["name"] for tool in registry.list_tools()
+        })
 
     def test_one_broken_module_does_not_take_down_the_rest(self):
         """这是整个模块存在的理由。

--- a/AgenticArxiv/tools/arxiv_tool.py
+++ b/AgenticArxiv/tools/arxiv_tool.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone, timedelta
 from typing import List, Dict, Optional
 import sys
 import os
+import re
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -61,6 +62,46 @@ def _default_output_path() -> str:
     return os.path.join(project_root, "output", "recent_cs_papers.txt")
 
 
+def _paper_info(result) -> Dict:
+    return {
+        "id": result.get_short_id(),
+        "title": result.title,
+        "authors": [author.name for author in result.authors],
+        "summary": (result.summary[:200] + "...")
+        if len(result.summary) > 200
+        else result.summary,
+        "published": result.published.strftime("%Y-%m-%d %H:%M:%S"),
+        "updated": result.updated.strftime("%Y-%m-%d %H:%M:%S")
+        if result.updated
+        else None,
+        "pdf_url": result.pdf_url,
+        "primary_category": result.primary_category,
+        "categories": result.categories,
+        "comment": result.comment,
+        "links": [link.href for link in result.links],
+    }
+
+
+_KEYWORD_FIELD_RE = re.compile(r"^(all|ti|au):\s*(.+)$", re.IGNORECASE)
+
+
+def _keyword_query_expression(query: str) -> str:
+    """Map a user query to the small, documented arXiv keyword surface.
+
+    Bare text searches all metadata. Advanced callers can explicitly select a
+    title (``ti:``) or author (``au:``) field, while keeping tool arguments
+    simple enough for the policy to learn.
+    """
+    normalized = " ".join(str(query or "").split())
+    if not normalized:
+        raise ValueError("query 不能为空")
+
+    match = _KEYWORD_FIELD_RE.match(normalized)
+    field, terms = (match.group(1).lower(), match.group(2)) if match else ("all", normalized)
+    escaped_terms = terms.replace('"', r'\"')
+    return f'{field}:"{escaped_terms}"'
+
+
 def get_recently_submitted_cs_papers(
     max_results: int = 50,
     aspect: str = "*",
@@ -90,30 +131,44 @@ def get_recently_submitted_cs_papers(
 
     papers: List[Dict] = []
     for result in client.results(search):
-        paper_info = {
-            "id": result.get_short_id(),
-            "title": result.title,
-            "authors": [author.name for author in result.authors],
-            "summary": (result.summary[:200] + "...")
-            if len(result.summary) > 200
-            else result.summary,
-            "published": result.published.strftime("%Y-%m-%d %H:%M:%S"),
-            "updated": result.updated.strftime("%Y-%m-%d %H:%M:%S")
-            if result.updated
-            else None,
-            "pdf_url": result.pdf_url,
-            "primary_category": result.primary_category,
-            "categories": result.categories,
-            "comment": result.comment,
-            "links": [link.href for link in result.links],
-        }
-        papers.append(paper_info)
+        papers.append(_paper_info(result))
 
     if save_to_file:
         path = output_path or _default_output_path()
         save_papers_to_file(papers, path)
 
     return papers
+
+
+def search_arxiv_papers(
+    query: str,
+    max_results: int = 10,
+    days: Optional[int] = None,
+) -> List[Dict]:
+    """Search arXiv by keyword, title, or author.
+
+    ``query`` accepts bare text (searched as ``all:``) and explicit ``all:``,
+    ``ti:``, or ``au:`` prefixes.  An optional time window is applied using
+    arXiv's submitted-date filter.
+    """
+    if days is not None and days < 1:
+        raise ValueError("days 必须大于 0")
+
+    search_query = _keyword_query_expression(query)
+    if days is not None:
+        now_utc = datetime.now(timezone.utc)
+        start_date = (now_utc - timedelta(days=days)).strftime("%Y%m%d")
+        end_date = now_utc.strftime("%Y%m%d")
+        search_query = f"{search_query} AND submittedDate:[{start_date} TO {end_date}]"
+
+    client = arxiv.Client()
+    search = arxiv.Search(
+        query=search_query,
+        max_results=max_results,
+        sort_by=arxiv.SortCriterion.Relevance,
+        sort_order=arxiv.SortOrder.Descending,
+    )
+    return [_paper_info(result) for result in client.results(search)]
 
 
 ARXIV_TOOL_SCHEMA = {
@@ -152,11 +207,42 @@ ARXIV_TOOL_SCHEMA = {
     "required": [],
 }
 
+KEYWORD_SEARCH_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": "检索词；默认全字段检索，也可用 all:、ti: 或 au: 限定字段",
+            "minLength": 1,
+        },
+        "max_results": {
+            "type": "integer",
+            "description": "最大返回结果数",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 10,
+        },
+        "days": {
+            "type": ["integer", "null"],
+            "description": "可选：只检索最近多少天内提交的论文",
+            "minimum": 1,
+        },
+    },
+    "required": ["query"],
+}
+
 registry.register_tool(
     name="get_recently_submitted_cs_papers",
     description="获取最近提交的计算机科学领域论文列表，支持按子领域筛选",
     parameter_schema=ARXIV_TOOL_SCHEMA,
     func=get_recently_submitted_cs_papers,
+)
+
+registry.register_tool(
+    name="search_arxiv_papers",
+    description="按关键词、标题或作者检索 arXiv 论文，可选按提交时间过滤",
+    parameter_schema=KEYWORD_SEARCH_SCHEMA,
+    func=search_arxiv_papers,
 )
 
 

--- a/AgenticArxiv/tools/bootstrap.py
+++ b/AgenticArxiv/tools/bootstrap.py
@@ -30,16 +30,19 @@
 from __future__ import annotations
 
 import importlib
-from typing import Dict, List
+from typing import Dict, List, Tuple
 
 from tools.tool_registry import registry
 
 #: 模块 -> 它提供的工具名。用于校验「导入成功」是否真的等于「工具可用」。
-TOOL_MODULES: Dict[str, str] = {
-    "tools.arxiv_tool": "get_recently_submitted_cs_papers",
-    "tools.pdf_download_tool": "download_arxiv_pdf",
-    "tools.pdf_translate_tool": "translate_arxiv_pdf",
-    "tools.cache_status_tool": "get_paper_cache_status",
+TOOL_MODULES: Dict[str, Tuple[str, ...]] = {
+    "tools.arxiv_tool": (
+        "get_recently_submitted_cs_papers",
+        "search_arxiv_papers",
+    ),
+    "tools.pdf_download_tool": ("download_arxiv_pdf",),
+    "tools.pdf_translate_tool": ("translate_arxiv_pdf",),
+    "tools.cache_status_tool": ("get_paper_cache_status",),
 }
 
 
@@ -60,7 +63,12 @@ def register_all_tools() -> Dict[str, str]:
 def missing_tools() -> List[str]:
     """当前 registry 里还缺哪些工具。"""
     registered = {t["name"] for t in registry.list_tools()}
-    return sorted(name for name in TOOL_MODULES.values() if name not in registered)
+    return sorted(
+        name
+        for names in TOOL_MODULES.values()
+        for name in names
+        if name not in registered
+    )
 
 
 def registered_tool_count() -> int:
@@ -80,7 +88,8 @@ def require_all_tools(context: str = "本次运行") -> None:
     if not missing:
         return
 
-    lines = [f"❌ {context}需要全部 {len(TOOL_MODULES)} 个工具，当前缺少: {missing}"]
+    expected_count = sum(len(names) for names in TOOL_MODULES.values())
+    lines = [f"❌ {context}需要全部 {expected_count} 个工具，当前缺少: {missing}"]
     for module, error in failures.items():
         lines.append(f"   {module}: {error}")
     lines.append("   工具列表不全时模型不会报错，而是会编造工具名 ——")

--- a/README.en.md
+++ b/README.en.md
@@ -100,8 +100,9 @@ python -m AgenticArxiv.rl.rollout search_01 traces/train/
 2. `download_arxiv_pdf(ref, session_id)` — Download PDF
 3. `translate_arxiv_pdf(ref, session_id)` — Translate PDF
 4. `get_paper_cache_status(ref, session_id)` — Query cache status
+5. `search_arxiv_papers(query, max_results, days=None)` — Search by keyword, title, or author
 
-> The next step of the toolset (keyword search / paper reading / summarization / figure analysis) has a finalized design but is not implemented yet — see "🧰 Toolset Evolution Design" below.
+> Keyword search is available. Paper reading, summarization, and figure analysis remain designed but unimplemented; see "🧰 Toolset Evolution Design" below.
 
 ### Verifiable Reward Components
 
@@ -592,7 +593,7 @@ Also, **a bigger action space is not automatically better**: the policy is a ~1.
 
 | Priority | Tool | Design | Why it stays RLVR-friendly |
 |--------|------|----------|----------------------|
-| **T1** | `search_arxiv_papers(query, max_results, days=None)` | Keyword search mapped to the arXiv API's `all:` / `ti:` / `au:` fields; coexists with the existing tool (time-window browsing vs precise lookup are different task types) | Expected tools/args still derive from `task_spec.steps`; `MockArxivEnv` replays offline keyed by a hash of the query string, and unseen queries degrade **deterministically** (return a fixed subset, explicitly flagged in the observation) — reproducible, and it prevents the model from mistaking an empty result for a successful search |
+| **T1** ✅ | `search_arxiv_papers(query, max_results, days=None)` | Keyword search mapped to the arXiv API's `all:` / `ti:` / `au:` fields; coexists with the existing tool (time-window browsing vs precise lookup are different task types) | Expected tools/args still derive from `task_spec.steps`; `MockArxivEnv` replays offline keyed by a hash of the query string, and unseen queries degrade **deterministically** (return a fixed subset, explicitly flagged in the observation) — reproducible, and it prevents the model from mistaking an empty result for a successful search |
 | **T2** | `get_paper_content(ref, section=None)` | PDF → plain text (PyMuPDF); returns title/abstract by default, per section (method / result / conclusion) on demand | Deterministic text extraction, no LLM involved; extraction results pre-stored in the snapshot. **It is the prerequisite of every interpretation task** |
 | **T3** | `summarize_paper(ref, style, max_words)` | Summarize a paper: an **env-side** local summarizer model (input from T2's text) returns the summary | What is trainable is "when to call it, on which ref, whether style/length args are right" — all rule-checkable; summary quality itself is **not rewarded** (see below) |
 | **T4** (optional) | `extract_paper_figures(ref)` | Figure/table preparation: extract figure images + captions, return file paths | Deterministic; verify "correct ref + files exist + count ≥ 1" |
@@ -631,9 +632,9 @@ Ordered by priority. Contributions welcome (see 🤝 Contributing).
 
 ### P0 — Toolset expansion (interpretation loop)
 
-Design finalized (see "🧰 Toolset Evolution Design"), none implemented yet:
+T1 is implemented; the remaining tools have finalized designs (see "🧰 Toolset Evolution Design"):
 
-- [ ] **T1 Keyword search** `search_arxiv_papers`: adds the "find a specific paper" lookup-type retrieval
+- [x] **T1 Keyword search** `search_arxiv_papers`: adds the "find a specific paper" lookup-type retrieval
 - [ ] **T2 Paper reading** `get_paper_content`: PDF → text, the prerequisite of all interpretation tasks (critical path)
 - [ ] **T3 Paper summarization** `summarize_paper`: env-side summarization, turning "interpretation" into a trainable tool-invocation decision
 - [ ] **T4/T5 Figure extraction & analysis** (optional, multimodal env): after T1–T3; the VLM lives only on the env side

--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -102,8 +102,9 @@ python -m AgenticArxiv.rl.rollout search_01 traces/train/
 2. `download_arxiv_pdf(ref, session_id)` — Descargar PDF
 3. `translate_arxiv_pdf(ref, session_id)` — Traducir PDF
 4. `get_paper_cache_status(ref, session_id)` — Consultar estado de la caché
+5. `search_arxiv_papers(query, max_results, days=None)` — Buscar por palabra clave, título o autor
 
-> El siguiente paso del conjunto de herramientas (búsqueda por palabras clave / lectura de papers / resumen / análisis de figuras) ya tiene un diseño cerrado, aún sin implementar — ver «🧰 Diseño de Evolución del Conjunto de Herramientas» más abajo.
+> La búsqueda por palabras clave ya está disponible. La lectura de papers, el resumen y el análisis de figuras tienen un diseño cerrado, pero aún no están implementados; ver «🧰 Diseño de Evolución del Conjunto de Herramientas» más abajo.
 
 ### Componentes de Verifiable Reward
 
@@ -587,7 +588,7 @@ Además, **un espacio de acciones más grande no es automáticamente mejor**: la
 
 | Prioridad | Herramienta | Diseño | Por qué sigue siendo amiga de RLVR |
 |--------|------|----------|----------------------|
-| **T1** | `search_arxiv_papers(query, max_results, days=None)` | Búsqueda por palabras clave mapeada a los campos `all:` / `ti:` / `au:` de la API de arXiv; coexiste con la herramienta actual (navegar por ventana temporal y búsqueda puntual son tipos de tarea distintos) | Las herramientas/parámetros esperados siguen derivándose de `task_spec.steps`; `MockArxivEnv` repite offline indexado por un hash del query, y los query no recogidos degradan de forma **determinista** (devuelve un subconjunto fijo, marcado explícitamente en la observation) — reproducible, y evita que el modelo confunda un resultado vacío con una búsqueda exitosa |
+| **T1** ✅ | `search_arxiv_papers(query, max_results, days=None)` | Búsqueda por palabras clave mapeada a los campos `all:` / `ti:` / `au:` de la API de arXiv; coexiste con la herramienta actual (navegar por ventana temporal y búsqueda puntual son tipos de tarea distintos) | Las herramientas/parámetros esperados siguen derivándose de `task_spec.steps`; `MockArxivEnv` repite offline indexado por un hash del query, y los query no recogidos degradan de forma **determinista** (devuelve un subconjunto fijo, marcado explícitamente en la observation) — reproducible, y evita que el modelo confunda un resultado vacío con una búsqueda exitosa |
 | **T2** | `get_paper_content(ref, section=None)` | PDF → texto plano (PyMuPDF); por defecto devuelve title/abstract, y por secciones (method / result / conclusion) a petición | Extracción de texto determinista, sin LLM; los resultados de extracción van pre-guardados en el snapshot. **Es el prerrequisito de todas las tareas de interpretación** |
 | **T3** | `summarize_paper(ref, style, max_words)` | Resumir un paper: un modelo resumidor local **en el lado del entorno** (con el texto de T2 como entrada) devuelve el resumen | Lo entrenable es «cuándo llamarlo, sobre qué ref, si style/longitud son correctos» — todo verificable por reglas; la calidad del resumen en sí **no entra en la recompensa** (ver abajo) |
 | **T4** (opcional) | `extract_paper_figures(ref)` | Preparación de figuras/tablas: extrae imágenes de figuras + captions, devuelve rutas de archivos | Determinista; se verifica «ref correcto + archivos existen + cantidad ≥ 1» |
@@ -626,9 +627,9 @@ Ordenado por prioridad. ¡Las contribuciones son bienvenidas (ver 🤝 Contribui
 
 ### P0 — Expansión del conjunto de herramientas (bucle de interpretación)
 
-Diseño cerrado (ver «🧰 Diseño de Evolución del Conjunto de Herramientas»), ninguno implementado aún:
+T1 está implementado; el resto tiene diseño cerrado (ver «🧰 Diseño de Evolución del Conjunto de Herramientas»):
 
-- [ ] **T1 Búsqueda por palabras clave** `search_arxiv_papers`: añade la búsqueda puntual de «encontrar un paper concreto»
+- [x] **T1 Búsqueda por palabras clave** `search_arxiv_papers`: añade la búsqueda puntual de «encontrar un paper concreto»
 - [ ] **T2 Lectura de papers** `get_paper_content`: PDF → texto, el prerrequisito de todas las tareas de interpretación (camino crítico)
 - [ ] **T3 Resumen de papers** `summarize_paper`: resumen del lado del entorno, convirtiendo «interpretar» en una decisión de llamada a herramientas entrenable
 - [ ] **T4/T5 Extracción y análisis de figuras** (opcional, entorno multimodal): después de T1–T3; el VLM vive solo en el lado del entorno

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ python -m AgenticArxiv.rl.rollout search_01 traces/train/
 2. `download_arxiv_pdf(ref, session_id)` — 下载 PDF
 3. `translate_arxiv_pdf(ref, session_id)` — 翻译 PDF
 4. `get_paper_cache_status(ref, session_id)` — 查询缓存状态
+5. `search_arxiv_papers(query, max_results, days=None)` — 按关键词、标题或作者检索
 
-> 工具集的下一步扩展（关键词检索 / 论文阅读 / 总结 / 图表分析）已有设计稿、暂不实现，见下文「🧰 工具集演进设计」。
+> 关键词检索已经可用；论文阅读、总结和图表分析已有设计稿、暂不实现，见下文「🧰 工具集演进设计」。
 
 ### Verifiable Reward 组件
 
@@ -608,7 +609,7 @@ PPO 更适合生产级大模型训练（7B+），本项目作为学习 demo 不�
 
 | 优先级 | 工具 | 设计要点 | 为什么仍是 RLVR 友好 |
 |--------|------|----------|----------------------|
-| **T1** | `search_arxiv_papers(query, max_results, days=None)` | 关键词检索，映射 arXiv API 的 `all:` / `ti:` / `au:` 字段；与现有工具并存（时间窗浏览 vs 精确查找是两类任务） | 期望工具/参数照常由 `task_spec.steps` 派生；`MockArxivEnv` 按查询串哈希离线回放，未收录的 query 走**确定性降级**（返回固定子集并在 observation 里显式标注），保证可复现、也防止模型把空结果当检索成功 |
+| **T1** ✅ | `search_arxiv_papers(query, max_results, days=None)` | 关键词检索，映射 arXiv API 的 `all:` / `ti:` / `au:` 字段；与现有工具并存（时间窗浏览 vs 精确查找是两类任务） | 期望工具/参数照常由 `task_spec.steps` 派生；`MockArxivEnv` 按查询串哈希离线回放，未收录的 query 走**确定性降级**（返回固定子集并在 observation 里显式标注），保证可复现、也防止模型把空结果当检索成功 |
 | **T2** | `get_paper_content(ref, section=None)` | PDF → 纯文本（PyMuPDF），默认返回 title/abstract，可按节取（method / result / conclusion） | 确定性文本抽取，无 LLM 参与；快照预存抽取结果。**它是全部解读类任务的前置件** |
 | **T3** | `summarize_paper(ref, style, max_words)` | 总结论文：**env 侧**调本地摘要模型（输入来自 T2 的文本），返回摘要文本 | 可训练的是「何时调、对哪个 ref 调、style/长度参数对不对」——全部规则可判；摘要质量本身**不进奖励**（见下） |
 | **T4**（可选） | `extract_paper_figures(ref)` | 图表可视化准备：抽出图表图片 + caption，返回文件路径列表 | 确定性；验证「ref 正确 + 文件存在 + 数量 ≥ 1」 |
@@ -645,9 +646,9 @@ T1 关键词检索 ──→ T2 读内容 ──→ T3 总结          （解读
 
 ### P0 — 工具集扩展（解读闭环）
 
-设计已定稿（见「🧰 工具集演进设计」），均未实现：
+T1 已实现；其余工具设计已定稿（见「🧰 工具集演进设计」）：
 
-- [ ] **T1 关键词检索** `search_arxiv_papers`：补全「找一篇具体论文」的查找型检索
+- [x] **T1 关键词检索** `search_arxiv_papers`：补全「找一篇具体论文」的查找型检索
 - [ ] **T2 论文阅读** `get_paper_content`：PDF → 文本，全部解读类任务的前置件（关键路径）
 - [ ] **T3 论文总结** `summarize_paper`：env 侧摘要，把「解读」变成可训练的工具调用决策
 - [ ] **T4/T5 图表抽取与分析**（可选，多模态环境）：排在 T1–T3 之后；VLM 只在 env 侧


### PR DESCRIPTION
## Summary

- Add `search_arxiv_papers(query, max_results, days=None)` with `all:`, `ti:`, and `au:` query support.
- Add query-hash snapshot replay and deterministic fallback behavior to `MockArxivEnv`.
- Wire the tool into snapshot building, multi-turn rollouts, GRPO rollouts, task templates, and tool registration.
- Add keyword-search tasks, tests, and multilingual README updates.

The offline path keeps training and evaluation reproducible. Unmatched queries return a deterministic fallback marked as an offline fallback instead of silently producing an empty result.

## Validation

- 51 related unit tests passed.
- Python syntax checks passed.
- `git diff --check` passed.
