### PR TITLE
fix: handle missing FSDPModule on torch<2.6 for DPO/GRPO/PPO

### DIFF
--- a/AgenticArxiv/rl/train_dpo.py
+++ b/AgenticArxiv/rl/train_dpo.py
@@ -20,6 +20,8 @@ REPO_ROOT = PACKAGE_ROOT.parent
 # 添加 AgenticArxiv 到 Python 路径
 sys.path.insert(0, str(PACKAGE_ROOT))
 
+# 先做旧 torch 的 trl 兼容（torch<2.6 时兜底 FSDPModule），再 import trl
+from rl import trl_compat  # noqa: F401
 from trl import DPOConfig, DPOTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from datasets import load_dataset

--- a/AgenticArxiv/rl/train_grpo.py
+++ b/AgenticArxiv/rl/train_grpo.py
@@ -37,6 +37,7 @@ os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
 from datasets import Dataset
 from transformers import AutoModelForCausalLM, AutoTokenizer, TrainerCallback
+from rl import trl_compat  # noqa: F401  (torch<2.6 时兜底 FSDPModule，须在 trl 之前)
 from trl import GRPOConfig, GRPOTrainer
 
 import tools.arxiv_tool  # noqa: F401  触发工具注册

--- a/AgenticArxiv/rl/train_ppo.py
+++ b/AgenticArxiv/rl/train_ppo.py
@@ -34,6 +34,7 @@ os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 import torch
 from datasets import Dataset
 from transformers import AutoTokenizer
+from rl import trl_compat  # noqa: F401  (torch<2.6 时兜底 FSDPModule，须在 trl 之前)
 from trl import AutoModelForCausalLMWithValueHead, PPOConfig, PPOTrainer
 
 import tools.arxiv_tool  # noqa: F401  触发工具注册

--- a/AgenticArxiv/rl/train_sft.py
+++ b/AgenticArxiv/rl/train_sft.py
@@ -21,6 +21,8 @@ REPO_ROOT = PACKAGE_ROOT.parent
 # 添加 AgenticArxiv 到 Python 路径
 sys.path.insert(0, str(PACKAGE_ROOT))
 
+# 先做旧 torch 的 trl 兼容（torch<2.6 时兜底 FSDPModule），再 import trl
+from rl import trl_compat  # noqa: F401
 from trl import SFTConfig, SFTTrainer
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from datasets import load_dataset

--- a/AgenticArxiv/rl/trl_compat.py
+++ b/AgenticArxiv/rl/trl_compat.py
@@ -1,0 +1,55 @@
+"""trl 的旧版 torch 兼容层。
+
+TRL 的 DPOTrainer / GRPOTrainer / PPOTrainer 在内部无条件地
+``from torch.distributed.fsdp import FSDPModule``，而 ``FSDPModule`` 只
+在 torch>=2.6 才存在。因此在使用 torch<2.6（例如本仓库本地 RTX 4050 +
+torch 2.5.x）时，仅仅 ``from trl import ...`` 就会直接崩溃：:
+
+    ImportError: cannot import name 'FSDPModule' from 'torch.distributed.fsdp'
+
+单卡训练（大多数用户的场景）根本不需要真正的 FSDP 分布式打包，所以这里
+在导入 trl 之前补一个最小可用的占位类，让 DPO / GRPO / PPO 的
+``prepare_fsdp`` 能正常通过 while isinstance 判断、正常走非 FSDP 分支。
+
+用法：在 ``from trl import ...`` 之前 ``import AgenticArxiv.rl.trl_compat``。
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# 目标：早期是 torch.distributed.fsdp.FSDPModule
+_ATTACH_TARGET: str = "torch.distributed.fsdp"
+
+
+def ensure_fsdp_compat() -> bool:
+    """在缺 FSDPModule 时注入占位类，返回是否真的注入了兜底。"""
+    import importlib
+
+    try:
+        fsdp = importlib.import_module(_ATTACH_TARGET)
+    except ImportError:
+        # torch 太老连 fsdp 模块都没有，直接放弃兜底，让后续 import 报它自己的错
+        return False
+
+    if hasattr(fsdp, "FSDPModule"):
+        return False  # torch>=2.6，什么都不用做
+
+    class _FSDPModulePlaceholder:
+        """仅用于让 trl 的 isinstance / 类型标注通过的最小占位。"""
+
+        def __init__(self, *args, **kwargs):
+            pass
+
+    setattr(fsdp, "FSDPModule", _FSDPModulePlaceholder)
+    logger.warning(
+        "torch<2.6 未提供 FSDPModule，已注入单卡兼容占位。"
+        "本仓库的单卡训练不需要真实 FSDP；若你需要多卡 FSDP，请升级到 torch>=2.6。"
+    )
+    return True
+
+
+# 模块导入即生效：任何训练脚本 import 本模块后，再 import trl 就不会崩
+ensure_fsdp_compat()


### PR DESCRIPTION
## Summary

On **torch < 2.6**, `trl`'s `DPOTrainer` / `GRPOTrainer` / `PPOTrainer` crash at import time because they unconditionally do
`from torch.distributed.fsdp import FSDPModule`, a symbol that only exists on torch>=2.6:

```
ImportError: cannot import name 'FSDPModule' from 'torch.distributed.fsdp'
```

This currently breaks any DPO / GRPO / PPO run on old torch (e.g. RTX 4050 with torch 2.5.x), even for plain single-GPU training that never needs real FSDP.

## Change

Add a small compat layer `AgenticArxiv/rl/trl_compat.py` that, in `torch<2.6`, injects a minimal placeholder `FSDPModule` before trl is imported. Single-GPU training doesn't exercise real FSDP, so the placeholder lets `prepare_fsdp`'s isinstance checks pass and execution falls through to the non-FSDP path.

The following training scripts import the compat layer before trl:
- `train_dpo.py`
- `train_grpo.py`
- `train_ppo.py`
- `train_sft.py`

`train_opd.py` already wraps its `from trl import ...` in a try/except, so it degrades gracefully and is left unchanged.

## Verification

Observed on this repo's local environment (Windows, torch 2.5.1 + cu121, which lacks `FSDPModule`):

- Before this change: `from trl import DPOConfig, DPOTrainer, ...` → `ImportError: cannot import name 'FSDPModule'`
- After adding `trl_compat`: SFT / DPO / GRPO / PPO all import cleanly, and a warning explains that a single-GPU placeholder was injected for torch<2.6.

On torch>=2.6 nothing changes — the module detects the symbol already exists and is a no-op.