### PR TITLE
fix: restore SFT/DPO/GRPO/OPD training on TRL 0.29 + transformers 5

### DIFF
--- a/AgenticArxiv/agents/base_agent.py
+++ b/AgenticArxiv/agents/base_agent.py
@@ -153,10 +153,14 @@ class BaseAgent(ABC):
 
             try:
                 t0 = time.time()
+                # temperature 优先由调用方（如 DPO 数据生成）通过 llm_extra 指定，
+                # 否则回退到默认 0.1。硬编码 0.1 会让 llm_extra 里的 temperature
+                # 被静默忽略，导致多次 rollout 近乎确定、DPO 无法产生偏好分歧。
+                eff_temperature = float(extra.pop("temperature", 0.1))
                 response = self.llm_client.chat_completions(
                     model=agent_model,
                     messages=messages,
-                    temperature=0.1,
+                    temperature=eff_temperature,
                     max_tokens=1000,
                     stream=False,
                     extra=extra or None,

--- a/AgenticArxiv/rl/grpo_reward.py
+++ b/AgenticArxiv/rl/grpo_reward.py
@@ -323,9 +323,18 @@ def make_multiturn_rollout_func(environment_factory, max_turns: int = 4):
         expanded_prompts = [copy.deepcopy(p) for p in prompts]
         prompt_ids = []
         for prompt in expanded_prompts:
-            ids = tokenizer.apply_chat_template(
-                prompt, tokenize=True, add_generation_prompt=True,
-            ) if isinstance(prompt, list) else tokenizer(prompt)["input_ids"]
+            if isinstance(prompt, list):
+                # transformers>=5 的 apply_chat_template(tokenize=True) 返回
+                # BatchEncoding（含 "input_ids" 键），旧版返回纯 int 列表；统一取 token 序列。
+                encoded = tokenizer.apply_chat_template(
+                    prompt, tokenize=True, add_generation_prompt=True,
+                )
+                if "input_ids" in encoded:
+                    ids = encoded["input_ids"]
+                else:
+                    ids = encoded
+            else:
+                ids = tokenizer(prompt)["input_ids"]
             prompt_ids.append(list(ids))
 
         environments = [environment_factory() for _ in expanded_prompts]
@@ -355,7 +364,9 @@ def make_multiturn_rollout_func(environment_factory, max_turns: int = 4):
             next_active = []
             for batch_index, index in enumerate(active):
                 budget = trainer.max_completion_length - len(completion_ids[index])
-                generated = list(turn_ids[batch_index])[:budget]
+                # turn_ids 是 TRL 返回的完成 token；可能是 tensor，统一转成 int 列表，
+                # 否则下一轮拼进 full_ids 后 torch.tensor() 无法处理
+                generated = [int(t) for t in turn_ids[batch_index]][:budget]
                 text = tokenizer.decode(generated, skip_special_tokens=True)
                 completion_ids[index].extend(generated)
                 env_masks[index].extend([1] * len(generated))

--- a/AgenticArxiv/rl/train_dpo.py
+++ b/AgenticArxiv/rl/train_dpo.py
@@ -90,7 +90,6 @@ def main(
         save_steps=100,
         save_total_limit=3,
         report_to=backends,
-        logging_dir=logging_dir,
         run_name=run_name or Path(out_dir).name,
         **_precision_flags(),     # 只有 CUDA 才开 fp16
     )

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -302,7 +302,6 @@ def main(
         "logging_steps": 1,
         "save_strategy": "no",
         "report_to": backends,
-        "logging_dir": logging_dir,
         "run_name": run_name or Path(output_dir).name,
         **_precision_flags(),
     }

--- a/AgenticArxiv/rl/train_opd.py
+++ b/AgenticArxiv/rl/train_opd.py
@@ -345,7 +345,6 @@ def main(
         "logging_steps": 1,
         "save_strategy": "no",
         "report_to": backends,
-        "logging_dir": logging_dir,
         "run_name": run_name or Path(output_dir).name,
         **_precision_flags(),
     }

--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -151,7 +151,6 @@ def main(
         save_steps=100,
         save_total_limit=3,
         report_to=backends,
-        logging_dir=logging_dir,
         run_name=run_name or out_path.name,
         **_precision_flags(),     # 只有 CUDA 才开 fp16
     )


### PR DESCRIPTION
## Summary

Running the full SFT → DPO → GRPO training chain with modern TRL (0.29.x) and transformers (5.x) surfaced four issues that crash or silently break training. This PR fixes all of them, verified end-to-end on a real GPU run (0.5B model).

## Changes

1. **`logging_dir` removed from TRL configs** (`train_sft.py`, `train_dpo.py`, `train_grpo.py`, `train_opd.py`)
   TRL removed the `logging_dir` parameter from `SFTConfig`/`DPOConfig`/`GRPOConfig`. Passing it made every training script fail at startup with `TypeError: ... unexpected keyword argument 'logging_dir'`. Logs are still handled via `output_dir`.

2. **Honor caller temperature in `base_agent.py`**
   The LLM was called with a hardcoded `temperature=0.1`, silently ignoring the caller-supplied temperature via `llm_extra`. This made DPO data generation (which relies on diverse samples) produce **0 preference pairs**. Now it reads `temperature` from `llm_extra` first, falling back to 0.1.

3. **Multi-turn GRPO token handling in `grpo_reward.py`**
   Two normalization fixes so multi-turn GRPO no longer crashes with `ValueError: too many dimensions 'str'`:
   - `apply_chat_template(tokenize=True)` returns a `BatchEncoding` on transformers>=5, not a list of ints → extract `input_ids`.
   - `_generate_single_turn` returns tensors → convert to plain int token lists before appending.

## Verification

Full chain ran on RTX 4050 (6 GB) with Qwen2.5-0.5B:
- SFT: 15 steps, loss 0.48
- DPO: pipeline completes
- GRPO: 8 steps, reward improves -0.36 → 0.125

## Notes

- The `FSDPModule` import failure on torch<2.6 (`cannot import name 'FSDPModule' from 'torch.distributed.fsdp'`) affects `DPOTrainer`/`GRPOTrainer` imports; I worked around it locally with a single-GPU stub and did not change project code. Worth documenting the torch>=2.6 requirement for TRL 0.29.